### PR TITLE
build(npm): release-npm pipeline + expose pkfire/pkspec via nix

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -118,6 +118,12 @@ local syncNpmBitCjs: Task = new {
   outputs { "npm/bit.cjs" }
 }
 
+local buildNpm: Task = new {
+  name = "build-npm"
+  description = "Build the JS lib + CLI and stage them into npm/ for publish"
+  deps { syncNpmLibRaw; syncNpmBitCjs }
+}
+
 local bundleJsLibMinimal: Task = new {
   name = "bundle-js-lib-minimal"
   description = "Tree-shake the minimal lib consumer (bun build)"
@@ -594,6 +600,24 @@ local releaseCheck: Task = new {
   deps { fmt; info; check; test; verifyJsLibTreeshake; e2e }
 }
 
+local releaseNpm: Task = new {
+  name = "release-npm"
+  description = "Build, validate, and `npm publish` the @mizchi/bit JS package"
+  cmd = #"""
+    cd npm && npm publish
+    """#
+  deps { buildNpm; testJsBuild }
+}
+
+local releaseNpmDryRun: Task = new {
+  name = "release-npm-dry-run"
+  description = "Same as release-npm but invokes `npm publish --dry-run`"
+  cmd = #"""
+    cd npm && npm publish --dry-run
+    """#
+  deps { buildNpm; testJsBuild }
+}
+
 // -- default ------------------------------------------------------------
 
 local default: Task = new {
@@ -618,6 +642,7 @@ tasks {
   buildJsCli
   syncNpmLibRaw
   syncNpmBitCjs
+  buildNpm
   bundleJsLibMinimal
   bundleJsLibGitOps
 
@@ -686,4 +711,6 @@ tasks {
   playgroundDev
 
   releaseCheck
+  releaseNpm
+  releaseNpmDryRun
 }

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
         {
           packages = {
             default = bit;
-            inherit bit;
+            inherit bit pkfire pkspec;
           };
 
           apps = {
@@ -83,6 +83,14 @@
             bit = {
               type = "app";
               program = "${bit}/bin/bit";
+            };
+            pkfire = {
+              type = "app";
+              program = "${pkfire}/bin/pkf";
+            };
+            pkspec = {
+              type = "app";
+              program = "${pkspec}/bin/pkspec";
             };
           };
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bit-vcs/bit"
+    "url": "git+https://github.com/bit-vcs/bit.git"
   },
   "exports": {
     ".": {
@@ -17,6 +17,9 @@
     "./bit.js": "./bit.js",
     "./bit.cjs": "./bit.cjs",
     "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "bin": {
     "bit": "bin/bit.mjs"


### PR DESCRIPTION
## Summary

- Add `release-npm` / `release-npm-dry-run` / `build-npm` tasks so `pkf run release-npm` performs a full **build → sync → test → `npm publish`** pipeline for the `@mizchi/bit` JS package (`npm/` directory).
- Set `publishConfig.access = "public"` and normalize `repository.url` in `npm/package.json` so the scoped package publishes cleanly without `npm pkg fix` warnings.
- Expose `packages.pkfire` / `packages.pkspec` and `apps.pkfire` / `apps.pkspec` from `flake.nix` so `nix run .#pkfire -- run release-npm-dry-run` and `nix profile install .#pkfire` work without entering the devShell.

`npm/package.json` is the source of truth for the published version (root `package.json` stays `private: true`). Bumping is done via `cd npm && npm version <patch|minor|major>` before invoking `release-npm`.

## DAG

`pkf run release-npm-dry-run` resolves to 9 tasks:

```
build-js-cli            moon build --target js --release modules/bit/src/cmd/bit
build-js-lib            moon build --target js --release modules/bit_lib/src
bundle-js-lib-git-ops   bun build … target/lib-js-git-ops.bundle.mjs
bundle-js-lib-minimal   bun build … target/lib-js-minimal.bundle.mjs
sync-npm-bit-cjs        cp _build/js/release/build/mizchi/bit/cmd/bit/bit.js npm/bit.cjs
sync-npm-lib-raw        cp _build/js/release/build/mizchi/bit_lib/bit_lib.js npm/lib.raw.js
build-npm               (aggregates the two syncs)
test-js-build           node --test tools/js-build.test.mjs tools/npm-lib.test.mjs tools/npm-cli.test.mjs …
release-npm-dry-run     cd npm && npm publish --dry-run
```

`release-npm` is identical except the leaf is `npm publish` (no `--dry-run`).

## Test plan

- [x] `pkf list` shows the new `build-npm`, `release-npm`, `release-npm-dry-run` tasks
- [x] `pkf run release-npm-dry-run` end-to-end: 9 tasks · 0 hit · 9 ran (~5s wall)
- [x] `npm publish --dry-run` reports `@mizchi/bit@0.41.0`, 8 files, 387.6 kB, `public access`, no `npm pkg fix` warnings
- [ ] (manual, requires `npm login`) `pkf run release-npm` performs the real publish
- [ ] (requires nix host) `nix run .#pkfire -- --help` / `nix build .#pkspec` succeed

https://claude.ai/code/session_01FgY6EMujwhzucSQkBVcodR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgY6EMujwhzucSQkBVcodR)_