### PR TITLE
allowlist: probe t1400-update-ref with dynamic per-test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,14 @@ jobs:
             # Strip third_party/git/t/ prefix if present
             t_base="${t#third_party/git/t/}"
             t_start=$SECONDS
-            if timeout 120 bash "./$t_base" > "$test_output" 2>&1; then
+            # Per-test timeout: 3× the recorded median runtime weight,
+            # floored at 120s. Recorded weights cap at the previous 120s
+            # timeout, so tests whose true runtime exceeds it (e.g.
+            # t1400-update-ref) get enough headroom to finish.
+            t_weight=$(awk -F'\t' -v t="$t_base" '$1==t {print $2}' "$GITHUB_WORKSPACE/tools/git-test-runtime-seconds.tsv")
+            t_timeout=$(( ${t_weight:-40} * 3 ))
+            if [ "$t_timeout" -lt 120 ]; then t_timeout=120; fi
+            if timeout "$t_timeout" bash "./$t_base" > "$test_output" 2>&1; then
               tail -5 "$test_output"
               passed=$((passed + 1))
             else
@@ -169,7 +176,7 @@ jobs:
               tail -5 "$test_output"
               echo "::endgroup::"
               if [ "$exit_code" -eq 124 ]; then
-                echo "TIMEOUT: $t_base exceeded 120s"
+                echo "TIMEOUT: $t_base exceeded ${t_timeout}s"
               fi
               failed=$((failed + 1))
               failed_tests="$failed_tests $t_base"

--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -15,6 +15,7 @@ t0450-txt-doc-vs-help.sh
 t1006-cat-file.sh
 t1007-hash-object.sh
 t1300-config.sh
+t1400-update-ref.sh
 t1401-symbolic-ref.sh
 t1403-show-ref.sh
 t1500-rev-parse.sh


### PR DESCRIPTION
## Summary

Enroll `t1400-update-ref.sh` in the strict-shim allowlist as a probe, after lifting the per-test runtime ceiling that was previously hiding it.

`tools/git-test-runtime-seconds.tsv` records `t1400` at exactly `120` seconds — the same value as the hard-coded `timeout 120` cap in the git-compat shard loop. That means the recorded weight is the cap, not the real runtime: any test whose true runtime exceeds 120s is recorded as exactly 120s. `t1400`'s actual upstream runtime is several minutes, which is why it was deferred from P2.5 with the "10分超で CI shard には重い" note in `TODO.md`.

This PR:
- Replaces the fixed 120s cap with a per-test budget derived from the recorded weight: `cap = max(weight × 3, 120s)`. The 3× headroom absorbs shim/instrumentation overhead; the 120s floor preserves the existing budget for fast tests without a recorded weight. Most allowlist entries already fit comfortably under 120s and pick up no extra budget.
- Adds `t1400-update-ref.sh` so CI can report whether bit's `update-ref` / refs backend now satisfies the t1400 subtests, or whether a known-breakage patch is needed for specific assertions.

## Test plan

- [x] `node --test tools/git-compat-allowlist.test.mjs` — no duplicate allowlist entries.
- [ ] CI `git-compat` shards: confirm t1400 either passes outright (best case) or shows a tractable list of failing subtests (so a known-breakage patch can be drafted in a follow-up).
- [ ] Confirm the timeout-bump does not regress any currently-green entry by inflating shard wall time materially.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_