### PR TITLE
allowlist: probe t4124-apply-ws-rule

### DIFF
--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -894,6 +894,7 @@ t4120-apply-popt.sh
 t4121-apply-diffs.sh
 t4122-apply-symlink-inside.sh
 t4123-apply-shrink.sh
+t4124-apply-ws-rule.sh
 t4125-apply-ws-fuzz.sh
 t4126-apply-empty.sh
 t4127-apply-same-fn.sh


### PR DESCRIPTION
## Summary

Following the same pattern used for `t5300` / `t5310` / `t5333` / `t5326`: enroll `t4124-apply-ws-rule.sh` without an upfront known-breakage patch so CI surfaces the exact subtests bit's `apply` / whitespace handling doesn't yet satisfy. A targeted known-breakage patch (or apply-side fix) can follow as a separate change once we have the list.

Several `t4124` subtests exercise `whitespace=fix` / `blank-at-EOF` / CR-LF-aware rules that aren't all covered by the existing `t4123-apply-shrink` / `t4125-apply-ws-fuzz` tests already on the allowlist, so this is the riskiest of the remaining P2.5 probes — expect failures, not a clean green. The CI output will tell us exactly which subtests need attention.

## Test plan

- [x] `node --test tools/git-compat-allowlist.test.mjs` — no duplicate allowlist entries.
- [ ] CI `git-compat` shards: capture the failing subtest list for follow-up.
- [ ] Either merge with a follow-up known-breakage patch, or close & redo once an apply-side fix lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_