### PR TITLE
fix(deps): bump moonbitlang/async 0.16.6 -> 0.19.4 to unbreak build (#83)

### DIFF
--- a/modules/bit/moon.mod.json
+++ b/modules/bit/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "mizchi/bit",
   "version": "0.42.2",
   "deps": {
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40",
     "mizchi/simd": "0.4.1",
     "mizchi/tempfile": "0.1.0",

--- a/modules/bit_fingerprint/moon.mod.json
+++ b/modules/bit_fingerprint/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/bit_osfs": "0.42.2",
     "mizchi/bit_types": "0.42.2",
     "mizchi/bit_utils": "0.42.2",
-    "moonbitlang/async": "0.16.6"
+    "moonbitlang/async": "0.19.4"
   },
   "repository": "https://github.com/mizchi/bit-vcs",
   "license": "Apache-2.0",

--- a/modules/bit_io/moon.mod.json
+++ b/modules/bit_io/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/bit_pack": "0.42.2",
     "mizchi/bit_protocol": "0.42.2",
     "mizchi/bit_types": "0.42.2",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },
   "repository": "https://github.com/mizchi/bit-vcs",

--- a/modules/bit_lib/moon.mod.json
+++ b/modules/bit_lib/moon.mod.json
@@ -21,7 +21,7 @@
     "mizchi/bit_utils": "0.42.2",
     "mizchi/bit_vfs": "0.42.2",
     "mizchi/zlib": "0.4.5",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },
   "repository": "https://github.com/mizchi/bit-vcs",

--- a/modules/bit_pack/moon.mod.json
+++ b/modules/bit_pack/moon.mod.json
@@ -9,7 +9,7 @@
     "mizchi/bit_protocol": "0.42.2",
     "mizchi/tempfile": "0.1.0",
     "mizchi/zlib": "0.4.5",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },
   "repository": "https://github.com/mizchi/bit-vcs",

--- a/modules/bit_pack_ops/moon.mod.json
+++ b/modules/bit_pack_ops/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/bit_object": "0.42.2",
     "mizchi/bit_pack": "0.42.2",
     "mizchi/bit_types": "0.42.2",
-    "moonbitlang/async": "0.16.6"
+    "moonbitlang/async": "0.19.4"
   },
   "repository": "https://github.com/mizchi/bit-vcs",
   "license": "Apache-2.0",

--- a/modules/bit_protocol/moon.mod.json
+++ b/modules/bit_protocol/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/bit_repo": "0.42.2",
     "mizchi/bit_types": "0.42.2",
     "mizchi/bit_pack": "0.42.2",
-    "moonbitlang/async": "0.16.6"
+    "moonbitlang/async": "0.19.4"
   },
   "repository": "https://github.com/mizchi/bit-vcs",
   "license": "Apache-2.0",

--- a/modules/bit_vfs/moon.mod.json
+++ b/modules/bit_vfs/moon.mod.json
@@ -10,7 +10,7 @@
     "mizchi/bit_repo": "0.42.2",
     "mizchi/bit_types": "0.42.2",
     "mizchi/zlib": "0.4.5",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },
   "repository": "https://github.com/mizchi/bit-vcs",

--- a/modules/bit_worktree/moon.mod.json
+++ b/modules/bit_worktree/moon.mod.json
@@ -7,7 +7,7 @@
     "mizchi/bit_lib": "0.42.2",
     "mizchi/bit_object": "0.42.2",
     "mizchi/bit_types": "0.42.2",
-    "moonbitlang/async": "0.16.6"
+    "moonbitlang/async": "0.19.4"
   },
   "repository": "https://github.com/mizchi/bit-vcs",
   "license": "Apache-2.0",

--- a/modules/bitx_hub/moon.mod.json
+++ b/modules/bitx_hub/moon.mod.json
@@ -11,7 +11,7 @@
     "mizchi/bit_pack": "0.42.2",
     "mizchi/bit_protocol": "0.42.2",
     "mizchi/x": "0.2.0",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },
   "repository": "https://github.com/mizchi/bit-vcs",

--- a/modules/bitx_kv/moon.mod.json
+++ b/modules/bitx_kv/moon.mod.json
@@ -10,7 +10,7 @@
     "mizchi/bit_types": "0.42.2",
     "mizchi/bit_vfs": "0.42.2",
     "mizchi/bit_osfs": "0.42.2",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40",
     "mizchi/x": "0.2.0"
   },

--- a/modules/bitx_rebase_ai/moon.mod.json
+++ b/modules/bitx_rebase_ai/moon.mod.json
@@ -10,7 +10,7 @@
     "mizchi/bit_osfs": "0.42.2",
     "mizchi/bit_utils": "0.42.2",
     "mizchi/llm": "0.2.2",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },
   "repository": "https://github.com/mizchi/bit-vcs",

--- a/modules/bitx_workspace/moon.mod.json
+++ b/modules/bitx_workspace/moon.mod.json
@@ -10,7 +10,7 @@
     "mizchi/bit_osfs": "0.42.2",
     "mizchi/bit_utils": "0.42.2",
     "mizchi/bitflow": "0.4.0",
-    "moonbitlang/async": "0.16.6",
+    "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },
   "repository": "https://github.com/mizchi/bit-vcs",


### PR DESCRIPTION
## 背景 (#83)

issue #83 (Git Compat Randomized failed) の最新の nightly 実行（6/21〜6/22）が、直近3回とも **`exit=255` を 4〜9秒**で全シャード失敗していた。通常は 250〜490 秒かかるため、これはテスト失敗ではなく **ビルド自体の失敗** を示している。

## 原因

- 2026-06-08 リリースの MoonBit ツールチェーン (`0.1.20260608`) が、非推奨だった `fn new()`（struct コンストラクタ構文）を **ハードエラー `[3002]`** に変更した。
- 固定依存の `moonbitlang/async@0.16.6` が `aqueue` / `cond_var` / `semaphore` / `gzip_internal` でこの旧構文を使っており、ビルドが通らなくなった。
- CI は `curl … | bash` で **常に最新ツールチェーン** を入れるため、nightly の Git Compat Randomized はビルド段階で即死していた（nix ビルドはオーバーレイでツールチェーンを固定しているため影響なし）。

## 修正

- `moonbitlang/async` を **0.16.6 → 0.19.4** に bump（依存している 13 モジュールすべて）。
  - `0.16.8` ではまだ `[3002]` で失敗、`0.19.4` でクリーンビルドを確認。
- `moonbitlang/x` は `0.4.40` のまま（新コンパイラで問題なくビルドできるため据え置き）。

## 検証

- `moon build`（default / native 両ターゲット）: **エラー 0 でビルド成功**
- native バイナリで `init` / `add` / `commit` / `log` のスモークテスト: **正常動作**
- 既存の async 利用箇所（247 箇所 / 77 ファイル）はソース変更なしでコンパイル通過
- 差分は 13 ファイル・各 1 行のバージョン変更のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_