### PR TITLE
fix: detect proxied relay URLs in hub sync push/fetch

### DIFF
--- a/src/x/hub/native/sync_native.mbt
+++ b/src/x/hub/native/sync_native.mbt
@@ -300,8 +300,56 @@ fn parse_relay_base_url(remote_url : String) -> String? {
     )
     Some(trim_trailing_slash("http://" + suffix))
   } else {
-    None
+    // Detect proxied relay URL: https://host/git/<session_id>
+    // This pattern is stored in git config after `bit clone relay+https://host/<session>`
+    match detect_relay_proxied_git_base(remote_url) {
+      Some(base) => Some(base)
+      None => None
+    }
   }
+}
+
+///|
+/// Detect proxied relay git session URL and extract the relay base URL.
+/// Matches: http(s)://host/git/<session_id> where session_id is 6-16 alphanumeric chars.
+/// Returns the base URL (everything before /git/).
+fn detect_relay_proxied_git_base(url : String) -> String? {
+  if not(is_http_url(url)) {
+    return None
+  }
+  let git_path = "/git/"
+  guard url.find(git_path) is Some(idx) else { return None }
+  let after_git_start = idx + git_path.length()
+  if after_git_start >= url.length() {
+    return None
+  }
+  // Strip query string and trailing slash to isolate the path segment
+  let after_git = String::unsafe_substring(
+    url,
+    start=after_git_start,
+    end=url.length(),
+  )
+  let segment = match after_git.find("?") {
+    Some(qi) => String::unsafe_substring(after_git, start=0, end=qi)
+    None => after_git
+  }
+  let session = if segment.has_suffix("/") {
+    String::unsafe_substring(segment, start=0, end=segment.length() - 1)
+  } else {
+    segment
+  }
+  // Session ID must be 6-16 alphanumeric chars with no path separators
+  if session.length() < 6 || session.length() > 16 {
+    return None
+  }
+  for c in session {
+    if not(
+      (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'),
+    ) {
+      return None
+    }
+  }
+  Some(String::unsafe_substring(url, start=0, end=idx))
 }
 
 ///|

--- a/src/x/hub/native/sync_native_wbtest.mbt
+++ b/src/x/hub/native/sync_native_wbtest.mbt
@@ -57,7 +57,62 @@ test "relay: parse_relay_base_url handles explicit prefixes" {
     parse_relay_base_url("relay://127.0.0.1:8787"),
     Some("http://127.0.0.1:8787"),
   )
+  // Plain HTTP URLs without /git/<session> pattern are NOT relay URLs
   assert_eq(parse_relay_base_url("http://127.0.0.1:8787"), None)
+  assert_eq(parse_relay_base_url("https://github.com/user/repo.git"), None)
+}
+
+///|
+test "relay: parse_relay_base_url detects proxied relay git session URLs" {
+  // Proxied URL stored by `bit clone relay+https://host/<session>`
+  assert_eq(
+    parse_relay_base_url("https://relay.example.com/git/AbCdEfGh"),
+    Some("https://relay.example.com"),
+  )
+  assert_eq(
+    parse_relay_base_url("http://localhost:8788/git/jfIGqUeq"),
+    Some("http://localhost:8788"),
+  )
+  // With trailing slash
+  assert_eq(
+    parse_relay_base_url("https://relay.example.com/git/AbCdEfGh/"),
+    Some("https://relay.example.com"),
+  )
+  // With query parameters
+  assert_eq(
+    parse_relay_base_url("https://relay.example.com/git/AbCdEfGh?room=main"),
+    Some("https://relay.example.com"),
+  )
+  // Too short session ID (< 6 chars) - not a relay URL
+  assert_eq(
+    parse_relay_base_url("https://relay.example.com/git/Ab12"),
+    None,
+  )
+  // Too long session ID (> 16 chars) - not a relay URL
+  assert_eq(
+    parse_relay_base_url("https://relay.example.com/git/AbCdEfGhIjKlMnOpQr"),
+    None,
+  )
+  // Named session (owner/repo) - not a random session, contains slash
+  assert_eq(
+    parse_relay_base_url("https://relay.example.com/git/owner/repo"),
+    None,
+  )
+  // Non-alphanumeric chars in session - not a relay URL
+  assert_eq(
+    parse_relay_base_url("https://relay.example.com/git/abc-def"),
+    None,
+  )
+  // .git suffix contains dot - not a relay URL
+  assert_eq(
+    parse_relay_base_url("https://github.com/git/foobar123.git"),
+    None,
+  )
+  // SSH URL - not a relay URL
+  assert_eq(
+    parse_relay_base_url("git@github.com:user/repo.git"),
+    None,
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary
- `bit clone relay+https://host/<session>` stores `https://host/git/<session>` in git config (without `relay+` prefix)
- `bit relay sync push` then falls through to git HTTP protocol instead of relay API, causing hangs at `GET /info/refs?service=git-receive-pack`
- Add `detect_relay_proxied_git_base` to recognize the proxied URL pattern and extract the relay base URL

## Test plan
- [x] Existing `parse_relay_base_url` tests still pass
- [x] New tests for proxied URL detection (positive and negative cases)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)