### PR TITLE
Probe: enroll remaining 8 P2.5 tests in allowlist

### DIFF
--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -15,6 +15,7 @@ t0450-txt-doc-vs-help.sh
 t1006-cat-file.sh
 t1007-hash-object.sh
 t1300-config.sh
+t1400-update-ref.sh
 t1401-symbolic-ref.sh
 t1403-show-ref.sh
 t1500-rev-parse.sh

--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -300,6 +300,7 @@ t5150-request-pull.sh
 t5200-update-server-info.sh
 
 # pack / idx (strict mode compatible)
+t5300-pack-object.sh
 t5301-sliding-window.sh
 t5302-pack-index.sh
 t5303-pack-corruption-resilience.sh
@@ -309,6 +310,7 @@ t5306-pack-nobase.sh
 t5307-pack-missing-commit.sh
 t5308-pack-detect-duplicates.sh
 t5309-pack-delta-cycles.sh
+t5310-pack-bitmaps.sh
 t5311-pack-bitmaps-shallow.sh
 t5312-prune-corruption.sh
 t5313-pack-bounds-checks.sh
@@ -324,12 +326,14 @@ t5322-pack-objects-sparse.sh
 t5323-pack-redundant.sh
 t5324-split-commit-graph.sh
 t5325-reverse-index.sh
+t5326-multi-pack-bitmaps.sh
 t5327-multi-pack-bitmaps-rev.sh
 t5328-commit-graph-64bit-time.sh
 t5329-pack-objects-cruft.sh
 t5330-no-lazy-fetch-with-commit-graph.sh
 t5331-pack-objects-stdin.sh
 t5332-multi-pack-reuse.sh
+t5333-pseudo-merge-bitmaps.sh
 t5334-incremental-multi-pack-index.sh
 t5351-unpack-large-objects.sh
 
@@ -642,6 +646,7 @@ t1700-split-index.sh
 t1701-racy-split-index.sh
 t1800-hook.sh
 t1900-repo.sh
+t1901-repo-structure.sh
 
 # t2*
 t2000-conflict-when-checking-files-out.sh
@@ -719,6 +724,7 @@ t3301-notes.sh
 t3302-notes-index-expensive.sh
 t3303-notes-subtrees.sh
 t3304-notes-mixed.sh
+t3305-notes-fanout.sh
 t3306-notes-prune.sh
 t3307-notes-man.sh
 t3308-notes-merge.sh
@@ -889,6 +895,7 @@ t4120-apply-popt.sh
 t4121-apply-diffs.sh
 t4122-apply-symlink-inside.sh
 t4123-apply-shrink.sh
+t4124-apply-ws-rule.sh
 t4125-apply-ws-fuzz.sh
 t4126-apply-empty.sh
 t4127-apply-same-fn.sh


### PR DESCRIPTION
## Summary

P2.5 残り **8 件** すべてを allowlist へ追加し、CI で一括判定する探索 PR：

```
t1400-update-ref.sh
t1901-repo-structure.sh
t3305-notes-fanout.sh
t4124-apply-ws-rule.sh
t5300-pack-object.sh
t5310-pack-bitmaps.sh        ← P2 で実装済 (commit f5f3d6c)
t5326-multi-pack-bitmaps.sh  ← P2 で実装済
t5333-pseudo-merge-bitmaps.sh ← P2 で実装済
```

ぜんぶ green なら **975 → 983/1027** で P2.5 完了。

## Strategy

CI から失敗テストを抜き出し、必要に応じて `tools/git-patches/*.patch` で known-breakage マークするか、対応する allowlist 行を一旦外して別 PR に切り出す。

## Test plan

- [ ] CI `git-compat` shards green for all 8 tests
- [ ] No regression in other allowlist entries