### PR TITLE
allowlist: probe t9300-fast-import

### DIFF
--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -966,6 +966,7 @@ t8020-last-modified.sh
 # t9*
 t9002-column.sh
 t9003-help-autocorrect.sh
+t9300-fast-import.sh
 t9301-fast-import-notes.sh
 t9302-fast-import-unpack-limit.sh
 t9303-fast-import-compression.sh


### PR DESCRIPTION
## Summary

The fast-import family `t9301`–`t9306` (notes, unpack-limit, compression, marks, signatures, signed-tags) is fully enrolled and green, but the **base `t9300-fast-import.sh`** — which exercises the core stream protocol — was never enrolled.

Sweeping all unenrolled `tNNNN` scripts confirms it's the only viable in-scope candidate left: every other unenrolled test is svn / cvs / p4 / perl-Git / send-email / scalar / gitweb territory, all explicitly out of scope per TODO.md.

Following the pattern used for #46 / #49 (t5310 / t4124): enroll without an upfront known-breakage patch so CI surfaces any subtests bit's native fast-import implementation doesn't yet satisfy.

## Risk

t9300 has 192 subtests covering blob/commit/tag commands, date formats, import/export-marks, checkpoint/done, get-mark/cat-blob/ls, and option handling. Recorded weight on real git is 10s, well within the `max(weight × 3, 120s)` per-test budget. No exotic prereqs in the script and the related t9301-t9306 family has **zero** known-breakage patches, so a clean run is plausible — but the probe is what tells us for sure.

## Test plan

- [ ] CI git-compat shards report pass/fail for t9300-fast-import.sh.
- [ ] If subtests fail, follow up with a targeted known-breakage patch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_