### PR TITLE
allowlist: add t3305-notes-fanout and t5300-pack-object

### DIFF
--- a/tools/git-patches/t5300-pack-object-known-breakage.patch
+++ b/tools/git-patches/t5300-pack-object-known-breakage.patch
@@ -1,0 +1,74 @@
+--- a/t/t5300-pack-object.sh
++++ b/t/t5300-pack-object.sh
+@@ -178,7 +178,7 @@
+ 	cmp "$object_list" current
+ }
+ 
+-test_expect_success 'unpack without delta' '
++test_expect_failure 'unpack without delta' '
+ 	check_unpack test-1-${packname_1} obj-list
+ '
+ 
+@@ -193,7 +193,7 @@
+ 	check_deltas stderr -gt 0
+ '
+ 
+-test_expect_success 'unpack with REF_DELTA' '
++test_expect_failure 'unpack with REF_DELTA' '
+ 	check_unpack test-2-${packname_2} obj-list
+ '
+ 
+@@ -207,7 +207,7 @@
+ 	check_deltas stderr -gt 0
+ '
+ 
+-test_expect_success 'unpack with OFS_DELTA' '
++test_expect_failure 'unpack with OFS_DELTA' '
+ 	check_unpack test-3-${packname_3} obj-list
+ '
+ 
+@@ -279,7 +279,7 @@
+ 		test-3-${packname_3}.idx
+ '
+ 
+-test_expect_success 'verify-pack catches mismatched .idx and .pack files' '
++test_expect_failure 'verify-pack catches mismatched .idx and .pack files' '
+ 	cat test-1-${packname_1}.idx >test-3.idx &&
+ 	cat test-2-${packname_2}.pack >test-3.pack &&
+ 	if git verify-pack test-3.idx
+@@ -315,7 +315,7 @@
+ 	fi
+ '
+ 
+-test_expect_success 'verify-pack catches a corrupted sum of the index file itself' '
++test_expect_failure 'verify-pack catches a corrupted sum of the index file itself' '
+ 	l=$(wc -c <test-3.idx) &&
+ 	l=$(expr $l - 20) &&
+ 	cat test-1-${packname_1}.pack >test-3.pack &&
+@@ -357,7 +357,7 @@
+ 	:
+ '
+ 
+-test_expect_success 'unpacking with --strict' '
++test_expect_failure 'unpacking with --strict' '
+ 
+ 	for j in a b c d e f g
+ 	do
+@@ -400,7 +400,7 @@
+ 	)
+ '
+ 
+-test_expect_success 'index-pack with --strict' '
++test_expect_failure 'index-pack with --strict' '
+ 
+ 	for j in a b c d e f g
+ 	do
+@@ -614,7 +614,7 @@
+ 	)
+ '
+ 
+-test_expect_success 'prefetch objects' '
++test_expect_failure 'prefetch objects' '
+ 	rm -rf server client &&
+ 
+ 	git init server &&

--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -299,6 +299,7 @@ t5150-request-pull.sh
 t5200-update-server-info.sh
 
 # pack / idx (strict mode compatible)
+t5300-pack-object.sh
 t5301-sliding-window.sh
 t5302-pack-index.sh
 t5303-pack-corruption-resilience.sh
@@ -720,6 +721,7 @@ t3301-notes.sh
 t3302-notes-index-expensive.sh
 t3303-notes-subtrees.sh
 t3304-notes-mixed.sh
+t3305-notes-fanout.sh
 t3306-notes-prune.sh
 t3307-notes-man.sh
 t3308-notes-merge.sh


### PR DESCRIPTION
## Summary

Adds two upstream tests to `tools/git-test-allowlist.txt`. Both pass within
the 120s per-test budget under CI's `SHIM_STRICT=1` configuration (the
99-command `SHIM_CMDS` list in `.github/workflows/ci.yml`).

- **t3305-notes-fanout** — passes all 7 subtests outright. Originally needed
  a known-breakage patch, but #44 (merged) makes `git notes` honour the
  fanout 0↔1 transition and surfaces notes in `git log`, so no patch is
  needed.
- **t5300-pack-object** (~49s, 60 subtests, 8 known breakages): bit's shim
  doesn't yet handle `unpack-objects`, `verify-pack` corruption checks,
  `unpack-objects --strict`, `index-pack --strict`, `show-index` outside a
  repo, or the prefetch flow used by `git push --filter`.

## Why these two only

The original investigation also looked at t1400, t4124, t5310, and t5326.
Each one turns out to be a poor fit for an ad-hoc known-breakage patch:

- **t1400-update-ref**: exceeds the 120s CI per-test budget even before
  reaching the failing subtests. Adding it would require a fundamental
  speedup, not a known-breakage patch.
- **t4124-apply-ws-rule**: 76 of 84 subtests fail. That is the entire test;
  marking them all as broken would be deletion in disguise.
- **t5310-pack-bitmaps** / **t5326-multi-pack-bitmaps**: the bulk of the
  subtests are registered inside `test_bitmap_cases ()` (and the helpers
  in `t/lib-bitmap.sh`), which is invoked 3–4 times per test with
  different config arguments. The same source-line subtest passes in some
  invocations and fails in others, so static `test_expect_failure` either
  over-marks (causing "known breakage vanished" → exit 1) or under-marks
  (residual failures → exit 1). Skipping with a prereq cascades into
  setup-state failures elsewhere. These need a deeper, runtime-aware
  approach than this PR.

## Test plan

- [x] Run `bash tools/run-git-test.sh T=t3305-notes-fanout.sh` under the
      strict shim → exit 0, 7/7 pass (no known breakages).
- [x] Run `bash tools/run-git-test.sh T=t5300-pack-object.sh` under the
      strict shim → exit 0, 8 known breakages, 52 passes.
- [x] `tools/apply-git-test-patches.sh` applies cleanly on a fresh
      `third_party/git` checkout.
- [ ] CI git-compat shards remain green.

https://claude.ai/code/session_01M3TPgeGLDKQxep3AAYpDVs