### PR TITLE
wasm: enable grep pattern + search wbtests on wasm target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           moon test --target wasm -p mizchi/bit/runtime -f storage_runtime_wbtest.mbt
           moon test --target wasm -p mizchi/bit/diff3
           moon test --target wasm -p mizchi/bit/repo
+          moon test --target wasm -p mizchi/bit/grep
           # Kill any orphan moon processes and remove stale lock before native tests
           pkill -f "moon" || true
           rm -f _build/.moon-lock

--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,7 @@ t3404 (rebase -i): **129/132 (97.7%)**
 
 - [ ] WASM target カバレッジ拡大
   - [x] diff3 wbtest (23/23 pass) / repo materialize wbtest (2/2 pass) — wasm CI 入り
+  - [x] grep pattern + search wbtest (28/28 pass) — wasm CI 入り
   - [ ] fingerprint / x-workspace の wbtest は `async/process` 依存で wasm 不可能、native のみ維持
 - [ ] Moonix integration
 - [ ] bit mcp 拡充

--- a/Test.pkl
+++ b/Test.pkl
@@ -28,6 +28,10 @@ tests {
     cmd = "moon test --target wasm -p mizchi/bit/repo"
   }
   new {
+    name = "moon-test-wasm-grep"
+    cmd = "moon test --target wasm -p mizchi/bit/grep"
+  }
+  new {
     name = "moon-test-native"
     cmd = "moon test --target native --no-parallelize -j 1"
   }

--- a/src/grep/moon.pkg
+++ b/src/grep/moon.pkg
@@ -11,8 +11,8 @@ warnings = "-29"
 
 options(
   targets: {
-    "pattern_wbtest.mbt": [ "native" ],
-    "search_wbtest.mbt": [ "native" ],
+    "pattern_wbtest.mbt": [ "native", "wasm" ],
+    "search_wbtest.mbt": [ "native", "wasm" ],
   },
 )
 


### PR DESCRIPTION
## Summary

Audit follow-up to #51 (diff3/repo materialize wasm enrollment). Both `grep` wbtest suites were restricted to native via `src/grep/moon.pkg` `targets`, but neither actually uses native-only facilities:

| wbtest | wasm result | uses |
|---|---|---|
| `pattern_wbtest.mbt` | **17/17 pass** | pure regex matching, no I/O |
| `search_wbtest.mbt` | **11/11 pass** | `@bit.TestFs` (in-memory) + `@bitlib.add_paths` — all wasm-compatible |

Total: **+28 wasm tests**. Adds a `moon-test-wasm-grep` suite to `Test.pkl` (canonical via pkfire/pkspec) and the CI `test` job.

## Test plan

- [x] `moon test --target wasm -p mizchi/bit/grep` → 28/28.
- [ ] CI confirms green in the `test` job.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_