### PR TITLE
TODO: P2.5 complete — t1400 and t4124 both green

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 最終整理日: 2026-05-16
 現バージョン: v0.41.0
-allowlist: 905 テスト
+allowlist: 907 テスト
 CI SHIM_CMDS: **108 コマンド**
 e2e: **43/43 全パス**
 t3404 (rebase -i): **129/132 (97.7%)**
@@ -52,18 +52,18 @@ t3404 (rebase -i): **129/132 (97.7%)**
 - [x] Pack bitmap 読み込み (t5310/t5326/t5333)
 - [x] Commit-graph 活用 — log/rev-list 高速化
 
-## P2.5: Allowlist 拡大
+## P2.5: Allowlist 拡大 — 完了
 
-- 現在: 905
+- 現在: 907
 - [x] t0008-ignores.sh
+- [x] t1400-update-ref.sh — per-test timeout を `max(weight×3, 120s)` に変更して enroll
 - [x] t1901-repo-structure.sh
 - [x] t3305-notes-fanout.sh
+- [x] t4124-apply-ws-rule.sh — known-breakage patch 不要
 - [x] t5300-pack-object.sh
 - [x] t5310-pack-bitmaps.sh
 - [x] t5326-multi-pack-bitmaps.sh
 - [x] t5333-pseudo-merge-bitmaps.sh
-- [ ] t1400-update-ref.sh (10分超で CI shard には重い)
-- [ ] t4124-apply-ws-rule.sh (known-breakage patch が必要)
 
 ## P3: 将来タスク
 


### PR DESCRIPTION
## Summary

CI on #48 / #49 came back fully green:
- `t1400-update-ref` passes once the per-test timeout is raised from a flat 120s to `max(weight × 3, 120s)` (merged in #48).
- `t4124-apply-ws-rule` passes outright — no known-breakage patch needed.

That closes the **P2.5: Allowlist 拡大** section. Total allowlist entries are now 907; the remaining open items in `TODO.md` live under **P3** (WASM coverage, Moonix integration, `bit mcp` 拡充).

## Test plan

- [x] Visual confirmation that PR #48 and PR #49 finished with all 14 checks green.
- [x] `node --test tools/git-compat-allowlist.test.mjs` — no duplicate allowlist entries.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_