### PR TITLE
wasm: extend test coverage to diff3 and repo materialize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           moon test --target js -p mizchi/bit -p mizchi/bit/lib
           moon test --target wasm -p mizchi/bit/runtime -f storage_runtime_wbtest.mbt
+          moon test --target wasm -p mizchi/bit/diff3
+          moon test --target wasm -p mizchi/bit/repo
           # Kill any orphan moon processes and remove stale lock before native tests
           pkill -f "moon" || true
           rm -f _build/.moon-lock

--- a/TODO.md
+++ b/TODO.md
@@ -68,6 +68,8 @@ t3404 (rebase -i): **129/132 (97.7%)**
 ## P3: 将来タスク
 
 - [ ] WASM target カバレッジ拡大
+  - [x] diff3 wbtest (23/23 pass) / repo materialize wbtest (2/2 pass) — wasm CI 入り
+  - [ ] fingerprint / x-workspace の wbtest は `async/process` 依存で wasm 不可能、native のみ維持
 - [ ] Moonix integration
 - [ ] bit mcp 拡充
 

--- a/Test.pkl
+++ b/Test.pkl
@@ -20,6 +20,14 @@ tests {
     cmd = "moon test --target wasm -p mizchi/bit/runtime -f storage_runtime_wbtest.mbt"
   }
   new {
+    name = "moon-test-wasm-diff3"
+    cmd = "moon test --target wasm -p mizchi/bit/diff3"
+  }
+  new {
+    name = "moon-test-wasm-repo"
+    cmd = "moon test --target wasm -p mizchi/bit/repo"
+  }
+  new {
     name = "moon-test-native"
     cmd = "moon test --target native --no-parallelize -j 1"
   }


### PR DESCRIPTION
## Summary

First step of the **P3 / WASM target カバレッジ拡大** item. Audit of the existing wbtest suites for wasm portability:

| wbtest | wasm result | reason |
|---|---|---|
| `diff3_wbtest.mbt` | **23/23 pass** | pure MoonBit, no I/O |
| `materialize_wbtest.mbt` | **2/2 pass** | in-memory `build_commit_for_index_order` |
| `fingerprint_wbtest.mbt` | native only | `moonbitlang/async/process` spawns external commands |
| `workspace_wbtest.mbt` | native only | `moonbitlang/async/process` + `moonbitlang/x/fs`/`sys` |
| `storage_runtime_wbtest.mbt` | already wasm | unchanged |

This PR enrolls the two tractable suites (`diff3`, `repo`) in the wasm test run, in both `Test.pkl` (canonical via pkfire/pkspec) and the CI workflow. `fingerprint` and `x-workspace` stay restricted to native via their existing `moon.pkg` `targets` declarations — porting them would mean rewriting the test fixtures, which is out of scope.

## Test plan

- [x] `moon test --target wasm -p mizchi/bit/diff3` → 23/23.
- [x] `moon test --target wasm -p mizchi/bit/repo` → 2/2.
- [ ] CI confirms both runs stay green in the `test` job.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_