### PR TITLE
allowlist: probe t9210-scalar + t9211-scalar-clone

### DIFF
--- a/tools/git-test-allowlist.txt
+++ b/tools/git-test-allowlist.txt
@@ -966,6 +966,8 @@ t8020-last-modified.sh
 # t9*
 t9002-column.sh
 t9003-help-autocorrect.sh
+t9210-scalar.sh
+t9211-scalar-clone.sh
 t9300-fast-import.sh
 t9301-fast-import-notes.sh
 t9302-fast-import-unpack-limit.sh


### PR DESCRIPTION
## Summary

P2.5 re-sweep — the only in-scope unenrolled tests remaining were t9210 and t9211 (scalar). Everything else in the 119 unenrolled is svn / cvs / p4 / perl-Git / send-email / svk territory, all out of scope.

bit ships scalar in `src/cmd/bit/scalar.mbt` (875 lines, substantial), and `tools/git-shim/bin/scalar` delegates to it via `$moon scalar "$@"`. The shim's `bin/` directory is on `GIT_TEST_INSTALLED`, so the upstream tests pick up bit's scalar binary.

- t9210-scalar.sh: 22 subtests (basic scalar command)
- t9211-scalar-clone.sh: 14 subtests (scalar clone)

Following the pattern of #43 / #46 / #49 / #53: probe-enroll without an upfront known-breakage patch. CI surfaces any subtests bit's scalar doesn't satisfy.

After this: **allowlist 908 → 910** if green.

## Test plan

- [ ] CI git-compat shards 1–10 green.
- [ ] If a shard fails on t9210 / t9211: investigate the failing subtest(s) and decide between known-breakage patch or scalar fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJrwUsEBW7qYWnBx9kd72v)_