### PR TITLE
fix: add -v flag and include bit version in output

### DIFF
--- a/src/cmd/bit/format_patch.mbt
+++ b/src/cmd/bit/format_patch.mbt
@@ -342,7 +342,7 @@ fn generate_patch(
   }
   let diff = generate_commit_diff(db, rfs, commit_id, parent_id)
   sb.write_string(diff)
-  sb.write_string("\n-- \n2.47.0 (bit)\n\n")
+  sb.write_string("\n-- \n\{bit_version_tag}\n\n")
   sb.to_string()
 }
 

--- a/src/cmd/bit/helpers.mbt
+++ b/src/cmd/bit/helpers.mbt
@@ -173,7 +173,7 @@ async fn run_git_internal_command(
 ) -> Int raise Error {
   match cmd {
     "version" => {
-      print_line("git version 2.47.0 (bit)")
+      print_line("git version \{bit_version_tag}")
       0
     }
     "clone" => {

--- a/src/cmd/bit/main.mbt
+++ b/src/cmd/bit/main.mbt
@@ -1,5 +1,8 @@
 ///| Git-shim main entry point and command dispatcher
 
+///| bit version tag (update this and moon.mod.json together when releasing)
+let bit_version_tag : String = "2.47.0 (bit v0.24.2)"
+
 ///|
 async fn show_help() -> Unit {
   let help =
@@ -572,8 +575,8 @@ async fn run_main_for_args(args : Array[String]) -> Unit {
   // Handle --version and --help early (can appear anywhere before command)
   for i in 1..<args.length() {
     match args[i] {
-      "--version" | "version" => {
-        print_line("git version 2.47.0 (bit)")
+      "-v" | "--version" | "version" => {
+        print_line("git version \{bit_version_tag}")
         return ()
       }
       "-h" | "--help" => {
@@ -976,7 +979,7 @@ async fn dispatch_known_command(
     "x/doc" => handle_x_doc(rest)
     "scalar" => handle_scalar(rest)
     "shell" => handle_shell(rest)
-    "version" => print_line("git version 2.47.0 (bit)")
+    "version" => print_line("git version \{bit_version_tag}")
     // Error for unknown commands
     _ => {
       eprint_line("bit: '\{cmd}' is not a bit command")


### PR DESCRIPTION
## Summary

Closes #12

- Add `-v` flag support alongside `--version` and `version` subcommand
- Include bit version number in output: `git version 2.47.0 (bit v0.24.2)`
- Centralize version string via `bit_version_tag` constant in `main.mbt`
- Update all 4 version output locations (early flag parse, version subcommand, git-shim internal, format-patch footer)

### Before
```
$ bit -v
bit: missing subcommand

$ bit --version
git version 2.47.0 (bit)
```

### After
```
$ bit -v
git version 2.47.0 (bit v0.24.2)

$ bit --version
git version 2.47.0 (bit v0.24.2)
```

## Test plan
- [x] `moon check` passes
- [x] `moon test` passes (36/36 in helpers_wbtest.mbt)
- [x] `bit -v`, `bit --version`, `bit version` all output `git version 2.47.0 (bit v0.24.2)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)