### PR TITLE
feat: add depth option to clone/fetch for shallow clones

### DIFF
--- a/npm/lib.d.ts
+++ b/npm/lib.d.ts
@@ -179,6 +179,7 @@ export type BitResetMode = "soft" | "mixed" | "hard";
 export interface BitFetchOptions {
   refspec?: string;
   preferV2?: boolean;
+  depth?: number;
   preferredSender?: string;
   preferredRepo?: string;
   authToken?: string;
@@ -186,6 +187,7 @@ export interface BitFetchOptions {
 
 export interface BitCloneOptions {
   preferV2?: boolean;
+  depth?: number;
   preferredSender?: string;
   preferredRepo?: string;
   authToken?: string;

--- a/npm/lib.js
+++ b/npm/lib.js
@@ -1124,6 +1124,7 @@ export const fetch = async (
       toTransportId(transport),
       options.refspec ?? "",
       options.preferV2 !== false,
+      options.depth ?? 0,
     ),
   );
 };
@@ -1151,6 +1152,7 @@ export const clone = async (
       resolvedRemoteUrl,
       toTransportId(transport),
       options.preferV2 !== false,
+      options.depth ?? 0,
     ),
   );
 };

--- a/npm/lib.js
+++ b/npm/lib.js
@@ -1034,6 +1034,7 @@ export const fetch = async (
       toTransportId(transport),
       options.refspec ?? "",
       options.preferV2 !== false,
+      options.depth ?? 0,
     ),
   );
 };
@@ -1061,6 +1062,7 @@ export const clone = async (
       resolvedRemoteUrl,
       toTransportId(transport),
       options.preferV2 !== false,
+      options.depth ?? 0,
     ),
   );
 };

--- a/src/lib/js_api_exports.mbt
+++ b/src/lib/js_api_exports.mbt
@@ -1393,6 +1393,7 @@ pub async fn js_clone_remote(
   remote_url : String,
   transport_id : Int,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> Result[JsCloneResult, String] {
   let fs = js_make_host_fs(host_id)
   js_wrap_error_async(async fn() -> JsCloneResult raise @bit.GitError {
@@ -1429,7 +1430,7 @@ pub async fn js_clone_remote(
             remote_url,
             wants,
             prefer_v2,
-            0,
+            depth,
             @protocol.FilterSpec::NoFilter,
             async fn(
               url : String,
@@ -1486,9 +1487,10 @@ pub fn js_clone_remote_promise(
   remote_url : String,
   transport_id : Int,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> @js_async.Promise[Result[JsCloneResult, String]] {
   js_export_promise(async fn() {
-    js_clone_remote(host_id, root, remote_url, transport_id, prefer_v2)
+    js_clone_remote(host_id, root, remote_url, transport_id, prefer_v2, depth)
   })
 }
 
@@ -1500,6 +1502,7 @@ pub async fn js_fetch_remote(
   transport_id : Int,
   refspec : String,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> Result[JsFetchResult, String] {
   let fs = js_make_host_fs(host_id)
   js_wrap_error_async(async fn() -> JsFetchResult raise @bit.GitError {
@@ -1528,7 +1531,7 @@ pub async fn js_fetch_remote(
           remote_url,
           [commit_id],
           prefer_v2,
-          0,
+          depth,
           @protocol.FilterSpec::NoFilter,
           async fn(
             url : String,
@@ -1577,9 +1580,10 @@ pub fn js_fetch_remote_promise(
   transport_id : Int,
   refspec : String,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> @js_async.Promise[Result[JsFetchResult, String]] {
   js_export_promise(async fn() {
-    js_fetch_remote(host_id, root, remote_url, transport_id, refspec, prefer_v2)
+    js_fetch_remote(host_id, root, remote_url, transport_id, refspec, prefer_v2, depth)
   })
 }
 

--- a/src/lib/js_api_exports.mbt
+++ b/src/lib/js_api_exports.mbt
@@ -2376,6 +2376,7 @@ pub async fn js_clone_remote(
   remote_url : String,
   transport_id : Int,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> Result[JsCloneResult, String] {
   let fs = js_make_host_fs(host_id)
   js_wrap_error_async(async fn() -> JsCloneResult raise @bit.GitError {
@@ -2412,7 +2413,7 @@ pub async fn js_clone_remote(
             remote_url,
             wants,
             prefer_v2,
-            0,
+            depth,
             @protocol.FilterSpec::NoFilter,
             async fn(
               url : String,
@@ -2469,9 +2470,10 @@ pub fn js_clone_remote_promise(
   remote_url : String,
   transport_id : Int,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> @js_async.Promise[Result[JsCloneResult, String]] {
   js_export_promise(async fn() {
-    js_clone_remote(host_id, root, remote_url, transport_id, prefer_v2)
+    js_clone_remote(host_id, root, remote_url, transport_id, prefer_v2, depth)
   })
 }
 
@@ -2483,6 +2485,7 @@ pub async fn js_fetch_remote(
   transport_id : Int,
   refspec : String,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> Result[JsFetchResult, String] {
   let fs = js_make_host_fs(host_id)
   js_wrap_error_async(async fn() -> JsFetchResult raise @bit.GitError {
@@ -2511,7 +2514,7 @@ pub async fn js_fetch_remote(
           remote_url,
           [commit_id],
           prefer_v2,
-          0,
+          depth,
           @protocol.FilterSpec::NoFilter,
           async fn(
             url : String,
@@ -2560,9 +2563,10 @@ pub fn js_fetch_remote_promise(
   transport_id : Int,
   refspec : String,
   prefer_v2 : Bool,
+  depth : Int,
 ) -> @js_async.Promise[Result[JsFetchResult, String]] {
   js_export_promise(async fn() {
-    js_fetch_remote(host_id, root, remote_url, transport_id, refspec, prefer_v2)
+    js_fetch_remote(host_id, root, remote_url, transport_id, refspec, prefer_v2, depth)
   })
 }
 


### PR DESCRIPTION
## Summary
- Expose existing protocol-level `deepen` support to the JavaScript API
- Add `depth?: number` to `BitCloneOptions` and `BitFetchOptions`
- When `depth` is 0 (default), full clone behavior is preserved
- When `depth > 0`, the server returns only the specified number of commits

## Changes
- `src/lib/js_api_exports.mbt`: Add `depth : Int` parameter to `js_clone_remote`, `js_fetch_remote`, and their promise wrappers
- `npm/lib.js`: Pass `options.depth ?? 0` to raw clone/fetch calls
- `npm/lib.d.ts`: Add `depth?: number` to option interfaces

## Usage
```javascript
import { clone, createFetchTransport } from "@mizchi/bit";

// Full clone (default, depth=0)
await clone(backend, "/repo", url, transport);

// Shallow clone (depth=1)
await clone(backend, "/repo", url, transport, { depth: 1 });
```

## Test plan
- [ ] Full clone still works (depth=0, default)
- [ ] Shallow clone with depth=1 returns single commit
- [ ] Fetch with depth works similarly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)