### PR TITLE
allowlist: probe t5310/t5326 pack-bitmap tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 # TODO (Active Only)
 
-最終整理日: 2026-04-05
+最終整理日: 2026-05-16
 現バージョン: v0.41.0
-allowlist: 975 テスト
+allowlist: 905 テスト (probe: t5310/t5326)
 CI SHIM_CMDS: **108 コマンド**
 e2e: **43/43 全パス**
 t3404 (rebase -i): **129/132 (97.7%)**
@@ -54,12 +54,15 @@ t3404 (rebase -i): **129/132 (97.7%)**
 
 ## P2.5: Allowlist 拡大
 
-- 現在: 977/1027 (非 t9xxx で 50 テスト未追加)
+- 現在: 905 (probe 反映後)
 - [x] t0008-ignores.sh
 - [x] t1901-repo-structure.sh
+- [x] t3305-notes-fanout.sh
+- [x] t5300-pack-object.sh
 - [x] t5333-pseudo-merge-bitmaps.sh
-- [ ] t1400 (10分超で CI shard には重い)
-- [ ] t4124, t5300, t5310, t5326 等 (known-breakage patch が必要)
+- [ ] t5310-pack-bitmaps.sh / t5326-multi-pack-bitmaps.sh — CI probe 中
+- [ ] t1400-update-ref.sh (10分超で CI shard には重い)
+- [ ] t4124-apply-ws-rule.sh (known-breakage patch が必要)
 
 ## P3: 将来タスク
 

--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -309,6 +309,7 @@ t5306-pack-nobase.sh
 t5307-pack-missing-commit.sh
 t5308-pack-detect-duplicates.sh
 t5309-pack-delta-cycles.sh
+t5310-pack-bitmaps.sh
 t5311-pack-bitmaps-shallow.sh
 t5312-prune-corruption.sh
 t5313-pack-bounds-checks.sh
@@ -324,6 +325,7 @@ t5322-pack-objects-sparse.sh
 t5323-pack-redundant.sh
 t5324-split-commit-graph.sh
 t5325-reverse-index.sh
+t5326-multi-pack-bitmaps.sh
 t5327-multi-pack-bitmaps-rev.sh
 t5328-commit-graph-64bit-time.sh
 t5329-pack-objects-cruft.sh


### PR DESCRIPTION
## Summary

Pack bitmap reader was added in P2 (commit `f5f3d6c`), but the bitmap-dependent compat tests `t5310-pack-bitmaps` and `t5326-multi-pack-bitmaps` were still outside the strict-shim allowlist. Enroll them and let CI confirm they pass without a known-breakage patch, mirroring the strategy used for `t5333-pseudo-merge-bitmaps` (already green) and `t5300-pack-object` (#43).

`TODO.md` is realigned with the post-#43 state:
- `t1901` / `t3305` / `t5300` / `t5333` are marked done.
- Remaining unchecked items reduced to `t1400` (heavy for a CI shard) and `t4124` (needs a known-breakage patch).

## Test plan

- [x] `node --test tools/git-compat-allowlist.test.mjs` — no duplicate allowlist entries.
- [ ] CI `git-compat` shards remain green on the two newly enrolled tests.
- [ ] No regression on the existing allowlist entries.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_