### PR TITLE
TODO: known-breakage 10 → 8 (SIGTERM-lock gap was virtual)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 最終整理日: 2026-05-17
 現バージョン: v0.41.0
 allowlist: 908 テスト
-known-breakage パッチ: 10 (audit pass 完了、残は機能 gap / 個別 test rewrite)
+known-breakage パッチ: 8 (実機能 gap / scope 除外 / contrib 修正のみ残)
 CI SHIM_CMDS: **108 コマンド**
 e2e: **43/43 全パス**
 t3404 (rebase -i): **129/132 (97.7%)**
@@ -70,20 +70,19 @@ t3404 (rebase -i): **129/132 (97.7%)**
 
 ## P2.6: Known-breakage パッチ精査 — audit pass 完了
 
-- 削除済: 18 → 10
+- 削除済: 18 → 8
   - [x] **case 1a (#54)**: t5610-clone-detached / t9350-fast-export / t5505-remote / t5801-remote-helpers
     — 純 relaxation (BIT prereq なし) → upstream `test_expect_failure` で支障なし
   - [x] **case 1b (#56)**: t1410-reflog / t2405-worktree-submodule / t3600-rm
     — BIT prereq 付きだが upstream は `test_expect_failure`、bit 側 skip を外しても TODO 扱い
-  - [x] **case 1c (#58)**: t5572-pull-submodule
-    — `lib-submodule-update.sh` 内の 2 件、再分類で case 1 判明
-- 残 10 パッチ = 機能 gap または rewrite 系。 audit 範囲外:
-  - **case 2 — bit 機能 gap を masking (6)**:
-    - t7502 / t7600 — commit / merge の SIGTERM 時 lock cleanup 未実装
+  - [x] **case 1c (#58)**: t5572-pull-submodule — 再分類で case 1 判明
+  - [x] **virtual gap (#60)**: t7502-commit-porcelain / t7600-merge — `BIT_SIGTERM_LOCKS` の "bit does not clean up lock files on SIGTERM" は実体無し。bit の index 書込パスが `.git/index.lock` を作らないため `! -f .git/index.lock` は trivially true、SIGTERM handler 実装は不要
+- 残 8 パッチ = 実機能 gap / 個別評価:
+  - **case 2 — bit 機能 gap (4)**:
     - t0411 / t5616 / t7703 — pack-objects の promisor remote 対応 (lazy-fetch / REF_DELTA / geometric repack)
     - t7527 — builtin fsmonitor--daemon の submodule 統合
     → patch 削除には機能実装が先
-  - **case 3 — test 書き換え (4)**: t1006-cat-file (rest+whitespace) / t5300-pack-object (8 件 success→failure) / t5540-http-push-webdav (skip 追加) / t9902-completion (contrib/completion 修正含む)
+  - **case 3 — test 書き換え / scope 除外 (4)**: t1006-cat-file (rest+whitespace) / t5300-pack-object (8 件 success→failure) / t5540-http-push-webdav (WebDAV 意図的非対応宣言 — 削除不可) / t9902-completion (contrib/completion 修正含む)
     → 個別評価
 
 ## P3: 将来タスク


### PR DESCRIPTION
Docs-only: known-breakage 10 → 8 after #60 confirmed the SIGTERM-lock patches were masking a non-existent gap (bit's index write path uses `fs.write_file` directly, never creates `.git/index.lock`).

Remaining 8:
- **case 2 (4)** — real bit feature gaps: t0411 / t5616 / t7703 (pack-objects promisor variants), t7527 (fsmonitor daemon submodule)
- **case 3 (4)** — t1006 / t5300 / t5540 / t9902 (rewrites / scope exclusions / contrib backports; t5540 not removable)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_