### PR TITLE
notes: support fanout 0→1 and surface notes in `git log`

### DIFF
--- a/src/cmd/bit/log.mbt
+++ b/src/cmd/bit/log.mbt
@@ -1932,6 +1932,45 @@ async fn log_emit_output(
 }
 
 ///|
+/// Emit the note for `commit_id` (from refs/notes/commits) in the same shape
+/// upstream git uses for the medium format: a "Notes:" header, the indented
+/// note body, and a trailing blank line. Emits nothing when no note exists.
+async fn log_emit_notes_for_commit(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  db : @bitlib.ObjectDb,
+  commit_id : @bitcore.ObjectId,
+  line_prefix : String,
+) -> Unit raise Error {
+  let notes_ref_path = git_dir + "/refs/notes/commits"
+  if !rfs.is_file(notes_ref_path) {
+    return
+  }
+  let ref_content = decode_bytes(rfs.read_file(notes_ref_path))
+  let commit_hex = trim_string(ref_content)
+  let notes_commit_id = @bitcore.ObjectId::from_hex(commit_hex)
+  let obj = db.get(rfs, notes_commit_id)
+  guard obj is Some(o) else { return }
+  let commit_info = @bitcore.parse_commit(o.data)
+  let target_hex = commit_id.to_hex()
+  let blob_id = notes_lookup_blob(rfs, db, commit_info.tree, target_hex)
+  guard blob_id is Some(bid) else { return }
+  let blob_obj = db.get(rfs, bid)
+  guard blob_obj is Some(bo) else { return }
+  let note_text = decode_bytes(bo.data)
+  let trimmed = if note_text.has_suffix("\n") {
+    string_slice_to(note_text, note_text.length() - 1)
+  } else {
+    note_text
+  }
+  log_emit_output("Notes:", true, line_prefix)
+  for line_view in trimmed.split("\n") {
+    log_emit_output("    " + line_view.to_owned(), true, line_prefix)
+  }
+  log_emit_output("", true, line_prefix)
+}
+
+///|
 fn log_build_ref_names(
   rfs : &@bitcore.RepoFileSystem,
   git_dir : String,
@@ -3841,6 +3880,7 @@ async fn log_emit_default_commit_entry(
   log_emit_output("", true, line_prefix)
   log_emit_output("    " + entry.message, true, line_prefix)
   log_emit_output("", true, line_prefix)
+  log_emit_notes_for_commit(rfs, git_dir, db, entry.id, line_prefix)
   if show_stat || show_patch {
     let diff_files = diff_apply_rotate_skip_files(
       @bitdiff.diff_trees(rfs, git_dir, entry.parent_tree, entry.tree, db~),
@@ -5204,6 +5244,9 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
             log_emit_output("", true, line_prefix)
             log_emit_output("    " + entry.message, true, line_prefix)
             log_emit_output("", true, line_prefix)
+            log_emit_notes_for_commit(
+              rfs, git_dir, db, entry.id, line_prefix,
+            )
             if show_stat || show_patch {
               let diff_files = diff_apply_rotate_skip_files(
                 @bitdiff.diff_trees(
@@ -5564,6 +5607,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         log_emit_output("", true, line_prefix)
         log_emit_output("    " + entry.message, true, line_prefix)
         log_emit_output("", true, line_prefix)
+        log_emit_notes_for_commit(rfs, git_dir, walk_db, entry.id, line_prefix)
         if show_stat || show_patch {
           let diff_files = diff_apply_rotate_skip_files(
             @bitdiff.diff_trees(
@@ -5683,6 +5727,9 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
     } else {
       None
     }
+    let notes_db = @bitlib.ObjectDb::load(
+      rfs, log_resolve_common_git_dir(rfs, git_dir),
+    )
     for entry in entries {
       log_emit_output("commit " + entry.id.to_hex(), true, line_prefix)
       log_emit_output("Author: " + entry.author, true, line_prefix)
@@ -5695,6 +5742,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
       log_emit_output("", true, line_prefix)
       log_emit_output("    " + entry.message, true, line_prefix)
       log_emit_output("", true, line_prefix)
+      log_emit_notes_for_commit(rfs, git_dir, notes_db, entry.id, line_prefix)
       if show_stat || show_patch {
         let diff_files = diff_apply_rotate_skip_files(
           @bitdiff.diff_trees(

--- a/src/cmd/bit/notes.mbt
+++ b/src/cmd/bit/notes.mbt
@@ -338,12 +338,10 @@ async fn notes_list(
   let obj = db.get(rfs, commit_id)
   guard obj is Some(o) else { return }
   let commit_info = @bitcore.parse_commit(o.data)
-  // Read tree
-  let tree_obj = db.get(rfs, commit_info.tree)
-  guard tree_obj is Some(to) else { return }
-  let entries = @bitcore.parse_tree(to.data)
-  for entry in entries {
-    print_line("\{entry.id.to_hex()} \{entry.name}")
+  let collected = notes_collect_all(rfs, db, commit_info.tree)
+  for pair in collected {
+    let (hex, id) = pair
+    print_line("\{id.to_hex()} \{hex}")
   }
 }
 
@@ -375,17 +373,10 @@ async fn notes_show(
     @sys.exit(1)
   }
   let commit_info = @bitcore.parse_commit(o.data)
-  // Read tree
-  let tree_obj = db.get(rfs, commit_info.tree)
-  guard tree_obj is Some(to) else {
-    @stdio.stderr.write("error: notes tree corrupt")
-    @sys.exit(1)
-  }
-  let entries = @bitcore.parse_tree(to.data)
-  // Find entry matching target commit
-  for entry in entries {
-    if entry.name == target_hex {
-      let note_obj = db.get(rfs, entry.id)
+  // Find entry matching target commit (supports any fanout depth).
+  match notes_lookup_blob(rfs, db, commit_info.tree, target_hex) {
+    Some(blob_id) => {
+      let note_obj = db.get(rfs, blob_id)
       guard note_obj is Some(no) else {
         @stdio.stderr.write("error: note blob corrupt")
         @sys.exit(1)
@@ -393,9 +384,128 @@ async fn notes_show(
       no.data |> decode_bytes |> print_line
       return
     }
+    None => ()
   }
   @stdio.stderr.write("error: no note found for \{target_hex}")
   @sys.exit(1)
+}
+
+///|
+/// Lookup a note blob ID for `commit_hex` in the given notes tree, supporting
+/// any fanout depth. Returns None if the note isn't present.
+fn notes_lookup_blob(
+  rfs : &@bitcore.RepoFileSystem,
+  db : @bitlib.ObjectDb,
+  tree_id : @bitcore.ObjectId,
+  commit_hex : String,
+) -> @bitcore.ObjectId? raise Error {
+  let obj = db.get(rfs, tree_id)
+  guard obj is Some(o) else { return None }
+  let entries = @bitcore.parse_tree(o.data)
+  for e in entries {
+    if e.name == commit_hex {
+      return Some(e.id)
+    }
+    if (e.mode == "40000" || e.mode == "040000") &&
+      commit_hex.length() > e.name.length() &&
+      string_slice_to(commit_hex, e.name.length()) == e.name {
+      let rest = string_slice_from(commit_hex, e.name.length())
+      return notes_lookup_blob(rfs, db, e.id, rest)
+    }
+  }
+  None
+}
+
+///|
+/// Recursively collect all (full_commit_hex, blob_id) pairs from a notes tree.
+fn notes_collect_all(
+  rfs : &@bitcore.RepoFileSystem,
+  db : @bitlib.ObjectDb,
+  tree_id : @bitcore.ObjectId,
+) -> Array[(String, @bitcore.ObjectId)] raise Error {
+  let result : Array[(String, @bitcore.ObjectId)] = []
+  notes_walk_tree(rfs, db, tree_id, "", result)
+  result
+}
+
+///|
+fn notes_walk_tree(
+  rfs : &@bitcore.RepoFileSystem,
+  db : @bitlib.ObjectDb,
+  tree_id : @bitcore.ObjectId,
+  prefix : String,
+  out : Array[(String, @bitcore.ObjectId)],
+) -> Unit raise Error {
+  let obj = db.get(rfs, tree_id)
+  guard obj is Some(o) else { return }
+  let entries = @bitcore.parse_tree(o.data)
+  for e in entries {
+    if e.mode == "40000" || e.mode == "040000" {
+      notes_walk_tree(rfs, db, e.id, prefix + e.name, out)
+    } else {
+      out.push((prefix + e.name, e.id))
+    }
+  }
+}
+
+///|
+/// Threshold above which the notes tree is rebalanced into 1-level fanout
+/// (subdirs named with the first 2 hex chars of the commit OID). Matches
+/// the conventional 256-entry boundary used by upstream git.
+let notes_fanout_threshold : Int = 256
+
+///|
+/// Build and write a notes tree for the given (commit_hex, blob_id) entries.
+/// Picks fanout 0 when entries.length() <= notes_fanout_threshold, otherwise
+/// fanout 1. Returns the root tree id.
+fn notes_write_tree(
+  wfs : &@bitcore.FileSystem,
+  git_dir : String,
+  notes : Array[(String, @bitcore.ObjectId)],
+) -> @bitcore.ObjectId raise Error {
+  if notes.length() <= notes_fanout_threshold {
+    let entries : Array[@bitcore.TreeEntry] = []
+    for pair in notes {
+      let (hex, id) = pair
+      entries.push(@bitcore.TreeEntry::new("100644", hex, id))
+    }
+    entries.sort_by((a, b) => a.name.compare(b.name))
+    let (tree_id, tree_data) = @bitcore.create_tree(entries)
+    @bitlib.write_object_bytes(wfs, git_dir, tree_id, tree_data)
+    return tree_id
+  }
+  // Fanout 1: group by first 2 hex chars.
+  let groups : Map[String, Array[@bitcore.TreeEntry]] = Map::new()
+  for pair in notes {
+    let (hex, id) = pair
+    let prefix = string_slice_to(hex, 2)
+    let suffix = string_slice_from(hex, 2)
+    let existing = groups.get(prefix)
+    match existing {
+      Some(g) => g.push(@bitcore.TreeEntry::new("100644", suffix, id))
+      None => {
+        let g : Array[@bitcore.TreeEntry] = []
+        g.push(@bitcore.TreeEntry::new("100644", suffix, id))
+        groups[prefix] = g
+      }
+    }
+  }
+  let prefixes : Array[String] = []
+  for prefix, _ in groups {
+    prefixes.push(prefix)
+  }
+  prefixes.sort()
+  let top_entries : Array[@bitcore.TreeEntry] = []
+  for prefix in prefixes {
+    let group = groups.get(prefix).unwrap()
+    group.sort_by((a, b) => a.name.compare(b.name))
+    let (sub_id, sub_data) = @bitcore.create_tree(group)
+    @bitlib.write_object_bytes(wfs, git_dir, sub_id, sub_data)
+    top_entries.push(@bitcore.TreeEntry::new("40000", prefix, sub_id))
+  }
+  let (tree_id, tree_data) = @bitcore.create_tree(top_entries)
+  @bitlib.write_object_bytes(wfs, git_dir, tree_id, tree_data)
+  tree_id
 }
 
 ///|
@@ -422,8 +532,8 @@ async fn notes_add(
     @bitcore.ObjectType::Blob,
     note_content,
   )
-  // Get existing tree entries if notes ref exists
-  let entries : Array[@bitcore.TreeEntry] = []
+  // Collect all existing notes (recursively across any fanout depth).
+  let notes : Array[(String, @bitcore.ObjectId)] = []
   let mut parent_commit : @bitcore.ObjectId? = None
   if rfs.is_file(notes_ref_path) {
     let ref_content = decode_bytes(rfs.read_file(notes_ref_path))
@@ -435,38 +545,27 @@ async fn notes_add(
     match obj {
       Some(o) => {
         let commit_info = @bitcore.parse_commit(o.data)
-        let tree_obj = db.get(rfs, commit_info.tree)
-        match tree_obj {
-          Some(to) => {
-            let existing = @bitcore.parse_tree(to.data)
-            for e in existing {
-              if e.name == target_hex {
-                if !force {
-                  @stdio.stderr.write(
-                    "error: note already exists for \{target_hex}",
-                  )
-                  @stdio.stderr.write("Use -f to overwrite existing note")
-                  @sys.exit(1)
-                }
-                // Skip existing note (will be replaced)
-              } else {
-                entries.push(e)
-              }
+        let collected = notes_collect_all(rfs, db, commit_info.tree)
+        for pair in collected {
+          let (hex, id) = pair
+          if hex == target_hex {
+            if !force {
+              @stdio.stderr.write("error: note already exists for \{target_hex}")
+              @stdio.stderr.write("Use -f to overwrite existing note")
+              @sys.exit(1)
             }
+            // Skip existing note (will be replaced)
+          } else {
+            notes.push((hex, id))
           }
-          None => ()
         }
       }
       None => ()
     }
   }
-  // Add new note entry
-  entries.push(@bitcore.TreeEntry::new("100644", target_hex, note_id))
-  // Sort entries by name (git requires sorted trees)
-  entries.sort_by((a, b) => a.name.compare(b.name))
-  // Create tree
-  let (tree_id, tree_data) = @bitcore.create_tree(entries)
-  @bitlib.write_object_bytes(wfs, git_dir, tree_id, tree_data)
+  // Add new note entry, then write tree at the appropriate fanout level.
+  notes.push((target_hex, note_id))
+  let tree_id = notes_write_tree(wfs, git_dir, notes)
   // Create commit
   let author = get_author_string()
   let timestamp = @sys.get_env_var("GIT_COMMITTER_DATE")
@@ -502,8 +601,8 @@ async fn notes_append(
     raise @bitcore.GitError::InvalidObject("unknown revision: \{commit_ref}")
   }
   let target_hex = tid.to_hex()
-  // Get existing tree entries and note content if present
-  let entries : Array[@bitcore.TreeEntry] = []
+  // Collect existing notes (across any fanout), capture current text if any.
+  let notes : Array[(String, @bitcore.ObjectId)] = []
   let mut parent_commit : @bitcore.ObjectId? = None
   let mut existing_text : String? = None
   if rfs.is_file(notes_ref_path) {
@@ -518,22 +617,18 @@ async fn notes_append(
       @sys.exit(1)
     }
     let commit_info = @bitcore.parse_commit(o.data)
-    let tree_obj = db.get(rfs, commit_info.tree)
-    guard tree_obj is Some(to) else {
-      @stdio.stderr.write("error: notes tree corrupt")
-      @sys.exit(1)
-    }
-    let existing = @bitcore.parse_tree(to.data)
-    for e in existing {
-      if e.name == target_hex {
-        let note_obj = db.get(rfs, e.id)
+    let collected = notes_collect_all(rfs, db, commit_info.tree)
+    for pair in collected {
+      let (hex, id) = pair
+      if hex == target_hex {
+        let note_obj = db.get(rfs, id)
         guard note_obj is Some(no) else {
           @stdio.stderr.write("error: note blob corrupt")
           @sys.exit(1)
         }
         existing_text = no.data |> decode_bytes |> Some
       } else {
-        entries.push(e)
+        notes.push((hex, id))
       }
     }
   }
@@ -552,13 +647,9 @@ async fn notes_append(
     @bitcore.ObjectType::Blob,
     note_content,
   )
-  // Add new note entry
-  entries.push(@bitcore.TreeEntry::new("100644", target_hex, note_id))
-  // Sort entries by name (git requires sorted trees)
-  entries.sort_by((a, b) => a.name.compare(b.name))
-  // Create tree
-  let (tree_id, tree_data) = @bitcore.create_tree(entries)
-  @bitlib.write_object_bytes(wfs, git_dir, tree_id, tree_data)
+  // Add new note entry, write tree at appropriate fanout.
+  notes.push((target_hex, note_id))
+  let tree_id = notes_write_tree(wfs, git_dir, notes)
   // Create commit
   let author = get_author_string()
   let timestamp = get_current_timestamp()
@@ -617,31 +708,27 @@ async fn notes_copy(
     @sys.exit(1)
   }
   let commit_info = @bitcore.parse_commit(o.data)
-  let tree_obj = db.get(rfs, commit_info.tree)
-  guard tree_obj is Some(to) else {
-    @stdio.stderr.write("error: notes tree corrupt")
-    @sys.exit(1)
-  }
-  let existing = @bitcore.parse_tree(to.data)
-  let entries : Array[@bitcore.TreeEntry] = []
-  let mut source_entry : @bitcore.TreeEntry? = None
+  let collected = notes_collect_all(rfs, db, commit_info.tree)
+  let notes : Array[(String, @bitcore.ObjectId)] = []
+  let mut source_blob : @bitcore.ObjectId? = None
   let mut dest_exists = false
-  for e in existing {
-    if e.name == from_hex {
-      source_entry = Some(e)
-      entries.push(e)
-    } else if e.name == to_hex {
+  for pair in collected {
+    let (hex, id) = pair
+    if hex == from_hex {
+      source_blob = Some(id)
+      notes.push((hex, id))
+    } else if hex == to_hex {
       dest_exists = true
       if force {
-        // skip existing destination
+        // skip existing destination (will be replaced below)
       } else {
-        entries.push(e)
+        notes.push((hex, id))
       }
     } else {
-      entries.push(e)
+      notes.push((hex, id))
     }
   }
-  guard source_entry is Some(src) else {
+  guard source_blob is Some(src_id) else {
     @stdio.stderr.write("error: no note found for \{from_hex}")
     @sys.exit(1)
   }
@@ -649,12 +736,12 @@ async fn notes_copy(
     @stdio.stderr.write("error: note already exists for \{to_hex}")
     @sys.exit(1)
   }
-  entries.push(@bitcore.TreeEntry::new("100644", to_hex, src.id))
-  entries.sort_by((a, b) => a.name.compare(b.name))
-  let (tree_id, tree_data) = @bitcore.create_tree(entries)
-  @bitlib.write_object_bytes(wfs, git_dir, tree_id, tree_data)
+  notes.push((to_hex, src_id))
+  let tree_id = notes_write_tree(wfs, git_dir, notes)
   let author = get_author_string()
-  let timestamp = get_current_timestamp()
+  let timestamp = @sys.get_env_var("GIT_COMMITTER_DATE")
+    .map(parse_commit_date)
+    .unwrap_or(get_current_timestamp())
   let commit = @bitcore.Commit::new(
     tree_id,
     [commit_id],
@@ -701,32 +788,28 @@ async fn notes_remove(
     @sys.exit(1)
   }
   let commit_info = @bitcore.parse_commit(o.data)
-  let tree_obj = db.get(rfs, commit_info.tree)
-  guard tree_obj is Some(to) else {
-    @stdio.stderr.write("error: notes tree corrupt")
-    @sys.exit(1)
-  }
-  let existing = @bitcore.parse_tree(to.data)
+  let collected = notes_collect_all(rfs, db, commit_info.tree)
   // Filter out target entry
   let mut found = false
-  let entries : Array[@bitcore.TreeEntry] = []
-  for e in existing {
-    if e.name == target_hex {
+  let notes : Array[(String, @bitcore.ObjectId)] = []
+  for pair in collected {
+    let (hex, id) = pair
+    if hex == target_hex {
       found = true
     } else {
-      entries.push(e)
+      notes.push((hex, id))
     }
   }
   if !found {
     @stdio.stderr.write("error: no note found for \{target_hex}")
     @sys.exit(1)
   }
-  // Create new tree
-  let (tree_id, tree_data) = @bitcore.create_tree(entries)
-  @bitlib.write_object_bytes(wfs, git_dir, tree_id, tree_data)
+  let tree_id = notes_write_tree(wfs, git_dir, notes)
   // Create commit
   let author = get_author_string()
-  let timestamp = get_current_timestamp()
+  let timestamp = @sys.get_env_var("GIT_COMMITTER_DATE")
+    .map(parse_commit_date)
+    .unwrap_or(get_current_timestamp())
   let commit = @bitcore.Commit::new(
     tree_id,
     [commit_id],
@@ -763,32 +846,31 @@ async fn notes_prune(
   let obj = db.get(rfs, commit_id)
   guard obj is Some(o) else { return }
   let commit_info = @bitcore.parse_commit(o.data)
-  let tree_obj = db.get(rfs, commit_info.tree)
-  guard tree_obj is Some(to) else { return }
-  let existing = @bitcore.parse_tree(to.data)
+  let collected = notes_collect_all(rfs, db, commit_info.tree)
   // Filter entries where the referenced commit still exists
-  let entries : Array[@bitcore.TreeEntry] = []
+  let notes : Array[(String, @bitcore.ObjectId)] = []
   let mut pruned = 0
-  for e in existing {
-    let ref_id = @bitcore.ObjectId::from_hex(e.name)
+  for pair in collected {
+    let (hex, id) = pair
+    let ref_id = @bitcore.ObjectId::from_hex(hex)
     let ref_obj = db.get(rfs, ref_id) catch {
       err if @async.is_cancellation_error(err) => raise err
       _ => None
     }
     match ref_obj {
-      Some(_) => entries.push(e)
+      Some(_) => notes.push((hex, id))
       None => pruned += 1
     }
   }
   if pruned == 0 {
     return
   }
-  // Create new tree
-  let (tree_id, tree_data) = @bitcore.create_tree(entries)
-  @bitlib.write_object_bytes(wfs, git_dir, tree_id, tree_data)
+  let tree_id = notes_write_tree(wfs, git_dir, notes)
   // Create commit
   let author = get_author_string()
-  let timestamp = get_current_timestamp()
+  let timestamp = @sys.get_env_var("GIT_COMMITTER_DATE")
+    .map(parse_commit_date)
+    .unwrap_or(get_current_timestamp())
   let commit = @bitcore.Commit::new(
     tree_id,
     [commit_id],


### PR DESCRIPTION
## Summary

Fix the underlying behaviour `t3305-notes-fanout` covers, instead of papering
over it with a `test_expect_failure` patch.

`git notes` previously only wrote flat trees (no fanout) and `git log` never
read notes. Upstream's test adds 300 notes, expects the working tree to
transition to 1-level fanout (`XX/<38-hex>`) once the entry count crosses
the conventional 256-entry boundary, deletes most of them, and expects the
structure to collapse back to fanout 0.

### `src/cmd/bit/notes.mbt`

- New `notes_collect_all` walks the notes tree recursively, so reads work at
  any fanout depth.
- New `notes_write_tree` rebuilds the tree from a flat list of
  `(commit_hex, blob_id)` pairs: flat at fanout 0 when `count <= 256`,
  otherwise one 2-hex subdir per prefix (fanout 1). Each subdir is itself a
  sorted tree of `100644` blobs.
- New `notes_lookup_blob` finds the blob for a commit in a notes tree at
  any depth.
- `notes_add`, `notes_append`, `notes_copy`, `notes_remove`, `notes_prune`
  now go through `notes_collect_all` + `notes_write_tree`, so a single add
  past the 256-entry threshold triggers a clean rebalance, and the
  symmetric collapse happens automatically on remove/prune.
- `notes_show` / `notes_list` walk the tree recursively too.

### `src/cmd/bit/log.mbt`

- New `log_emit_notes_for_commit` reads `refs/notes/commits`, looks up the
  current commit's note (any fanout), and emits upstream's medium-format
  `Notes:` block: a `Notes:` header followed by the indented note body and
  a trailing blank line. Emits nothing when no note exists.
- Wired into all four medium-format commit-emit sites in `log.mbt`.

### Threshold

256 entries matches upstream git's effective fanout-1 transition point for
t3305's 300-note workload. The remove path uses the same threshold in the
other direction, so the test's final "stable fanout 1 is followed by
stable fanout 0" assertion is satisfied as deletes drop the count back below
the boundary.

## Test plan

- [x] t3305-notes-fanout: all 7 subtests pass under the CI strict shim
      (`SHIM_STRICT=1` with the 99-command `SHIM_CMDS` list). No
      known-breakage patch needed.
- [ ] CI git-compat shards remain green.

## Interaction with #43

#43 adds t3305 to the allowlist with a known-breakage patch. Once this PR
lands, that patch can be dropped — t3305 passes outright. I'd suggest
merging this first, then rebasing #43 to remove the `t3305-notes-fanout-known-breakage.patch`
file while keeping the allowlist entry and the t5300 work.

https://claude.ai/code/session_01M3TPgeGLDKQxep3AAYpDVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3TPgeGLDKQxep3AAYpDVs)_