### PR TITLE
TODO: known-breakage 11 → 10; audit pass complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 最終整理日: 2026-05-17
 現バージョン: v0.41.0
 allowlist: 908 テスト
-known-breakage パッチ: 11 (case 1 relaxation 削除済、case 2 / rewrite 系のみ残)
+known-breakage パッチ: 10 (audit pass 完了、残は機能 gap / 個別 test rewrite)
 CI SHIM_CMDS: **108 コマンド**
 e2e: **43/43 全パス**
 t3404 (rebase -i): **129/132 (97.7%)**
@@ -68,18 +68,23 @@ t3404 (rebase -i): **129/132 (97.7%)**
 - [x] t9300-fast-import.sh — known-breakage patch 不要 (t9301-9306 と同列)
 - 残候補 in-scope: なし (未収録 120 件は svn/cvs/p4/perl/scalar 系 = スコープ外)
 
-## P2.6: Known-breakage パッチ精査
+## P2.6: Known-breakage パッチ精査 — audit pass 完了
 
-- 削除済: 18 → 11
+- 削除済: 18 → 10
   - [x] **case 1a (#54)**: t5610-clone-detached / t9350-fast-export / t5505-remote / t5801-remote-helpers
     — 純 relaxation (BIT prereq なし) → upstream `test_expect_failure` で支障なし
   - [x] **case 1b (#56)**: t1410-reflog / t2405-worktree-submodule / t3600-rm
     — BIT prereq 付きだが upstream は `test_expect_failure`、bit 側 skip を外しても TODO 扱い
-- 残 11 パッチの内訳と次手:
-  - **case 2 — BIT prereq で upstream success を skip (7)**: t0411 / t5572 / t5616 / t7502 / t7527 / t7600 / t7703
-    → 外すと bit gap が露呈し suite 落ちる可能性大。各機能 (例: pack-objects REF_DELTA, builtin-fsmonitor 等) を確認してから削除
-  - **case 3 — test 書き換え / skip 系 (4)**: t1006-cat-file (rest+whitespace) / t5300-pack-object (8 件 success→failure) / t5540-http-push-webdav (skip 追加) / t9902-completion (contrib/completion 修正含む)
-    → 機能修正を伴う。個別評価。
+  - [x] **case 1c (#58)**: t5572-pull-submodule
+    — `lib-submodule-update.sh` 内の 2 件、再分類で case 1 判明
+- 残 10 パッチ = 機能 gap または rewrite 系。 audit 範囲外:
+  - **case 2 — bit 機能 gap を masking (6)**:
+    - t7502 / t7600 — commit / merge の SIGTERM 時 lock cleanup 未実装
+    - t0411 / t5616 / t7703 — pack-objects の promisor remote 対応 (lazy-fetch / REF_DELTA / geometric repack)
+    - t7527 — builtin fsmonitor--daemon の submodule 統合
+    → patch 削除には機能実装が先
+  - **case 3 — test 書き換え (4)**: t1006-cat-file (rest+whitespace) / t5300-pack-object (8 件 success→failure) / t5540-http-push-webdav (skip 追加) / t9902-completion (contrib/completion 修正含む)
+    → 個別評価
 
 ## P3: 将来タスク
 


### PR DESCRIPTION
Docs-only: mark P2.6 audit pass complete (11 → 10 patches after #58) and group the remaining case-2 patches by the underlying bit feature gap:

- **SIGTERM lock cleanup** (commit + merge): t7502, t7600
- **pack-objects promisor**: t0411, t5616, t7703
- **fsmonitor daemon submodule integration**: t7527

case 3 (4 patches) needs per-patch evaluation of a test rewrite.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_