### PR TITLE
allowlist: add t1901-repo-structure and t5333-pseudo-merge-bitmaps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,9 +54,12 @@ t3404 (rebase -i): **129/132 (97.7%)**
 
 ## P2.5: Allowlist 拡大
 
-- 現在: 975/1027 (非 t9xxx で 52 テスト未追加)
+- 現在: 977/1027 (非 t9xxx で 50 テスト未追加)
 - [x] t0008-ignores.sh
-- [ ] t1400, t4124, t5300 等
+- [x] t1901-repo-structure.sh
+- [x] t5333-pseudo-merge-bitmaps.sh
+- [ ] t1400 (10分超で CI shard には重い)
+- [ ] t4124, t5300, t5310, t5326 等 (known-breakage patch が必要)
 
 ## P3: 将来タスク
 

--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -329,6 +329,7 @@ t5329-pack-objects-cruft.sh
 t5330-no-lazy-fetch-with-commit-graph.sh
 t5331-pack-objects-stdin.sh
 t5332-multi-pack-reuse.sh
+t5333-pseudo-merge-bitmaps.sh
 t5334-incremental-multi-pack-index.sh
 t5351-unpack-large-objects.sh
 
@@ -641,6 +642,7 @@ t1700-split-index.sh
 t1701-racy-split-index.sh
 t1800-hook.sh
 t1900-repo.sh
+t1901-repo-structure.sh
 
 # t2*
 t2000-conflict-when-checking-files-out.sh


### PR DESCRIPTION
## Summary
Add two upstream Git tests to `tools/git-test-allowlist.txt` that pass cleanly under the strict shim with the full 55-command SHIM_CMDS list:

- `t1901-repo-structure.sh` — passed all 4 test(s)
- `t5333-pseudo-merge-bitmaps.sh` — passed all 18 test(s)

Brings the non-t9xxx allowlist from 975/1027 → 977/1027.

## Notes on the other P2.5 candidates
Verified locally under the same strict shim. Not added because they don't pass cleanly today; would need known-breakage patches under `tools/git-patches/` to be added safely:

| Test | Result | Reason |
|---|---|---|
| t1400-update-ref | timeout >10m | Too slow for CI shard budget |
| t3305-notes-fanout | 4/7 (failed 3) | Hard failures |
| t4124-apply-ws-rule | 28/84 (failed 56) | Hard failures |
| t5300-pack-object | 59/60 (failed 1, subtest "prefetch objects") | One known gap |
| t5310-pack-bitmaps | 92/233 (failed 141) | Many hard failures |
| t5326-multi-pack-bitmaps | 83/357 (failed 274) | Many hard failures |

## Test plan
- [x] `bash third_party/git/t/t1901-repo-structure.sh` under strict shim — clean pass
- [x] `bash third_party/git/t/t5333-pseudo-merge-bitmaps.sh` under strict shim — clean pass
- [ ] CI green on PR

https://claude.ai/code/session_01M3TPgeGLDKQxep3AAYpDVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3TPgeGLDKQxep3AAYpDVs)_