### PR TITLE
fix(refs): describe match/exclude+peel, pseudoref update-ref/symbolic-ref, symbolic-ref delete/--short/recurse (#86)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # cmd/bit's whitebox tests are split into 6 file-based shards: a single
+        # `moon test <files>` only compiles a test driver for the selected files
+        # and runs their tests, so each shard's compile and run is ~1/6 of the
+        # whole. This keeps every job well under the timeout (the unsharded run
+        # exceeded 150 min even with gcc). cmd/git-bit is small, run whole.
         include:
-          - { name: cmd-bit,     pkg: mizchi/bit/cmd/bit,     timeout: 150, mode: "" }
-          - { name: cmd-git-bit, pkg: mizchi/bit/cmd/git-bit, timeout: 30,  mode: "" }
+          - { name: cmd-git-bit, kind: pkg,   sel: mizchi/bit/cmd/git-bit, timeout: 30 }
+          - { name: cmd-bit-0,   kind: shard, sel: "0",                     timeout: 60 }
+          - { name: cmd-bit-1,   kind: shard, sel: "1",                     timeout: 60 }
+          - { name: cmd-bit-2,   kind: shard, sel: "2",                     timeout: 60 }
+          - { name: cmd-bit-3,   kind: shard, sel: "3",                     timeout: 60 }
+          - { name: cmd-bit-4,   kind: shard, sel: "4",                     timeout: 60 }
+          - { name: cmd-bit-5,   kind: shard, sel: "5",                     timeout: 60 }
     name: cmd-native-test (${{ matrix.name }})
     steps:
       - name: Checkout
@@ -122,9 +132,19 @@ jobs:
           pkill -f "clang" || true
           sleep 1
           rm -f _build/.moon-lock
-      - name: Run ${{ matrix.pkg }} native tests
+      - name: Run ${{ matrix.name }} native tests
         timeout-minutes: ${{ matrix.timeout }}
-        run: moon test --target native ${{ matrix.mode }} -p ${{ matrix.pkg }}
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.kind }}" = "pkg" ]; then
+            moon test --target native -p ${{ matrix.sel }}
+          else
+            files=$(ls modules/bit/src/cmd/bit/*.mbt | sort | awk "(NR-1) % 6 == ${{ matrix.sel }}")
+            echo "cmd-bit shard ${{ matrix.sel }}/6 — files:"
+            echo "$files"
+            # shellcheck disable=SC2086
+            moon test --target native $files
+          fi
 
   distributed-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,18 @@ jobs:
 
   cmd-native-test:
     runs-on: ubuntu-latest
+    # The bundled `tcc` backend hangs compiling cmd/bit's large test binary, so
+    # override the native C compiler with gcc (MOON_CC). gcc at -O0 (the debug
+    # default) compiles it quickly and never hangs, unlike tcc; using gcc -O
+    # (--release) also works but is far slower.
+    env:
+      MOON_CC: gcc
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: cmd-bit,     pkg: mizchi/bit/cmd/bit,     timeout: 120 }
-          - { name: cmd-git-bit, pkg: mizchi/bit/cmd/git-bit, timeout: 30  }
+          - { name: cmd-bit,     pkg: mizchi/bit/cmd/bit,     timeout: 150, mode: "" }
+          - { name: cmd-git-bit, pkg: mizchi/bit/cmd/git-bit, timeout: 30,  mode: "" }
     name: cmd-native-test (${{ matrix.name }})
     steps:
       - name: Checkout
@@ -98,7 +104,7 @@ jobs:
         run: |
           set -euo pipefail
           moon --version
-          moon build --target native --release modules/bit/src/cmd/bit
+          moon build --target native modules/bit/src/cmd/bit
           bin_path=$(find _build/native -maxdepth 8 -type f -name 'bit.exe' | head -1)
           if [ -z "$bin_path" ]; then
             echo "bit.exe not found after moon build"
@@ -118,7 +124,7 @@ jobs:
           rm -f _build/.moon-lock
       - name: Run ${{ matrix.pkg }} native tests
         timeout-minutes: ${{ matrix.timeout }}
-        run: moon test --target native -p ${{ matrix.pkg }}
+        run: moon test --target native ${{ matrix.mode }} -p ${{ matrix.pkg }}
 
   distributed-test:
     runs-on: ubuntu-latest

--- a/modules/bit/src/cmd/bit/cat_file.mbt
+++ b/modules/bit/src/cmd/bit/cat_file.mbt
@@ -1727,7 +1727,64 @@ fn cat_file_rev_parse_with_compat(
   if reflog_zero is Some(_) {
     return reflog_zero
   }
+  // Resolve reflog date selectors such as `main@{2005-05-26 23:30}` so that
+  // `cat-file <rev>:<path>` accepts them (git resolves the rev part the same
+  // way `rev-parse` does).
+  let reflog_date = cat_file_rev_parse_reflog_date(fs, git_dir, spec)
+  if reflog_date is Some(_) {
+    return reflog_date
+  }
   cat_file_rev_parse_commit_message_search_with_compat(fs, git_dir, spec)
+}
+
+///|
+/// Resolve a reflog date selector (`<ref>@{<date>}`) to an object id without
+/// emitting the diagnostic warnings that the interactive `rev-parse` path does
+/// (cat-file only needs the resolved value).
+fn cat_file_rev_parse_reflog_date(
+  fs : OsFs,
+  git_dir : String,
+  spec : String,
+) -> @bitcore.ObjectId? raise Error {
+  guard @bitlib.parse_reflog_date_selector(spec) is Some((raw_ref, date_str)) else {
+    return None
+  }
+  let mut refname = raw_ref
+  if refname.length() == 0 {
+    match @bitlib.read_head_ref(fs, git_dir) {
+      @bitlib.HeadRef::Branch(name) => refname = "refs/heads/" + name
+      @bitlib.HeadRef::Detached(_) => refname = "HEAD"
+    }
+  }
+  guard parse_reflog_date(date_str) is Some(at_time) else { return None }
+  let entries = @bitrepo.read_reflog(fs, git_dir, refname)
+  let len = entries.length()
+  if len == 0 {
+    return None
+  }
+  let mut prev_ooid : @bitcore.ObjectId? = None
+  for i = len - 1; i >= 0; i = i - 1 {
+    let entry = entries[i]
+    if entry.timestamp <= at_time {
+      match prev_ooid {
+        Some(_) => return Some(entry.new_id)
+        None =>
+          if entry.timestamp == at_time {
+            return Some(entry.new_id)
+          } else {
+            return @bitrepo.rev_parse(fs, git_dir, refname)
+          }
+      }
+    }
+    prev_ooid = Some(entry.old_id)
+  }
+  // Requested time precedes the whole log: report the oldest known state.
+  let oldest = entries[0]
+  if oldest.old_id == @bitcore.ObjectId::zero() {
+    Some(oldest.new_id)
+  } else {
+    Some(oldest.old_id)
+  }
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/checkout_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/checkout_wbtest.mbt
@@ -17,7 +17,7 @@ async fn checkout_wbtest_collect_shim_git_output(
   let fs = OsFs::new()
   // Build the native binary first so exit codes propagate correctly
   // (moon run swallows non-zero exit codes)
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
     let build_code = @process.run(
       "moon",

--- a/modules/bit/src/cmd/bit/checkout_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/checkout_wbtest.mbt
@@ -19,12 +19,9 @@ async fn checkout_wbtest_collect_shim_git_output(
   // (moon run swallows non-zero exit codes)
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
-    let build_code = @process.run(
-      "moon",
-      ["build", "--target", "native", "--release"],
-      inherit_env=true,
+    fail(
+      "bit.exe not found at \{bit_exe}; build it with `moon build --target native modules/bit/src/cmd/bit` first",
     )
-    @test.assert_eq(build_code, 0)
   }
   fs.write_string(shim_moon, "#!/bin/sh\nset -eu\nexec '\{bit_exe}' \"$@\"\n")
   let chmod_code = @process.run("chmod", ["+x", shim_moon], inherit_env=true)

--- a/modules/bit/src/cmd/bit/checkout_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/checkout_wbtest.mbt
@@ -11,7 +11,7 @@ async fn checkout_wbtest_collect_shim_git_output(
 ) -> (Int, String, String) raise Error {
   checkout_wbtest_shim_lock.acquire()
   defer checkout_wbtest_shim_lock.release()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let shim_moon = "/tmp/bit-checkout-shim-moon.sh"
   let fs = OsFs::new()

--- a/modules/bit/src/cmd/bit/commit.mbt
+++ b/modules/bit/src/cmd/bit/commit.mbt
@@ -1122,6 +1122,10 @@ async fn commit_with_merge_heads(
     head_parent,
     if head_parent is None {
       "commit (initial): " + commit_subject_line(message)
+    } else if merge_heads.length() > 0 {
+      // A commit recording MERGE_HEAD parents is a merge; git tags its reflog
+      // entry with the "(merge)" qualifier.
+      "commit (merge): " + commit_subject_line(message)
     } else {
       "commit: " + commit_subject_line(message)
     },

--- a/modules/bit/src/cmd/bit/describe.mbt
+++ b/modules/bit/src/cmd/bit/describe.mbt
@@ -11,29 +11,61 @@ async fn handle_describe(args : Array[String]) -> Unit raise Error {
   let mut abbrev = 7 // --abbrev=N: abbreviation length
   let mut commit_ref = "HEAD"
   let mut dirty_mark = ""
-  for arg in args {
-    match arg {
-      "--tags" => use_tags = true
-      "--always" => always = true
-      "--long" => long_format = true
-      "--dirty" => dirty_mark = "-dirty"
-      _ if arg.has_prefix("--abbrev=") =>
-        abbrev = parse_int(
-          String::unsafe_substring(arg, start=9, end=arg.length()),
-        )
-      _ if arg.has_prefix("--dirty=") =>
-        dirty_mark = String::unsafe_substring(arg, start=8, end=arg.length())
-      _ if !arg.has_prefix("-") => commit_ref = arg
-      _ => ()
+  // --match/--exclude: glob patterns restricting which tags are considered.
+  // Both the two-arg (`--match <pat>`) and `--match=<pat>` forms are accepted,
+  // and each may be given multiple times (matching git).
+  let match_patterns : Array[String] = []
+  let exclude_patterns : Array[String] = []
+  let mut i = 0
+  while i < args.length() {
+    let arg = args[i]
+    if arg == "--tags" {
+      use_tags = true
+    } else if arg == "--always" {
+      always = true
+    } else if arg == "--long" {
+      long_format = true
+    } else if arg == "--dirty" {
+      dirty_mark = "-dirty"
+    } else if arg.has_prefix("--abbrev=") {
+      abbrev = parse_int(String::unsafe_substring(arg, start=9, end=arg.length()))
+    } else if arg.has_prefix("--dirty=") {
+      dirty_mark = String::unsafe_substring(arg, start=8, end=arg.length())
+    } else if arg == "--match" {
+      i = i + 1
+      if i < args.length() {
+        match_patterns.push(args[i])
+      }
+    } else if arg.has_prefix("--match=") {
+      match_patterns.push(String::unsafe_substring(arg, start=8, end=arg.length()))
+    } else if arg == "--exclude" {
+      i = i + 1
+      if i < args.length() {
+        exclude_patterns.push(args[i])
+      }
+    } else if arg.has_prefix("--exclude=") {
+      exclude_patterns.push(
+        String::unsafe_substring(arg, start=10, end=arg.length()),
+      )
+    } else if !arg.has_prefix("-") {
+      commit_ref = arg
     }
+    i = i + 1
   }
   // Resolve target commit
   let target_id = @bitrepo.rev_parse(rfs, git_dir, commit_ref)
-  guard target_id is Some(tid) else {
+  guard target_id is Some(tid0) else {
     raise @bitcore.GitError::InvalidObject("unknown revision: \{commit_ref}")
   }
-  // Get all tags
-  let tags = get_all_tags(rfs, git_dir, use_tags)
+  // Peel annotated tag objects down to the commit they point at, matching
+  // `git describe` (e.g. `git describe <tag-object-sha>` describes the commit).
+  let tid = describe_peel_to_commit(rfs, git_dir, tid0)
+  // Get all tags, then apply --match/--exclude filtering on the tag name.
+  let tags = filter_tags(
+    get_all_tags(rfs, git_dir, use_tags),
+    match_patterns,
+    exclude_patterns,
+  )
   if tags.length() == 0 && !always {
     @stdio.stderr.write("fatal: No names found, cannot describe anything.")
     @sys.exit(128)
@@ -117,6 +149,67 @@ fn get_all_tags(
 ///|
 fn parse_tag_object(data : String) -> @bitcore.ObjectId? raise Error {
   @bitlib.parse_tag_object(data)
+}
+
+///|
+/// Follow a chain of annotated tag objects to the commit they ultimately point
+/// at. Non-tag objects (and unresolvable ids) are returned unchanged.
+fn describe_peel_to_commit(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  id : @bitcore.ObjectId,
+) -> @bitcore.ObjectId raise Error {
+  let db = @bitlib.ObjectDb::load(rfs, git_dir)
+  let mut cur = id
+  for _depth in 0..<10 {
+    match db.get(rfs, cur) {
+      Some(o) =>
+        if o.obj_type == @bitcore.ObjectType::Tag {
+          match parse_tag_object(decode_bytes(o.data)) {
+            Some(t) => cur = t
+            None => break
+          }
+        } else {
+          break
+        }
+      None => break
+    }
+  }
+  cur
+}
+
+///|
+/// Whether `name` matches any of the glob `patterns`.
+fn matches_any(patterns : Array[String], name : String) -> Bool {
+  for pat in patterns {
+    if @ignore.match_glob(pat, name) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Restrict candidate tags by `--match`/`--exclude` glob patterns (matched
+/// against the tag name). A tag is kept when it matches at least one match
+/// pattern (or none were given) and matches no exclude pattern.
+fn filter_tags(
+  tags : Map[String, @bitcore.ObjectId],
+  match_patterns : Array[String],
+  exclude_patterns : Array[String],
+) -> Map[String, @bitcore.ObjectId] {
+  if match_patterns.length() == 0 && exclude_patterns.length() == 0 {
+    return tags
+  }
+  let filtered : Map[String, @bitcore.ObjectId] = {}
+  for name, cid in tags {
+    let included = match_patterns.length() == 0 ||
+      matches_any(match_patterns, name)
+    if included && !matches_any(exclude_patterns, name) {
+      filtered[name] = cid
+    }
+  }
+  filtered
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/handlers_remote_pull_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/handlers_remote_pull_wbtest.mbt
@@ -263,12 +263,9 @@ async fn handlers_remote_pull_wbtest_collect_shim_git(
   // (moon run swallows non-zero exit codes)
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
-    let build_code = @process.run(
-      "moon",
-      ["build", "--target", "native", "--release"],
-      inherit_env=true,
+    fail(
+      "bit.exe not found at \{bit_exe}; build it with `moon build --target native modules/bit/src/cmd/bit` first",
     )
-    @test.assert_eq(build_code, 0)
   }
   fs.write_string(shim_moon, "#!/bin/sh\nset -eu\nexec '\{bit_exe}' \"$@\"\n")
   let chmod_code = @process.run("chmod", ["+x", shim_moon], inherit_env=true)

--- a/modules/bit/src/cmd/bit/handlers_remote_pull_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/handlers_remote_pull_wbtest.mbt
@@ -261,7 +261,7 @@ async fn handlers_remote_pull_wbtest_collect_shim_git(
   let fs = OsFs::new()
   // Build the native binary first so exit codes propagate correctly
   // (moon run swallows non-zero exit codes)
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
     let build_code = @process.run(
       "moon",

--- a/modules/bit/src/cmd/bit/helpers_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/helpers_wbtest.mbt
@@ -166,6 +166,12 @@ test "helpers: parse_git_env_timestamp supports timezone suffix" {
 }
 
 ///|
+test "helpers: parse_git_env_timestamp parses human ISO date" {
+  @test.assert_eq(parse_iso_date_timestamp("2005-05-26 23:30"), Some(1117150200L))
+  @test.assert_eq(parse_git_env_timestamp("2005-05-26 23:30"), Some(1117150200L))
+}
+
+///|
 test "helpers: parse_git_env_timezone extracts timezone token" {
   @test.assert_eq(parse_git_env_timezone("1234567890 -0700"), Some("-0700"))
   @test.assert_eq(parse_git_env_timezone("@1234567890 +0900"), Some("+0900"))

--- a/modules/bit/src/cmd/bit/merge_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/merge_wbtest.mbt
@@ -108,12 +108,9 @@ async fn merge_wbtest_collect_shim_git(
   // (moon run swallows non-zero exit codes)
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
-    let build_code = @process.run(
-      "moon",
-      ["build", "--target", "native", "--release"],
-      inherit_env=true,
+    fail(
+      "bit.exe not found at \{bit_exe}; build it with `moon build --target native modules/bit/src/cmd/bit` first",
     )
-    assert_eq(build_code, 0)
   }
   fs.write_string(shim_moon, "#!/bin/sh\nset -eu\nexec '\{bit_exe}' \"$@\"\n")
   let chmod_code = @process.run("chmod", ["+x", shim_moon], inherit_env=true)

--- a/modules/bit/src/cmd/bit/merge_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/merge_wbtest.mbt
@@ -106,7 +106,7 @@ async fn merge_wbtest_collect_shim_git(
   let fs = OsFs::new()
   // Build the native binary first so exit codes propagate correctly
   // (moon run swallows non-zero exit codes)
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
     let build_code = @process.run(
       "moon",

--- a/modules/bit/src/cmd/bit/merge_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/merge_wbtest.mbt
@@ -100,7 +100,7 @@ async fn merge_wbtest_collect_shim_git(
 ) -> (Int, String, String) raise Error {
   merge_wbtest_shim_lock.acquire()
   defer merge_wbtest_shim_lock.release()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let shim_moon = "/tmp/bit-merge-shim-moon.sh"
   let fs = OsFs::new()

--- a/modules/bit/src/cmd/bit/reflog.mbt
+++ b/modules/bit/src/cmd/bit/reflog.mbt
@@ -217,10 +217,12 @@ fn parse_reflog_expire_args(args : Array[String]) -> ReflogExpireArgs {
 ///|
 async fn handle_reflog(args : Array[String]) -> Unit raise Error {
   let root = get_work_root()
-  let git_dir = root + "/.git"
   let fs = OsFs::new()
   let rfs : &@bitcore.RepoFileSystem = fs
   let wfs : &@bitcore.FileSystem = fs
+  // Resolve the real git dir so bare repositories (where the git dir is the
+  // work root, with no .git subdirectory) are handled correctly.
+  let git_dir = resolve_git_dir(rfs, root)
   let empty_grep_patterns : Array[String] = []
   if args.length() == 0 {
     // Default to show HEAD

--- a/modules/bit/src/cmd/bit/repack.mbt
+++ b/modules/bit/src/cmd/bit/repack.mbt
@@ -333,9 +333,14 @@ fn repack_find_bit_exe(git_dir : String) -> String {
     Some(path) if path.length() > 0 => return path
     _ => ()
   }
-  // Try relative to git_dir (standard build location)
+  // Try relative to git_dir (standard build location), debug or release.
   let fs = OsFs::new()
-  let build_path = git_dir + "/../_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let base = git_dir + "/../_build/native"
+  let debug_path = base + "/debug/build/mizchi/bit/cmd/bit/bit.exe"
+  if fs.is_file(debug_path) {
+    return debug_path
+  }
+  let build_path = base + "/release/build/mizchi/bit/cmd/bit/bit.exe"
   if fs.is_file(build_path) {
     return build_path
   }

--- a/modules/bit/src/cmd/bit/rev_list_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/rev_list_wbtest.mbt
@@ -75,7 +75,7 @@ async fn rev_list_test_bit_stdout(
   root : String,
   args : Array[String],
 ) -> String raise Error {
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   let bit_args : Array[String] = ["-C", root]
   for arg in args {
@@ -111,7 +111,7 @@ async fn rev_list_test_run_shim_git(
   cwd : String,
   args : Array[String],
 ) -> Unit raise Error {
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let env : Map[String, String] = {
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),
@@ -141,7 +141,7 @@ async fn rev_list_test_shim_git_stdout(
   cwd : String,
   args : Array[String],
 ) -> String raise Error {
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let env : Map[String, String] = {
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),

--- a/modules/bit/src/cmd/bit/rev_list_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/rev_list_wbtest.mbt
@@ -76,7 +76,7 @@ async fn rev_list_test_bit_stdout(
   args : Array[String],
 ) -> String raise Error {
   let repo_root = @env.current_dir().unwrap_or(".")
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   let bit_args : Array[String] = ["-C", root]
   for arg in args {
     bit_args.push(arg)
@@ -117,7 +117,7 @@ async fn rev_list_test_run_shim_git(
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),
     "SHIM_REAL_GIT_FALLBACK": "",
     "SHIM_EXEC_PATH": repo_root + "/third_party/git",
-    "SHIM_MOON": repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe",
+    "SHIM_MOON": wbtest_resolve_bit_exe(repo_root),
     "SHIM_CMDS": "init status add commit log show branch checkout switch reset rebase stash cherry-pick diff diff-files diff-index merge tag rm mv config sparse-checkout restore rev-parse cat-file ls-files hash-object ls-tree write-tree show-ref update-ref update-index symbolic-ref reflog worktree gc clean grep submodule revert notes bisect describe blame format-patch shortlog remote clone fetch pull push receive-pack upload-pack pack-objects index-pack shell",
     "SHIM_STRICT": "1",
   }
@@ -147,7 +147,7 @@ async fn rev_list_test_shim_git_stdout(
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),
     "SHIM_REAL_GIT_FALLBACK": "",
     "SHIM_EXEC_PATH": repo_root + "/third_party/git",
-    "SHIM_MOON": repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe",
+    "SHIM_MOON": wbtest_resolve_bit_exe(repo_root),
     "SHIM_CMDS": "init status add commit log show branch checkout switch reset rebase stash cherry-pick diff diff-files diff-index merge tag rm mv config sparse-checkout restore rev-parse cat-file ls-files hash-object ls-tree write-tree show-ref update-ref update-index symbolic-ref reflog worktree gc clean grep submodule revert notes bisect describe blame format-patch shortlog remote clone fetch pull push receive-pack upload-pack pack-objects index-pack shell",
     "SHIM_STRICT": "1",
   }

--- a/modules/bit/src/cmd/bit/show_branches.mbt
+++ b/modules/bit/src/cmd/bit/show_branches.mbt
@@ -51,7 +51,7 @@ async fn handle_show_branches(args : Array[String]) -> Unit raise Error {
   let branch_chars = "!*+-o=#@%&"
   for idx, branch in branches_to_show {
     let marker = if idx < branch_chars.length() {
-      branch_chars[idx].to_string()
+      Int::unsafe_to_char(branch_chars[idx].to_int()).to_string()
     } else {
       "!"
     }
@@ -78,7 +78,7 @@ async fn handle_show_branches(args : Array[String]) -> Unit raise Error {
       for i = 0; i < branches_to_show.length(); i = i + 1 {
         if i == branch_idx {
           let ch = if i < branch_chars.length() {
-            branch_chars[i].to_string()
+            Int::unsafe_to_char(branch_chars[i].to_int()).to_string()
           } else {
             "+"
           }
@@ -94,7 +94,7 @@ async fn handle_show_branches(args : Array[String]) -> Unit raise Error {
           )
           if reachable {
             let ch = if i < branch_chars.length() {
-              branch_chars[i].to_string()
+              Int::unsafe_to_char(branch_chars[i].to_int()).to_string()
             } else {
               "+"
             }

--- a/modules/bit/src/cmd/bit/show_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/show_wbtest.mbt
@@ -39,7 +39,7 @@ async fn show_wbtest_collect_shim_git_stderr(
   cwd : String,
   args : Array[String],
 ) -> (Int, String) raise Error {
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let env : Map[String, String] = {
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),

--- a/modules/bit/src/cmd/bit/show_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/show_wbtest.mbt
@@ -45,7 +45,7 @@ async fn show_wbtest_collect_shim_git_stderr(
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),
     "SHIM_REAL_GIT_FALLBACK": "",
     "SHIM_EXEC_PATH": repo_root + "/third_party/git",
-    "SHIM_MOON": repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe",
+    "SHIM_MOON": wbtest_resolve_bit_exe(repo_root),
     "SHIM_CMDS": "show",
     "SHIM_STRICT": "1",
   }

--- a/modules/bit/src/cmd/bit/sparse_checkout_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/sparse_checkout_wbtest.mbt
@@ -116,7 +116,7 @@ async fn sparse_checkout_wbtest_collect_shim_git_output(
 ) -> (Int, String, String) raise Error {
   sparse_checkout_wbtest_shim_lock.acquire()
   defer sparse_checkout_wbtest_shim_lock.release()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let shim_moon = sparse_checkout_wbtest_shim_moon_path(repo_root)
   let env : Map[String, String] = {
@@ -174,7 +174,7 @@ async fn sparse_checkout_wbtest_collect_shim_git_shell_output(
 ) -> (Int, String, String) raise Error {
   sparse_checkout_wbtest_shim_lock.acquire()
   defer sparse_checkout_wbtest_shim_lock.release()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let shim_moon = sparse_checkout_wbtest_shim_moon_path(repo_root)
   let env : Map[String, String] = {
@@ -1092,7 +1092,7 @@ test "sparse-checkout: check-rules helper preserves quoted and nul-delimited mat
 async test "sparse-checkout: check-rules defaults to cone mode for rules files" {
   @bitnative.init_native_io()
   let fs = OsFs::new()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_moon = sparse_checkout_wbtest_shim_moon_path(repo_root)
   let root = "/tmp/bit-test-sparse-check-rules-" +
     get_current_timestamp().to_string()

--- a/modules/bit/src/cmd/bit/sparse_checkout_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/sparse_checkout_wbtest.mbt
@@ -60,7 +60,7 @@ async fn sparse_checkout_wbtest_shim_moon_path(
   let wrapper_path = "/tmp/bit-sparse-shim-moon.sh"
   // Build the native binary first so exit codes propagate correctly
   // (moon run swallows non-zero exit codes)
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
     let build_code = @process.run(
       "moon",

--- a/modules/bit/src/cmd/bit/sparse_checkout_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/sparse_checkout_wbtest.mbt
@@ -62,12 +62,9 @@ async fn sparse_checkout_wbtest_shim_moon_path(
   // (moon run swallows non-zero exit codes)
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
-    let build_code = @process.run(
-      "moon",
-      ["build", "--target", "native", "--release"],
-      inherit_env=true,
+    fail(
+      "bit.exe not found at \{bit_exe}; build it with `moon build --target native modules/bit/src/cmd/bit` first",
     )
-    @test.assert_eq(build_code, 0)
   }
   fs.write_string(
     wrapper_path,

--- a/modules/bit/src/cmd/bit/submodule_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/submodule_wbtest.mbt
@@ -68,7 +68,7 @@ async fn submodule_wbtest_collect_shim_git_stderr(
   cwd : String,
   args : Array[String],
 ) -> (Int, String) raise Error {
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let env : Map[String, String] = {
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),

--- a/modules/bit/src/cmd/bit/submodule_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/submodule_wbtest.mbt
@@ -73,7 +73,7 @@ async fn submodule_wbtest_collect_shim_git_stderr(
   let env : Map[String, String] = {
     "SHIM_REAL_GIT": wbtest_resolve_real_git(repo_root),
     "SHIM_EXEC_PATH": repo_root + "/third_party/git",
-    "SHIM_MOON": repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe",
+    "SHIM_MOON": wbtest_resolve_bit_exe(repo_root),
     "SHIM_CMDS": "submodule submodule--helper",
     "SHIM_STRICT": "1",
   }

--- a/modules/bit/src/cmd/bit/switch_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/switch_wbtest.mbt
@@ -19,12 +19,9 @@ async fn switch_wbtest_run_shim_git(
   // (moon run swallows non-zero exit codes)
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
-    let build_code = @process.run(
-      "moon",
-      ["build", "--target", "native", "--release"],
-      inherit_env=true,
+    fail(
+      "bit.exe not found at \{bit_exe}; build it with `moon build --target native modules/bit/src/cmd/bit` first",
     )
-    @test.assert_eq(build_code, 0)
   }
   fs.write_string(shim_moon, "#!/bin/sh\nset -eu\nexec '\{bit_exe}' \"$@\"\n")
   let chmod_code = @process.run("chmod", ["+x", shim_moon], inherit_env=true)

--- a/modules/bit/src/cmd/bit/switch_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/switch_wbtest.mbt
@@ -17,7 +17,7 @@ async fn switch_wbtest_run_shim_git(
   let fs = OsFs::new()
   // Build the native binary first so exit codes propagate correctly
   // (moon run swallows non-zero exit codes)
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
     let build_code = @process.run(
       "moon",

--- a/modules/bit/src/cmd/bit/switch_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/switch_wbtest.mbt
@@ -11,7 +11,7 @@ async fn switch_wbtest_run_shim_git(
 ) -> Unit raise Error {
   switch_wbtest_shim_lock.acquire()
   defer switch_wbtest_shim_lock.release()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let shim_moon = "/tmp/bit-switch-shim-moon.sh"
   let fs = OsFs::new()

--- a/modules/bit/src/cmd/bit/symbolic_ref.mbt
+++ b/modules/bit/src/cmd/bit/symbolic_ref.mbt
@@ -5,17 +5,25 @@ async fn handle_symbolic_ref(args : Array[String]) -> Unit raise Error {
   let mut delete_mode = false
   let mut short_mode = false
   let mut recurse = true
+  let mut message : String? = None
   let positional : Array[String] = []
-  for arg in args {
+  let mut ai = 0
+  while ai < args.length() {
+    let arg = args[ai]
     match arg {
       "-d" | "--delete" => delete_mode = true
       "--short" => short_mode = true
       "--recurse" => recurse = true
       "--no-recurse" => recurse = false
+      "-m" if ai + 1 < args.length() => {
+        message = Some(args[ai + 1])
+        ai = ai + 1
+      }
       _ if !arg.has_prefix("-") => positional.push(arg)
       _ if arg.has_prefix("-") => warn_unimplemented_arg("symbolic-ref", arg)
       _ => ()
     }
+    ai = ai + 1
   }
   if positional.length() == 0 {
     raise @bitcore.GitError::InvalidObject(
@@ -96,7 +104,31 @@ async fn handle_symbolic_ref(args : Array[String]) -> Unit raise Error {
   } else {
     // Write mode
     let target = symbolic_ref_normalize_refname(positional[1])
+    let git_dir = resolve_git_dir(fs, root)
+    // Capture the pre-update resolved value for the reflog (zero if unborn).
+    let old_id = match @bitrepo.rev_parse(fs, git_dir, name) {
+      Some(id) => id
+      None => @bitcore.ObjectId::zero()
+    }
     fs.write_string(ref_path, "ref: \{target}\n")
+    // git records a reflog entry for the updated ref when given a reason (-m).
+    match message {
+      Some(msg) => {
+        let rfs : &@bitcore.RepoFileSystem = fs
+        let wfs : &@bitcore.FileSystem = fs
+        let new_id = match @bitrepo.rev_parse(fs, git_dir, target) {
+          Some(id) => id
+          None => @bitcore.ObjectId::zero()
+        }
+        let timestamp = get_current_timestamp()
+        let (author, email) = get_author_info(fs, git_dir)
+        @bitrepo.append_reflog(
+          wfs, rfs, git_dir, name, old_id, new_id, author, email, timestamp,
+          "+0000", msg,
+        )
+      }
+      None => ()
+    }
   }
 }
 

--- a/modules/bit/src/cmd/bit/symbolic_ref.mbt
+++ b/modules/bit/src/cmd/bit/symbolic_ref.mbt
@@ -4,11 +4,14 @@ async fn handle_symbolic_ref(args : Array[String]) -> Unit raise Error {
   let fs = OsFs::new()
   let mut delete_mode = false
   let mut short_mode = false
+  let mut recurse = true
   let positional : Array[String] = []
   for arg in args {
     match arg {
       "-d" | "--delete" => delete_mode = true
       "--short" => short_mode = true
+      "--recurse" => recurse = true
+      "--no-recurse" => recurse = false
       _ if !arg.has_prefix("-") => positional.push(arg)
       _ if arg.has_prefix("-") => warn_unimplemented_arg("symbolic-ref", arg)
       _ => ()
@@ -22,9 +25,26 @@ async fn handle_symbolic_ref(args : Array[String]) -> Unit raise Error {
   let name = symbolic_ref_normalize_refname(positional[0])
   let ref_path = symbolic_ref_resolve_ref_path(fs, root, name)
   if delete_mode {
-    if fs.is_file(ref_path) {
-      fs.remove_file(ref_path)
+    // git refuses to delete HEAD outright.
+    if name == "HEAD" {
+      eprint_line("fatal: deleting 'HEAD' is not allowed")
+      @sys.exit(128)
     }
+    // Only symbolic refs may be deleted via symbolic-ref -d. A missing ref or
+    // a regular (non-symbolic) ref is refused, and left untouched.
+    let is_symbolic = if fs.is_file(ref_path) {
+      decode_bytes(fs.read_file(ref_path))
+      .trim_end(chars="\n\r ")
+      .to_owned()
+      .has_prefix("ref: ")
+    } else {
+      false
+    }
+    if !is_symbolic {
+      eprint_line("fatal: Cannot delete \{name}, not a symbolic ref")
+      @sys.exit(128)
+    }
+    fs.remove_file(ref_path)
     return ()
   }
   if positional.length() == 1 {
@@ -35,15 +55,36 @@ async fn handle_symbolic_ref(args : Array[String]) -> Unit raise Error {
     let content = decode_bytes(fs.read_file(ref_path))
     let trimmed = content.trim_end(chars="\n\r ").to_owned()
     if trimmed.has_prefix("ref: ") {
-      let target = String::unsafe_substring(
+      let mut target = String::unsafe_substring(
         trimmed,
         start=5,
         end=trimmed.length(),
       )
-      if short_mode && target.has_prefix("refs/heads/") {
-        print_line(
-          String::unsafe_substring(target, start=11, end=target.length()),
-        )
+      // By default git follows the symref chain to the final target; the last
+      // ref in the chain that is itself a symref determines the output.
+      // --no-recurse stops after the first level.
+      if recurse {
+        for _depth in 0..<10 {
+          let tpath = symbolic_ref_resolve_ref_path(fs, root, target)
+          if !fs.is_file(tpath) {
+            break
+          }
+          let tcontent = decode_bytes(fs.read_file(tpath))
+            .trim_end(chars="\n\r ")
+            .to_owned()
+          if tcontent.has_prefix("ref: ") {
+            target = String::unsafe_substring(
+              tcontent,
+              start=5,
+              end=tcontent.length(),
+            )
+          } else {
+            break
+          }
+        }
+      }
+      if short_mode {
+        print_line(symbolic_ref_shorten(target))
       } else {
         print_line(target)
       }
@@ -71,6 +112,34 @@ fn symbolic_ref_resolve_ref_path(
   } else {
     normalize_path(git_dir + "/" + name)
   }
+}
+
+///|
+/// Shorten a ref name for `symbolic-ref --short`, mirroring git's prefix rules
+/// (most specific / shortest result first):
+///   refs/remotes/<x>/HEAD -> <x>, refs/heads/<x> -> <x>, refs/tags/<x> -> <x>,
+///   refs/remotes/<x> -> <x>, refs/<x> -> <x>.
+fn symbolic_ref_shorten(target : String) -> String {
+  fn strip(prefix_len : Int) -> String {
+    String::unsafe_substring(target, start=prefix_len, end=target.length())
+  }
+
+  if target.has_prefix("refs/remotes/") && target.has_suffix("/HEAD") {
+    return String::unsafe_substring(target, start=13, end=target.length() - 5)
+  }
+  if target.has_prefix("refs/heads/") {
+    return strip(11)
+  }
+  if target.has_prefix("refs/tags/") {
+    return strip(10)
+  }
+  if target.has_prefix("refs/remotes/") {
+    return strip(13)
+  }
+  if target.has_prefix("refs/") {
+    return strip(5)
+  }
+  target
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/symbolic_ref.mbt
+++ b/modules/bit/src/cmd/bit/symbolic_ref.mbt
@@ -80,7 +80,11 @@ fn symbolic_ref_normalize_refname(
   let normalized = @bitlib.normalize_repo_path(name) catch {
     _ => raise @bitcore.GitError::InvalidObject("invalid refname: " + name)
   }
-  if normalized == "HEAD" || normalized.has_prefix("refs/") {
+  // Accept HEAD, refs/..., and one-component root refs such as DANGLING_HEAD
+  // (git allows symbolic-ref on these).
+  if normalized == "HEAD" ||
+    normalized.has_prefix("refs/") ||
+    for_each_ref_is_root_ref_syntax(normalized) {
     normalized
   } else {
     raise @bitcore.GitError::InvalidObject("invalid refname: " + name)

--- a/modules/bit/src/cmd/bit/update_index_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/update_index_wbtest.mbt
@@ -96,12 +96,9 @@ async fn update_index_wbtest_run_sparse_checkout_shim(
   // (moon run swallows non-zero exit codes)
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
-    let build_code = @process.run(
-      "moon",
-      ["build", "--target", "native", "--release"],
-      inherit_env=true,
+    fail(
+      "bit.exe not found at \{bit_exe}; build it with `moon build --target native modules/bit/src/cmd/bit` first",
     )
-    @test.assert_eq(build_code, 0)
   }
   fs.write_string(shim_moon, "#!/bin/sh\nset -eu\nexec '\{bit_exe}' \"$@\"\n")
   let chmod_code = @process.run("chmod", ["+x", shim_moon], inherit_env=true)

--- a/modules/bit/src/cmd/bit/update_index_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/update_index_wbtest.mbt
@@ -94,7 +94,7 @@ async fn update_index_wbtest_run_sparse_checkout_shim(
   let fs = OsFs::new()
   // Build the native binary first so exit codes propagate correctly
   // (moon run swallows non-zero exit codes)
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
     let build_code = @process.run(
       "moon",

--- a/modules/bit/src/cmd/bit/update_index_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/update_index_wbtest.mbt
@@ -88,7 +88,7 @@ async fn update_index_wbtest_run_sparse_checkout_shim(
 ) -> Unit raise Error {
   update_index_wbtest_shim_lock.acquire()
   defer update_index_wbtest_shim_lock.release()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let shim_moon = "/tmp/bit-update-index-sparse-shim-moon.sh"
   let fs = OsFs::new()

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -147,8 +147,8 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     // git applies a --stdin batch as one transaction: validate every command
     // (syntax, duplicate refs) before applying any, so a later error leaves the
     // repo untouched. Pass 1 validates and records actions; pass 2 applies.
-    // Each action is ("call", <handle_update_ref args>) or ("verify", [ref, old?]).
-    let actions : Array[(String, Array[String])] = []
+    // Pass 1: parse + syntax-check every command into a structured op list.
+    let ops : Array[UpdateRefStdinOp] = []
     for raw in lines {
       let line = if raw.has_suffix("\r") {
         String::unsafe_substring(raw, start=0, end=raw.length() - 1)
@@ -164,10 +164,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
         eprint_line("fatal: whitespace before command: " + line)
         @sys.exit(128)
       }
-      let fields : Array[String] = []
-      for fv in line.split(" ") {
-        fields.push(fv.to_owned())
-      }
+      let fields = update_ref_stdin_split_fields(line)
       // Unquote C-style quoted arguments, reporting git's exact errors on
       // malformed quoting (before any command is applied).
       for fi = 0; fi < fields.length(); fi = fi + 1 {
@@ -195,8 +192,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             eprint_line("fatal: create: missing <ref>")
             @sys.exit(128)
           }
-          let val_tok = if fields.length() >= 3 { fields[2] } else { "" }
-          if val_tok.length() == 0 {
+          if fields.length() < 3 {
             eprint_line("fatal: create \{ref_tok}: missing <new-oid>")
             @sys.exit(128)
           }
@@ -208,21 +204,21 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             @sys.exit(128)
           }
           update_ref_stdin_check_dup(seen_refs, ref_tok)
-          let cmd_args = update_ref_stdin_base_args(
-            stdin_no_deref, stdin_create_reflog, message,
-          )
-          cmd_args.push(ref_tok)
-          cmd_args.push(val_tok)
-          cmd_args.push(@bitcore.ObjectId::zero().to_hex())
-          actions.push(("call", cmd_args))
+          ops.push({
+            kind: "create",
+            refname: ref_tok,
+            new_tok: Some(fields[2]),
+            old_tok: None,
+            no_deref: stdin_no_deref,
+            create_reflog: stdin_create_reflog,
+          })
         }
         "update" => {
           if ref_tok.length() == 0 {
             eprint_line("fatal: update: missing <ref>")
             @sys.exit(128)
           }
-          let val_tok = if fields.length() >= 3 { fields[2] } else { "" }
-          if val_tok.length() == 0 {
+          if fields.length() < 3 {
             eprint_line("fatal: update \{ref_tok}: missing <new-oid>")
             @sys.exit(128)
           }
@@ -234,15 +230,14 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             @sys.exit(128)
           }
           update_ref_stdin_check_dup(seen_refs, ref_tok)
-          let cmd_args = update_ref_stdin_base_args(
-            stdin_no_deref, stdin_create_reflog, message,
-          )
-          cmd_args.push(ref_tok)
-          cmd_args.push(val_tok)
-          if fields.length() == 4 {
-            cmd_args.push(fields[3])
-          }
-          actions.push(("call", cmd_args))
+          ops.push({
+            kind: "update",
+            refname: ref_tok,
+            new_tok: Some(fields[2]),
+            old_tok: if fields.length() >= 4 { Some(fields[3]) } else { None },
+            no_deref: stdin_no_deref,
+            create_reflog: stdin_create_reflog,
+          })
         }
         "delete" => {
           if ref_tok.length() == 0 {
@@ -257,15 +252,14 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             @sys.exit(128)
           }
           update_ref_stdin_check_dup(seen_refs, ref_tok)
-          let cmd_args = update_ref_stdin_base_args(
-            stdin_no_deref, stdin_create_reflog, message,
-          )
-          cmd_args.push("-d")
-          cmd_args.push(ref_tok)
-          if fields.length() == 3 {
-            cmd_args.push(fields[2])
-          }
-          actions.push(("call", cmd_args))
+          ops.push({
+            kind: "delete",
+            refname: ref_tok,
+            new_tok: None,
+            old_tok: if fields.length() >= 3 { Some(fields[2]) } else { None },
+            no_deref: stdin_no_deref,
+            create_reflog: stdin_create_reflog,
+          })
         }
         "verify" => {
           if ref_tok.length() == 0 {
@@ -279,11 +273,14 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             )
             @sys.exit(128)
           }
-          let verify_args : Array[String] = [ref_tok]
-          if fields.length() >= 3 {
-            verify_args.push(fields[2])
-          }
-          actions.push(("verify", verify_args))
+          ops.push({
+            kind: "verify",
+            refname: ref_tok,
+            new_tok: None,
+            old_tok: if fields.length() >= 3 { Some(fields[2]) } else { None },
+            no_deref: stdin_no_deref,
+            create_reflog: stdin_create_reflog,
+          })
         }
         _ => {
           eprint_line("fatal: unknown command: " + line)
@@ -291,33 +288,74 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
         }
       }
     }
-    // Pass 2: apply the validated actions in order.
-    for action in actions {
-      if action.0 == "call" {
-        handle_update_ref(action.1)
-      } else {
-        let v_ref = action.1[0]
-        let refname = normalize_update_ref_name(v_ref)
-        let refname = resolve_update_target_ref(
-          fs, actual_git_dir, refname, stdin_no_deref,
-        )
-        let current_id = read_ref_value(fs, actual_git_dir, refname)
-        let ok = if action.1.length() < 2 {
-          current_id is Some(_)
-        } else {
-          let expected_id = @bitcore.ObjectId::from_hex(action.1[1]) catch {
-            _ => @bitcore.ObjectId::zero()
+    // Pass 2: validate the whole batch against the current repo state before
+    // touching anything, so a later failure leaves the repo untouched.
+    for op in ops {
+      update_ref_stdin_validate_op(fs, actual_git_dir, op)
+    }
+    // Pass 3: apply. Verify commands have no effect; the rest reuse the regular
+    // update-ref machinery (reflogs, symref deref) now that they are validated.
+    let zero_hex = @bitcore.ObjectId::zero().to_hex()
+    for op in ops {
+      if op.kind == "verify" {
+        continue
+      }
+      let cmd_args = update_ref_stdin_base_args(
+        op.no_deref, op.create_reflog, message,
+      )
+      // Resolve the old value to a concrete oid hex; the regular handler's
+      // old-value check expects a hex string, not a ref name or revision.
+      let old_hex = match op.old_tok {
+        Some(t) =>
+          if t.length() == 0 {
+            Some(zero_hex)
+          } else {
+            match update_ref_resolve_oid(fs, actual_git_dir, t) {
+              Some(oid) => Some(oid.to_hex())
+              None => Some(t)
+            }
           }
-          match current_id {
-            Some(cur_id) => cur_id.to_hex() == expected_id.to_hex()
-            None => expected_id.to_hex() == @bitcore.ObjectId::zero().to_hex()
+        None => None
+      }
+      // Resolve the new value; an `update` to the zero oid means "delete".
+      let new_hex = match op.new_tok {
+        Some(t) =>
+          if t.length() == 0 {
+            zero_hex
+          } else {
+            match update_ref_resolve_oid(fs, actual_git_dir, t) {
+              Some(oid) => oid.to_hex()
+              None => t
+            }
           }
+        None => zero_hex
+      }
+      let deletes = op.kind == "delete" ||
+        (op.kind == "update" && new_hex == zero_hex)
+      if deletes {
+        // Ensuring a ref is absent when it is already gone is a no-op.
+        if @bitrepo.rev_parse(fs, actual_git_dir, op.refname) is None {
+          continue
         }
-        if !ok {
-          eprint_line("fatal: update-ref: verify failed for " + v_ref)
-          @sys.exit(1)
+        cmd_args.push("-d")
+        cmd_args.push(op.refname)
+        match old_hex {
+          Some(h) => cmd_args.push(h)
+          None => ()
+        }
+      } else {
+        cmd_args.push(op.refname)
+        cmd_args.push(new_hex)
+        if op.kind == "create" {
+          cmd_args.push(zero_hex)
+        } else {
+          match old_hex {
+            Some(h) => cmd_args.push(h)
+            None => ()
+          }
         }
       }
+      handle_update_ref(cmd_args)
     }
     return ()
   }
@@ -808,6 +846,169 @@ fn update_ref_extra_input(fields : Array[String], consumed : Int) -> String {
 /// unterminated/invalid-escape -> "badly quoted argument: <tok>", trailing
 /// junk after the closing quote -> "unexpected character after quoted argument:
 /// <tok>".
+/// One parsed `--stdin` operation, captured during the syntax pass so that the
+/// whole batch can be validated atomically before anything is written.
+struct UpdateRefStdinOp {
+  kind : String // "create" | "update" | "delete" | "verify"
+  refname : String
+  new_tok : String? // None when the command takes no new value (delete/verify)
+  old_tok : String? // None when no old value was supplied
+  no_deref : Bool
+  create_reflog : Bool
+}
+
+///|
+/// Resolve a `--stdin` value token (hex oid, ref name, or revision) to an
+/// object id, or None when it cannot be resolved.
+fn update_ref_resolve_oid(
+  fs : OsFs,
+  git_dir : String,
+  tok : String,
+) -> @bitcore.ObjectId? raise Error {
+  let direct = @bitcore.ObjectId::from_hex(tok) catch {
+    _ => return @bitrepo.rev_parse(fs, git_dir, tok)
+  }
+  Some(direct)
+}
+
+///|
+/// Validate one parsed stdin op against the current repository state, emitting
+/// git's exact `fatal:` diagnostics and exiting without applying anything when
+/// the operation cannot proceed.
+async fn update_ref_stdin_validate_op(
+  fs : OsFs,
+  git_dir : String,
+  op : UpdateRefStdinOp,
+) -> Unit raise Error {
+  let zero = @bitcore.ObjectId::zero()
+  // Resolve and sanity-check the new value (create/update only).
+  match op.new_tok {
+    Some(tok) => {
+      // An empty new value (e.g. `create R ` with a trailing space) is the zero
+      // oid, which git rejects for create as "zero <new-oid>".
+      let new_id = if tok.length() == 0 {
+        Some(zero)
+      } else {
+        update_ref_resolve_oid(fs, git_dir, tok)
+      }
+      guard new_id is Some(nid) else {
+        eprint_line("fatal: \{op.kind} \{op.refname}: invalid <new-oid>: \{tok}")
+        @sys.exit(128)
+      }
+      if op.kind == "create" && nid.to_hex() == zero.to_hex() {
+        eprint_line("fatal: create \{op.refname}: zero <new-oid>")
+        @sys.exit(128)
+      }
+    }
+    None => ()
+  }
+  // Determine the expected previous value: Some(id) means "must currently
+  // equal id" (zero means "must not exist"); None means "no check".
+  let expected : @bitcore.ObjectId? = if op.kind == "create" {
+    Some(zero)
+  } else {
+    match op.old_tok {
+      Some(tok) => {
+        let resolved = if tok.length() == 0 {
+          Some(zero)
+        } else {
+          update_ref_resolve_oid(fs, git_dir, tok)
+        }
+        guard resolved is Some(oid) else {
+          eprint_line(
+            "fatal: \{op.kind} \{op.refname}: invalid <old-oid>: \{tok}",
+          )
+          @sys.exit(128)
+          return
+        }
+        // A zero <old-oid> is meaningless for delete.
+        if op.kind == "delete" && oid.to_hex() == zero.to_hex() {
+          eprint_line("fatal: delete \{op.refname}: zero <old-oid>")
+          @sys.exit(128)
+        }
+        Some(oid)
+      }
+      // verify with no value defaults to "must not exist"; update/delete with
+      // no old value skip the check entirely.
+      None => if op.kind == "verify" { Some(zero) } else { None }
+    }
+  }
+  match expected {
+    Some(eid) => {
+      let current = @bitrepo.rev_parse(fs, git_dir, op.refname)
+      match current {
+        Some(cur) =>
+          if cur.to_hex() != eid.to_hex() {
+            if eid.to_hex() == zero.to_hex() {
+              eprint_line(
+                "fatal: cannot lock ref '\{op.refname}': reference already exists",
+              )
+            } else {
+              eprint_line(
+                "fatal: cannot lock ref '\{op.refname}': is at \{cur.to_hex()} but expected \{eid.to_hex()}",
+              )
+            }
+            @sys.exit(128)
+          }
+        None =>
+          if eid.to_hex() != zero.to_hex() {
+            eprint_line(
+              "fatal: cannot lock ref '\{op.refname}': unable to resolve reference '\{op.refname}'",
+            )
+            @sys.exit(128)
+          }
+      }
+    }
+    None => ()
+  }
+}
+
+///|
+/// Split a `--stdin` command line into space-separated fields, keeping a
+/// C-quoted field (one that starts with `"`) intact even when it contains
+/// spaces — e.g. `create R "refs/heads/main:path with space"` yields three
+/// fields, not five. Any trailing junk after a closing quote stays attached to
+/// the field so the unquoter can report it.
+fn update_ref_stdin_split_fields(line : String) -> Array[String] {
+  let fields : Array[String] = []
+  let n = line.length()
+  let mut i = 0
+  for ;; {
+    let start = i
+    if i < n && line[i] == '"' {
+      i = i + 1
+      let mut closed = false
+      while i < n {
+        if !closed && line[i] == '\\' && i + 1 < n {
+          i = i + 2
+        } else if !closed && line[i] == '"' {
+          closed = true
+          i = i + 1
+        } else if closed && line[i] == ' ' {
+          break
+        } else {
+          i = i + 1
+        }
+      }
+    } else {
+      while i < n && line[i] != ' ' {
+        i = i + 1
+      }
+    }
+    fields.push(String::unsafe_substring(line, start=start, end=i))
+    // A single space separates fields; consuming it and continuing means a
+    // trailing space yields a trailing empty field (git treats `create R ` as
+    // an empty <new-oid>, distinct from `create R`).
+    if i < n && line[i] == ' ' {
+      i = i + 1
+    } else {
+      break
+    }
+  }
+  fields
+}
+
+///|
 async fn update_ref_unquote_arg(token : String) -> String {
   let n = token.length()
   let mut result = ""

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -133,6 +133,9 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     let mut stdin_no_deref = no_deref
     let mut stdin_create_reflog = create_reflog
     let seen_refs : Map[String, Bool] = {}
+    // Maps a --no-deref symref's referent to the symref name, so a later update
+    // of that referent is detected as a duplicate.
+    let noderef_referents : Map[String, String] = {}
     // git applies a --stdin batch as one transaction: every command is parsed
     // into a structured op, the whole batch is validated against the current
     // repo state, and only then is anything written.
@@ -146,7 +149,8 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     let mut txn_started = false
     if z_mode {
       update_ref_parse_stdin_z(
-        input, ops, seen_refs, stdin_no_deref, stdin_create_reflog,
+        fs, actual_git_dir, input, ops, seen_refs, noderef_referents,
+        stdin_no_deref, stdin_create_reflog,
       )
     } else {
       // A trailing newline terminates the final command (it does not introduce
@@ -197,6 +201,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
         txn_state = 0
         txn_started = false
         seen_refs.clear()
+        noderef_referents.clear()
       }
       match cmd {
         "option" => {
@@ -222,6 +227,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             // A fresh start (initial open or after a prior commit/abort).
             ops.clear()
             seen_refs.clear()
+            noderef_referents.clear()
             txn_state = 0
             txn_started = true
             print_line("start: ok")
@@ -245,6 +251,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             update_ref_stdin_flush(fs, actual_git_dir, ops, message)
             ops.clear()
             seen_refs.clear()
+            noderef_referents.clear()
             print_line("commit: ok")
             txn_state = 2
           }
@@ -255,6 +262,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
           } else {
             ops.clear()
             seen_refs.clear()
+            noderef_referents.clear()
             print_line("abort: ok")
             txn_state = 2
           }
@@ -274,7 +282,10 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             )
             @sys.exit(128)
           }
-          update_ref_stdin_check_dup(seen_refs, ref_tok)
+          update_ref_stdin_check_dup(
+            fs, actual_git_dir, ref_tok, stdin_no_deref, seen_refs,
+            noderef_referents,
+          )
           ops.push({
             kind: "create",
             refname: ref_tok,
@@ -300,7 +311,10 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             )
             @sys.exit(128)
           }
-          update_ref_stdin_check_dup(seen_refs, ref_tok)
+          update_ref_stdin_check_dup(
+            fs, actual_git_dir, ref_tok, stdin_no_deref, seen_refs,
+            noderef_referents,
+          )
           ops.push({
             kind: "update",
             refname: ref_tok,
@@ -322,7 +336,10 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             )
             @sys.exit(128)
           }
-          update_ref_stdin_check_dup(seen_refs, ref_tok)
+          update_ref_stdin_check_dup(
+            fs, actual_git_dir, ref_tok, stdin_no_deref, seen_refs,
+            noderef_referents,
+          )
           ops.push({
             kind: "delete",
             refname: ref_tok,
@@ -1064,9 +1081,12 @@ async fn update_ref_stdin_flush(
 /// takes two. An empty new value is the zero oid (a delete, with git's warning);
 /// an empty old value means "do not check".
 async fn update_ref_parse_stdin_z(
+  fs : OsFs,
+  git_dir : String,
   input : String,
   ops : Array[UpdateRefStdinOp],
   seen_refs : Map[String, Bool],
+  noderef_referents : Map[String, String],
   no_deref_init : Bool,
   create_reflog_init : Bool,
 ) -> Unit raise Error {
@@ -1140,7 +1160,10 @@ async fn update_ref_parse_stdin_z(
           eprint_line("fatal: create \{ref_tok}: missing <new-oid>")
           @sys.exit(128)
         }
-        update_ref_stdin_check_dup(seen_refs, ref_tok)
+        update_ref_stdin_check_dup(
+            fs, git_dir, ref_tok, no_deref, seen_refs,
+            noderef_referents,
+          )
         ops.push({
           kind: "create",
           refname: ref_tok,
@@ -1176,7 +1199,10 @@ async fn update_ref_parse_stdin_z(
             "warning: update \{ref_tok}: missing <new-oid>, treating as zero",
           )
         }
-        update_ref_stdin_check_dup(seen_refs, ref_tok)
+        update_ref_stdin_check_dup(
+            fs, git_dir, ref_tok, no_deref, seen_refs,
+            noderef_referents,
+          )
         ops.push({
           kind: "update",
           refname: ref_tok,
@@ -1199,7 +1225,10 @@ async fn update_ref_parse_stdin_z(
         }
         let old_val = records[ri]
         ri = ri + 1
-        update_ref_stdin_check_dup(seen_refs, ref_tok)
+        update_ref_stdin_check_dup(
+            fs, git_dir, ref_tok, no_deref, seen_refs,
+            noderef_referents,
+          )
         ops.push({
           kind: "delete",
           refname: ref_tok,
@@ -1335,17 +1364,89 @@ async fn update_ref_unquote_arg(token : String) -> String {
 
 ///|
 /// git's stdin transaction rejects multiple updates to the same ref.
-async fn update_ref_stdin_check_dup(
-  seen : Map[String, Bool],
-  ref_tok : String,
-) -> Unit {
-  if seen.get(ref_tok).unwrap_or(false) {
-    eprint_line(
-      "fatal: multiple updates for ref '" + ref_tok + "' not allowed",
-    )
-    @sys.exit(128)
+/// Read the immediate (one-level) symref target of `refname`, or None if it is
+/// not a symbolic ref.
+fn update_ref_symref_target_one(
+  fs : OsFs,
+  git_dir : String,
+  refname : String,
+) -> String? {
+  let ref_path = git_dir + "/" + refname
+  if !fs.is_file(ref_path) {
+    return None
   }
-  seen[ref_tok] = true
+  let content = decode_bytes(fs.read_file(ref_path)) catch { _ => return None }
+  let line = trim_chars(content, " \t\r\n")
+  if line.has_prefix("ref: ") {
+    Some(String::unsafe_substring(line, start=5, end=line.length()))
+  } else {
+    None
+  }
+}
+
+///|
+/// git's stdin transaction rejects two updates that touch the same underlying
+/// ref. A dereferencing symref update collides on its (resolved) target; a
+/// `--no-deref` symref update collides with a separate update of its referent.
+async fn update_ref_stdin_check_dup(
+  fs : OsFs,
+  git_dir : String,
+  ref_tok : String,
+  no_deref : Bool,
+  seen : Map[String, Bool],
+  noderef_referents : Map[String, String],
+) -> Unit raise Error {
+  match update_ref_symref_target_one(fs, git_dir, ref_tok) {
+    Some(referent) =>
+      if no_deref {
+        // The symref itself is updated; conflicts if its referent is too.
+        if seen.get(referent).unwrap_or(false) {
+          eprint_line(
+            "fatal: multiple updates for '\{ref_tok}' (including one via its referent '\{referent}') are not allowed",
+          )
+          @sys.exit(128)
+        }
+        if seen.get(ref_tok).unwrap_or(false) {
+          eprint_line(
+            "fatal: multiple updates for ref '\{ref_tok}' not allowed",
+          )
+          @sys.exit(128)
+        }
+        seen[ref_tok] = true
+        noderef_referents[referent] = ref_tok
+      } else {
+        // Dereferencing: the update lands on the fully resolved target.
+        let target = resolve_symbolic_ref_target(fs, git_dir, ref_tok).unwrap_or(
+          ref_tok,
+        )
+        if seen.get(target).unwrap_or(false) {
+          eprint_line(
+            "fatal: multiple updates for '\{target}' (including one via symref '\{ref_tok}') are not allowed",
+          )
+          @sys.exit(128)
+        }
+        seen[target] = true
+      }
+    None => {
+      if seen.get(ref_tok).unwrap_or(false) {
+        eprint_line(
+          "fatal: multiple updates for ref '\{ref_tok}' not allowed",
+        )
+        @sys.exit(128)
+      }
+      // A prior --no-deref symref update may have claimed this ref as referent.
+      match noderef_referents.get(ref_tok) {
+        Some(symref) => {
+          eprint_line(
+            "fatal: multiple updates for '\{symref}' (including one via its referent '\{ref_tok}') are not allowed",
+          )
+          @sys.exit(128)
+        }
+        None => ()
+      }
+      seen[ref_tok] = true
+    }
+  }
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -133,38 +133,42 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     let mut stdin_no_deref = no_deref
     let mut stdin_create_reflog = create_reflog
     let seen_refs : Map[String, Bool] = {}
-    // Build command lines. A trailing newline terminates the final command (it
-    // does not introduce an empty command); truly empty input means no commands.
-    let lines : Array[String] = []
-    if input.length() > 0 {
-      for lv in input.split("\n") {
-        lines.push(lv.to_owned())
-      }
-      if input.has_suffix("\n") && lines.length() > 0 {
-        ignore(lines.pop())
-      }
-    }
-    // git applies a --stdin batch as one transaction: validate every command
-    // (syntax, duplicate refs) before applying any, so a later error leaves the
-    // repo untouched. Pass 1 validates and records actions; pass 2 applies.
-    // Pass 1: parse + syntax-check every command into a structured op list.
+    // git applies a --stdin batch as one transaction: every command is parsed
+    // into a structured op, the whole batch is validated against the current
+    // repo state, and only then is anything written.
     let ops : Array[UpdateRefStdinOp] = []
-    for raw in lines {
-      let line = if raw.has_suffix("\r") {
-        String::unsafe_substring(raw, start=0, end=raw.length() - 1)
-      } else {
-        raw
+    if z_mode {
+      update_ref_parse_stdin_z(
+        input, ops, seen_refs, stdin_no_deref, stdin_create_reflog,
+      )
+    } else {
+      // A trailing newline terminates the final command (it does not introduce
+      // an empty command); truly empty input means no commands.
+      let lines : Array[String] = []
+      if input.length() > 0 {
+        for lv in input.split("\n") {
+          lines.push(lv.to_owned())
+        }
+        if input.has_suffix("\n") && lines.length() > 0 {
+          ignore(lines.pop())
+        }
       }
-      if line.length() == 0 {
-        eprint_line("fatal: empty command in input")
-        @sys.exit(128)
-      }
-      let first = line[0]
-      if first == ' ' || first == '\t' {
-        eprint_line("fatal: whitespace before command: " + line)
-        @sys.exit(128)
-      }
-      let fields = update_ref_stdin_split_fields(line)
+      for raw in lines {
+        let line = if raw.has_suffix("\r") {
+          String::unsafe_substring(raw, start=0, end=raw.length() - 1)
+        } else {
+          raw
+        }
+        if line.length() == 0 {
+          eprint_line("fatal: empty command in input")
+          @sys.exit(128)
+        }
+        let first = line[0]
+        if first == ' ' || first == '\t' {
+          eprint_line("fatal: whitespace before command: " + line)
+          @sys.exit(128)
+        }
+        let fields = update_ref_stdin_split_fields(line)
       // Unquote C-style quoted arguments, reporting git's exact errors on
       // malformed quoting (before any command is applied).
       for fi = 0; fi < fields.length(); fi = fi + 1 {
@@ -286,6 +290,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
           eprint_line("fatal: unknown command: " + line)
           @sys.exit(128)
         }
+      }
       }
     }
     // Pass 2: validate the whole batch against the current repo state before
@@ -960,6 +965,188 @@ async fn update_ref_stdin_validate_op(
       }
     }
     None => ()
+  }
+}
+
+///|
+/// Parse `--stdin -z` input (NUL-separated records) into the shared op list.
+/// In this format each command record is `<cmd> SP <ref>` and the values are
+/// separate NUL records; create/verify/delete take exactly one value, update
+/// takes two. An empty new value is the zero oid (a delete, with git's warning);
+/// an empty old value means "do not check".
+async fn update_ref_parse_stdin_z(
+  input : String,
+  ops : Array[UpdateRefStdinOp],
+  seen_refs : Map[String, Bool],
+  no_deref_init : Bool,
+  create_reflog_init : Bool,
+) -> Unit raise Error {
+  let mut no_deref = no_deref_init
+  let mut create_reflog = create_reflog_init
+  // Split into NUL-terminated records; the trailing NUL closes the last field.
+  let records : Array[String] = []
+  let cur = StringBuilder::new()
+  let mut pending = false
+  for ch in input {
+    if ch == '\u{0}' {
+      records.push(cur.to_string())
+      cur.reset()
+      pending = false
+    } else {
+      cur.write_char(ch)
+      pending = true
+    }
+  }
+  if pending {
+    records.push(cur.to_string())
+  }
+  let mut ri = 0
+  while ri < records.length() {
+    let rec = records[ri]
+    ri = ri + 1
+    if rec.length() == 0 {
+      eprint_line("fatal: empty command in input")
+      @sys.exit(128)
+    }
+    let fc = rec[0]
+    if fc == ' ' || fc == '\t' || fc == '\n' || fc == '\r' {
+      eprint_line("fatal: whitespace before command: " + rec)
+      @sys.exit(128)
+    }
+    let (cmd, ref_tok) = match rec.find(" ") {
+      Some(si) =>
+        (
+          String::unsafe_substring(rec, start=0, end=si),
+          String::unsafe_substring(rec, start=si + 1, end=rec.length()),
+        )
+      None => (rec, "")
+    }
+    match cmd {
+      "option" =>
+        match ref_tok {
+          "no-deref" => no_deref = true
+          "create-reflog" => create_reflog = true
+          _ => {
+            eprint_line("fatal: option unknown: " + ref_tok)
+            @sys.exit(128)
+          }
+        }
+      "start" | "prepare" | "commit" | "abort" => ()
+      "create" => {
+        if ref_tok.length() == 0 {
+          eprint_line("fatal: create: missing <ref>")
+          @sys.exit(128)
+        }
+        if ri >= records.length() {
+          eprint_line(
+            "fatal: create \{ref_tok}: unexpected end of input when reading <new-oid>",
+          )
+          @sys.exit(128)
+        }
+        let new_val = records[ri]
+        ri = ri + 1
+        // Unlike line mode (where an empty field is a zero oid), -z reports an
+        // empty <new-oid> for create as missing.
+        if new_val.length() == 0 {
+          eprint_line("fatal: create \{ref_tok}: missing <new-oid>")
+          @sys.exit(128)
+        }
+        update_ref_stdin_check_dup(seen_refs, ref_tok)
+        ops.push({
+          kind: "create",
+          refname: ref_tok,
+          new_tok: Some(new_val),
+          old_tok: None,
+          no_deref,
+          create_reflog,
+        })
+      }
+      "update" => {
+        if ref_tok.length() == 0 {
+          eprint_line("fatal: update: missing <ref>")
+          @sys.exit(128)
+        }
+        if ri >= records.length() {
+          eprint_line(
+            "fatal: update \{ref_tok}: unexpected end of input when reading <new-oid>",
+          )
+          @sys.exit(128)
+        }
+        let new_val = records[ri]
+        ri = ri + 1
+        if ri >= records.length() {
+          eprint_line(
+            "fatal: update \{ref_tok}: unexpected end of input when reading <old-oid>",
+          )
+          @sys.exit(128)
+        }
+        let old_val = records[ri]
+        ri = ri + 1
+        if new_val.length() == 0 {
+          eprint_line(
+            "warning: update \{ref_tok}: missing <new-oid>, treating as zero",
+          )
+        }
+        update_ref_stdin_check_dup(seen_refs, ref_tok)
+        ops.push({
+          kind: "update",
+          refname: ref_tok,
+          new_tok: Some(new_val),
+          old_tok: if old_val.length() == 0 { None } else { Some(old_val) },
+          no_deref,
+          create_reflog,
+        })
+      }
+      "delete" => {
+        if ref_tok.length() == 0 {
+          eprint_line("fatal: delete: missing <ref>")
+          @sys.exit(128)
+        }
+        if ri >= records.length() {
+          eprint_line(
+            "fatal: delete \{ref_tok}: unexpected end of input when reading <old-oid>",
+          )
+          @sys.exit(128)
+        }
+        let old_val = records[ri]
+        ri = ri + 1
+        update_ref_stdin_check_dup(seen_refs, ref_tok)
+        ops.push({
+          kind: "delete",
+          refname: ref_tok,
+          new_tok: None,
+          old_tok: if old_val.length() == 0 { None } else { Some(old_val) },
+          no_deref,
+          create_reflog,
+        })
+      }
+      "verify" => {
+        if ref_tok.length() == 0 {
+          eprint_line("fatal: verify: missing <ref>")
+          @sys.exit(128)
+        }
+        if ri >= records.length() {
+          eprint_line(
+            "fatal: verify \{ref_tok}: unexpected end of input when reading <old-oid>",
+          )
+          @sys.exit(128)
+        }
+        let old_val = records[ri]
+        ri = ri + 1
+        ops.push({
+          kind: "verify",
+          refname: ref_tok,
+          new_tok: None,
+          old_tok: if old_val.length() == 0 { None } else { Some(old_val) },
+          no_deref,
+          create_reflog,
+        })
+      }
+      _ => {
+        eprint_line("fatal: unknown command: " + rec)
+        @sys.exit(128)
+      }
+    }
   }
 }
 

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -123,9 +123,10 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
   }
   let actual_git_dir = git_dir
   let head_target = resolve_symbolic_ref_target(fs, actual_git_dir, "HEAD")
-  // Get current timestamp for reflog
-  let timestamp = get_current_timestamp()
-  let timezone = "+0000"
+  // Reflog timestamp honors GIT_COMMITTER_DATE (falling back to now), matching
+  // git — reflog entries created by update-ref must record the committer date.
+  let timestamp = get_commit_tree_timestamp("GIT_COMMITTER_DATE")
+  let timezone = get_commit_tree_timezone("GIT_COMMITTER_DATE")
   let (author, email) = get_author_info(fs, actual_git_dir)
   if stdin_mode {
     let input = decode_bytes(read_all_stdin())

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -137,6 +137,9 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     // into a structured op, the whole batch is validated against the current
     // repo state, and only then is anything written.
     let ops : Array[UpdateRefStdinOp] = []
+    // Transaction state for the explicit start/prepare/commit/abort commands:
+    // 0 = open, 1 = prepared, 2 = closed.
+    let mut txn_state = 0
     if z_mode {
       update_ref_parse_stdin_z(
         input, ops, seen_refs, stdin_no_deref, stdin_create_reflog,
@@ -190,7 +193,46 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             }
           }
         }
-        "start" | "prepare" | "commit" | "abort" => ()
+        "start" =>
+          if txn_state == 2 {
+            eprint_line("fatal: transaction is closed")
+            @sys.exit(128)
+          } else if txn_state == 1 {
+            eprint_line("fatal: prepared transactions can only be closed")
+            @sys.exit(128)
+          } else {
+            print_line("start: ok")
+          }
+        "prepare" =>
+          if txn_state == 2 {
+            eprint_line("fatal: transaction is closed")
+            @sys.exit(128)
+          } else {
+            for op in ops {
+              update_ref_stdin_validate_op(fs, actual_git_dir, op)
+            }
+            print_line("prepare: ok")
+            txn_state = 1
+          }
+        "commit" =>
+          if txn_state == 2 {
+            eprint_line("fatal: transaction is closed")
+            @sys.exit(128)
+          } else {
+            update_ref_stdin_flush(fs, actual_git_dir, ops, message)
+            ops.clear()
+            print_line("commit: ok")
+            txn_state = 2
+          }
+        "abort" =>
+          if txn_state == 2 {
+            eprint_line("fatal: transaction is closed")
+            @sys.exit(128)
+          } else {
+            ops.clear()
+            print_line("abort: ok")
+            txn_state = 2
+          }
         "create" => {
           if ref_tok.length() == 0 {
             eprint_line("fatal: create: missing <ref>")
@@ -293,74 +335,10 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
       }
       }
     }
-    // Pass 2: validate the whole batch against the current repo state before
-    // touching anything, so a later failure leaves the repo untouched.
-    for op in ops {
-      update_ref_stdin_validate_op(fs, actual_git_dir, op)
-    }
-    // Pass 3: apply. Verify commands have no effect; the rest reuse the regular
-    // update-ref machinery (reflogs, symref deref) now that they are validated.
-    let zero_hex = @bitcore.ObjectId::zero().to_hex()
-    for op in ops {
-      if op.kind == "verify" {
-        continue
-      }
-      let cmd_args = update_ref_stdin_base_args(
-        op.no_deref, op.create_reflog, message,
-      )
-      // Resolve the old value to a concrete oid hex; the regular handler's
-      // old-value check expects a hex string, not a ref name or revision.
-      let old_hex = match op.old_tok {
-        Some(t) =>
-          if t.length() == 0 {
-            Some(zero_hex)
-          } else {
-            match update_ref_resolve_oid(fs, actual_git_dir, t) {
-              Some(oid) => Some(oid.to_hex())
-              None => Some(t)
-            }
-          }
-        None => None
-      }
-      // Resolve the new value; an `update` to the zero oid means "delete".
-      let new_hex = match op.new_tok {
-        Some(t) =>
-          if t.length() == 0 {
-            zero_hex
-          } else {
-            match update_ref_resolve_oid(fs, actual_git_dir, t) {
-              Some(oid) => oid.to_hex()
-              None => t
-            }
-          }
-        None => zero_hex
-      }
-      let deletes = op.kind == "delete" ||
-        (op.kind == "update" && new_hex == zero_hex)
-      if deletes {
-        // Ensuring a ref is absent when it is already gone is a no-op.
-        if @bitrepo.rev_parse(fs, actual_git_dir, op.refname) is None {
-          continue
-        }
-        cmd_args.push("-d")
-        cmd_args.push(op.refname)
-        match old_hex {
-          Some(h) => cmd_args.push(h)
-          None => ()
-        }
-      } else {
-        cmd_args.push(op.refname)
-        cmd_args.push(new_hex)
-        if op.kind == "create" {
-          cmd_args.push(zero_hex)
-        } else {
-          match old_hex {
-            Some(h) => cmd_args.push(h)
-            None => ()
-          }
-        }
-      }
-      handle_update_ref(cmd_args)
+    // At end of input an open (or prepared-but-not-closed) transaction is
+    // committed implicitly; an explicit commit/abort already flushed/discarded.
+    if txn_state != 2 {
+      update_ref_stdin_flush(fs, actual_git_dir, ops, message)
     }
     return ()
   }
@@ -965,6 +943,83 @@ async fn update_ref_stdin_validate_op(
       }
     }
     None => ()
+  }
+}
+
+///|
+/// Validate then apply a batch of parsed stdin ops as a single transaction:
+/// the whole batch is checked against the current repo state first, so a later
+/// failure leaves the repo untouched, and only then is each op written.
+async fn update_ref_stdin_flush(
+  fs : OsFs,
+  git_dir : String,
+  ops : Array[UpdateRefStdinOp],
+  message : String?,
+) -> Unit raise Error {
+  for op in ops {
+    update_ref_stdin_validate_op(fs, git_dir, op)
+  }
+  let zero_hex = @bitcore.ObjectId::zero().to_hex()
+  for op in ops {
+    if op.kind == "verify" {
+      continue
+    }
+    let cmd_args = update_ref_stdin_base_args(
+      op.no_deref, op.create_reflog, message,
+    )
+    // Resolve the old value to a concrete oid hex; the regular handler's
+    // old-value check expects a hex string, not a ref name or revision.
+    let old_hex = match op.old_tok {
+      Some(t) =>
+        if t.length() == 0 {
+          Some(zero_hex)
+        } else {
+          match update_ref_resolve_oid(fs, git_dir, t) {
+            Some(oid) => Some(oid.to_hex())
+            None => Some(t)
+          }
+        }
+      None => None
+    }
+    // Resolve the new value; an `update` to the zero oid means "delete".
+    let new_hex = match op.new_tok {
+      Some(t) =>
+        if t.length() == 0 {
+          zero_hex
+        } else {
+          match update_ref_resolve_oid(fs, git_dir, t) {
+            Some(oid) => oid.to_hex()
+            None => t
+          }
+        }
+      None => zero_hex
+    }
+    let deletes = op.kind == "delete" ||
+      (op.kind == "update" && new_hex == zero_hex)
+    if deletes {
+      // Ensuring a ref is absent when it is already gone is a no-op.
+      if @bitrepo.rev_parse(fs, git_dir, op.refname) is None {
+        continue
+      }
+      cmd_args.push("-d")
+      cmd_args.push(op.refname)
+      match old_hex {
+        Some(h) => cmd_args.push(h)
+        None => ()
+      }
+    } else {
+      cmd_args.push(op.refname)
+      cmd_args.push(new_hex)
+      if op.kind == "create" {
+        cmd_args.push(zero_hex)
+      } else {
+        match old_hex {
+          Some(h) => cmd_args.push(h)
+          None => ()
+        }
+      }
+    }
+    handle_update_ref(cmd_args)
   }
 }
 

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -380,7 +380,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     let should_head_log = should_update_head_reflog(
       input_refname, refname, no_deref, head_target,
     )
-    let msg = message.unwrap_or("update-ref: delete")
+    let msg = message.unwrap_or("")
     if should_log || @bitrepo.reflog_exists(rfs, actual_git_dir, refname) {
       @bitrepo.append_reflog(
         wfs,
@@ -502,7 +502,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     should_head_log ||
     @bitrepo.reflog_exists(rfs, actual_git_dir, refname) {
     let old_id = current_id.unwrap_or(@bitcore.ObjectId::zero())
-    let msg = message.unwrap_or("update-ref: updating")
+    let msg = message.unwrap_or("")
     if should_log ||
       always ||
       create_reflog ||
@@ -844,7 +844,9 @@ async fn update_ref_unquote_arg(token : String) -> String {
       result = result + decoded
       i = i + 2
     } else {
-      result = result + c.to_string()
+      // `token[i]` is a UInt16 code unit; render it as the character it
+      // represents rather than its numeric value.
+      result = result + Int::unsafe_to_char(c.to_int()).to_string()
       i = i + 1
     }
   }

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -138,8 +138,12 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     // repo state, and only then is anything written.
     let ops : Array[UpdateRefStdinOp] = []
     // Transaction state for the explicit start/prepare/commit/abort commands:
-    // 0 = open, 1 = prepared, 2 = closed.
+    // phase 0 = open, 1 = prepared, 2 = closed. `txn_started` records whether
+    // the active transaction was opened with an explicit `start` (which aborts
+    // by default at end of input, unlike the implicit transaction which
+    // commits).
     let mut txn_state = 0
+    let mut txn_started = false
     if z_mode {
       update_ref_parse_stdin_z(
         input, ops, seen_refs, stdin_no_deref, stdin_create_reflog,
@@ -181,6 +185,19 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
       }
       let cmd = fields[0]
       let ref_tok = if fields.length() >= 2 { fields[1] } else { "" }
+      // A ref command issued after a closed transaction implicitly begins a
+      // new (un-started) transaction.
+      if txn_state == 2 &&
+        (
+          cmd == "create" ||
+          cmd == "update" ||
+          cmd == "delete" ||
+          cmd == "verify"
+        ) {
+        txn_state = 0
+        txn_started = false
+        seen_refs.clear()
+      }
       match cmd {
         "option" => {
           let name = ref_tok
@@ -194,13 +211,19 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
           }
         }
         "start" =>
-          if txn_state == 2 {
-            eprint_line("fatal: transaction is closed")
-            @sys.exit(128)
-          } else if txn_state == 1 {
+          if txn_state == 1 {
             eprint_line("fatal: prepared transactions can only be closed")
             @sys.exit(128)
+          } else if txn_state == 0 && txn_started {
+            // A transaction is already open and explicitly started.
+            eprint_line("fatal: transaction already in progress")
+            @sys.exit(128)
           } else {
+            // A fresh start (initial open or after a prior commit/abort).
+            ops.clear()
+            seen_refs.clear()
+            txn_state = 0
+            txn_started = true
             print_line("start: ok")
           }
         "prepare" =>
@@ -221,6 +244,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
           } else {
             update_ref_stdin_flush(fs, actual_git_dir, ops, message)
             ops.clear()
+            seen_refs.clear()
             print_line("commit: ok")
             txn_state = 2
           }
@@ -230,6 +254,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
             @sys.exit(128)
           } else {
             ops.clear()
+            seen_refs.clear()
             print_line("abort: ok")
             txn_state = 2
           }
@@ -335,9 +360,10 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
       }
       }
     }
-    // At end of input an open (or prepared-but-not-closed) transaction is
-    // committed implicitly; an explicit commit/abort already flushed/discarded.
-    if txn_state != 2 {
+    // At end of input the implicit transaction commits, but an explicitly
+    // started transaction that was never committed aborts by default; an
+    // explicit commit/abort has already flushed/discarded.
+    if txn_state != 2 && !txn_started {
       update_ref_stdin_flush(fs, actual_git_dir, ops, message)
     }
     return ()

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -438,7 +438,11 @@ fn normalize_update_ref_name(
   let normalized = @bitlib.normalize_repo_path(refname) catch {
     _ => raise @bitcore.GitError::InvalidObject("invalid refname: " + refname)
   }
-  if normalized == "HEAD" || normalized.has_prefix("refs/") {
+  // Accept HEAD, refs/..., and one-component root/pseudo refs such as
+  // ORIG_HEAD or CHERRY_PICK_HEAD (git allows updating these directly).
+  if normalized == "HEAD" ||
+    normalized.has_prefix("refs/") ||
+    for_each_ref_is_root_ref_syntax(normalized) {
     normalized
   } else {
     raise @bitcore.GitError::InvalidObject("invalid refname: " + refname)

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -167,6 +167,13 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
       for fv in line.split(" ") {
         fields.push(fv.to_owned())
       }
+      // Unquote C-style quoted arguments, reporting git's exact errors on
+      // malformed quoting (before any command is applied).
+      for fi = 0; fi < fields.length(); fi = fi + 1 {
+        if fields[fi].has_prefix("\"") {
+          fields[fi] = update_ref_unquote_arg(fields[fi])
+        }
+      }
       let cmd = fields[0]
       let ref_tok = if fields.length() >= 2 { fields[1] } else { "" }
       match cmd {
@@ -792,6 +799,58 @@ fn update_ref_extra_input(fields : Array[String], consumed : Int) -> String {
     s = s + " " + fields[i]
   }
   s
+}
+
+///|
+/// Unquote a C-style quoted --stdin argument (token starts with `"`), matching
+/// git's parser. Exits with git's exact diagnostics on malformed quoting:
+/// unterminated/invalid-escape -> "badly quoted argument: <tok>", trailing
+/// junk after the closing quote -> "unexpected character after quoted argument:
+/// <tok>".
+async fn update_ref_unquote_arg(token : String) -> String {
+  let n = token.length()
+  let mut result = ""
+  let mut i = 1 // skip opening quote
+  while i < n {
+    let c = token[i]
+    if c == '"' {
+      // Closing quote must be the final character of the token.
+      if i != n - 1 {
+        eprint_line(
+          "fatal: unexpected character after quoted argument: " + token,
+        )
+        @sys.exit(128)
+      }
+      return result
+    }
+    if c == '\\' {
+      if i + 1 >= n {
+        eprint_line("fatal: badly quoted argument: " + token)
+        @sys.exit(128)
+      }
+      let decoded = match token[i + 1] {
+        '"' => "\""
+        '\\' => "\\"
+        'n' => "\n"
+        't' => "\t"
+        'r' => "\r"
+        _ => {
+          eprint_line("fatal: badly quoted argument: " + token)
+          @sys.exit(128)
+          ""
+        }
+      }
+      result = result + decoded
+      i = i + 2
+    } else {
+      result = result + c.to_string()
+      i = i + 1
+    }
+  }
+  // Reached end of token without a closing quote.
+  eprint_line("fatal: badly quoted argument: " + token)
+  @sys.exit(128)
+  ""
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -477,9 +477,17 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
       match current_id {
         Some(cur_id) =>
           if cur_id.to_hex() != expected_id.to_hex() {
-            @stdio.stderr.write(
-              "error: cannot lock ref '\{refname}': is at \{cur_id.to_hex()} but expected \{expected_id.to_hex()}",
-            )
+            // A zero expected value means "must not exist"; git reports an
+            // existing ref as "already exists" rather than a value mismatch.
+            if expected_id.to_hex() == @bitcore.ObjectId::zero().to_hex() {
+              @stdio.stderr.write(
+                "error: cannot lock ref '\{refname}': reference already exists",
+              )
+            } else {
+              @stdio.stderr.write(
+                "error: cannot lock ref '\{refname}': is at \{cur_id.to_hex()} but expected \{expected_id.to_hex()}",
+              )
+            }
             @sys.exit(1)
           }
         None =>

--- a/modules/bit/src/cmd/bit/update_ref.mbt
+++ b/modules/bit/src/cmd/bit/update_ref.mbt
@@ -94,6 +94,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
   let mut create_reflog = false
   let mut no_deref = false
   let mut stdin_mode = false
+  let mut z_mode = false
   let mut message : String? = None
   let positional : Array[String] = []
   let mut i = 0
@@ -104,6 +105,7 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
       "--create-reflog" => create_reflog = true
       "--no-deref" => no_deref = true
       "--stdin" => stdin_mode = true
+      "-z" => z_mode = true
       "-m" if i + 1 < args.length() => {
         message = Some(args[i + 1])
         i += 1
@@ -113,6 +115,11 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
       _ => ()
     }
     i += 1
+  }
+  // -z only makes sense together with --stdin.
+  if z_mode && !stdin_mode {
+    eprint_line("usage: git update-ref [<options>]    <refname> <new-oid> [<old-oid>]")
+    @sys.exit(129)
   }
   let actual_git_dir = git_dir
   let head_target = resolve_symbolic_ref_target(fs, actual_git_dir, "HEAD")
@@ -124,108 +131,183 @@ async fn handle_update_ref(args : Array[String]) -> Unit raise Error {
     let input = decode_bytes(read_all_stdin())
     let mut stdin_no_deref = no_deref
     let mut stdin_create_reflog = create_reflog
-    for line_view in input.split("\n") {
-      let line = trim_chars(line_view.to_owned(), " \t\r\n")
+    let seen_refs : Map[String, Bool] = {}
+    // Build command lines. A trailing newline terminates the final command (it
+    // does not introduce an empty command); truly empty input means no commands.
+    let lines : Array[String] = []
+    if input.length() > 0 {
+      for lv in input.split("\n") {
+        lines.push(lv.to_owned())
+      }
+      if input.has_suffix("\n") && lines.length() > 0 {
+        ignore(lines.pop())
+      }
+    }
+    // git applies a --stdin batch as one transaction: validate every command
+    // (syntax, duplicate refs) before applying any, so a later error leaves the
+    // repo untouched. Pass 1 validates and records actions; pass 2 applies.
+    // Each action is ("call", <handle_update_ref args>) or ("verify", [ref, old?]).
+    let actions : Array[(String, Array[String])] = []
+    for raw in lines {
+      let line = if raw.has_suffix("\r") {
+        String::unsafe_substring(raw, start=0, end=raw.length() - 1)
+      } else {
+        raw
+      }
       if line.length() == 0 {
-        continue
+        eprint_line("fatal: empty command in input")
+        @sys.exit(128)
       }
-      let tokens = update_ref_split_stdin_tokens(line)
-      if tokens.length() == 0 {
-        continue
+      let first = line[0]
+      if first == ' ' || first == '\t' {
+        eprint_line("fatal: whitespace before command: " + line)
+        @sys.exit(128)
       }
-      let cmd = tokens[0]
+      let fields : Array[String] = []
+      for fv in line.split(" ") {
+        fields.push(fv.to_owned())
+      }
+      let cmd = fields[0]
+      let ref_tok = if fields.length() >= 2 { fields[1] } else { "" }
       match cmd {
         "option" => {
-          if tokens.length() != 2 {
-            eprint_line("fatal: update-ref: option requires one argument")
-            @sys.exit(128)
-          }
-          match tokens[1] {
+          let name = ref_tok
+          match name {
             "no-deref" => stdin_no_deref = true
             "create-reflog" => stdin_create_reflog = true
             _ => {
-              eprint_line("fatal: update-ref: unknown option: " + tokens[1])
+              eprint_line("fatal: option unknown: " + name)
               @sys.exit(128)
             }
           }
         }
         "start" | "prepare" | "commit" | "abort" => ()
         "create" => {
-          if tokens.length() != 3 {
-            eprint_line("fatal: update-ref: create requires <ref> <newvalue>")
+          if ref_tok.length() == 0 {
+            eprint_line("fatal: create: missing <ref>")
             @sys.exit(128)
           }
-          let cmd_args = update_ref_stdin_base_args(
-            stdin_no_deref, stdin_create_reflog, message,
-          )
-          cmd_args.push(tokens[1])
-          cmd_args.push(tokens[2])
-          cmd_args.push(@bitcore.ObjectId::zero().to_hex())
-          handle_update_ref(cmd_args)
-        }
-        "update" => {
-          if tokens.length() != 3 && tokens.length() != 4 {
+          let val_tok = if fields.length() >= 3 { fields[2] } else { "" }
+          if val_tok.length() == 0 {
+            eprint_line("fatal: create \{ref_tok}: missing <new-oid>")
+            @sys.exit(128)
+          }
+          if fields.length() > 3 {
             eprint_line(
-              "fatal: update-ref: update requires <ref> <newvalue> [<oldvalue>]",
+              "fatal: create \{ref_tok}: extra input: " +
+              update_ref_extra_input(fields, 3),
             )
             @sys.exit(128)
           }
+          update_ref_stdin_check_dup(seen_refs, ref_tok)
           let cmd_args = update_ref_stdin_base_args(
             stdin_no_deref, stdin_create_reflog, message,
           )
-          cmd_args.push(tokens[1])
-          cmd_args.push(tokens[2])
-          if tokens.length() == 4 {
-            cmd_args.push(tokens[3])
-          }
-          handle_update_ref(cmd_args)
+          cmd_args.push(ref_tok)
+          cmd_args.push(val_tok)
+          cmd_args.push(@bitcore.ObjectId::zero().to_hex())
+          actions.push(("call", cmd_args))
         }
-        "delete" => {
-          if tokens.length() != 2 && tokens.length() != 3 {
-            eprint_line("fatal: update-ref: delete requires <ref> [<oldvalue>]")
+        "update" => {
+          if ref_tok.length() == 0 {
+            eprint_line("fatal: update: missing <ref>")
             @sys.exit(128)
           }
+          let val_tok = if fields.length() >= 3 { fields[2] } else { "" }
+          if val_tok.length() == 0 {
+            eprint_line("fatal: update \{ref_tok}: missing <new-oid>")
+            @sys.exit(128)
+          }
+          if fields.length() > 4 {
+            eprint_line(
+              "fatal: update \{ref_tok}: extra input: " +
+              update_ref_extra_input(fields, 4),
+            )
+            @sys.exit(128)
+          }
+          update_ref_stdin_check_dup(seen_refs, ref_tok)
+          let cmd_args = update_ref_stdin_base_args(
+            stdin_no_deref, stdin_create_reflog, message,
+          )
+          cmd_args.push(ref_tok)
+          cmd_args.push(val_tok)
+          if fields.length() == 4 {
+            cmd_args.push(fields[3])
+          }
+          actions.push(("call", cmd_args))
+        }
+        "delete" => {
+          if ref_tok.length() == 0 {
+            eprint_line("fatal: delete: missing <ref>")
+            @sys.exit(128)
+          }
+          if fields.length() > 3 {
+            eprint_line(
+              "fatal: delete \{ref_tok}: extra input: " +
+              update_ref_extra_input(fields, 3),
+            )
+            @sys.exit(128)
+          }
+          update_ref_stdin_check_dup(seen_refs, ref_tok)
           let cmd_args = update_ref_stdin_base_args(
             stdin_no_deref, stdin_create_reflog, message,
           )
           cmd_args.push("-d")
-          cmd_args.push(tokens[1])
-          if tokens.length() == 3 {
-            cmd_args.push(tokens[2])
+          cmd_args.push(ref_tok)
+          if fields.length() == 3 {
+            cmd_args.push(fields[2])
           }
-          handle_update_ref(cmd_args)
+          actions.push(("call", cmd_args))
         }
         "verify" => {
-          if tokens.length() != 2 && tokens.length() != 3 {
-            eprint_line("fatal: update-ref: verify requires <ref> [<oldvalue>]")
+          if ref_tok.length() == 0 {
+            eprint_line("fatal: verify: missing <ref>")
             @sys.exit(128)
           }
-          let refname = normalize_update_ref_name(tokens[1])
-          let refname = resolve_update_target_ref(
-            fs, actual_git_dir, refname, stdin_no_deref,
-          )
-          let current_id = read_ref_value(fs, actual_git_dir, refname)
-          let ok = match tokens.length() {
-            2 => current_id is Some(_)
-            _ => {
-              let expected_id = @bitcore.ObjectId::from_hex(tokens[2]) catch {
-                _ => @bitcore.ObjectId::zero()
-              }
-              match current_id {
-                Some(cur_id) => cur_id.to_hex() == expected_id.to_hex()
-                None =>
-                  expected_id.to_hex() == @bitcore.ObjectId::zero().to_hex()
-              }
-            }
+          if fields.length() > 3 {
+            eprint_line(
+              "fatal: verify \{ref_tok}: extra input: " +
+              update_ref_extra_input(fields, 3),
+            )
+            @sys.exit(128)
           }
-          if !ok {
-            eprint_line("fatal: update-ref: verify failed for " + tokens[1])
-            @sys.exit(1)
+          let verify_args : Array[String] = [ref_tok]
+          if fields.length() >= 3 {
+            verify_args.push(fields[2])
           }
+          actions.push(("verify", verify_args))
         }
         _ => {
-          eprint_line("fatal: update-ref: unknown command: " + cmd)
+          eprint_line("fatal: unknown command: " + line)
           @sys.exit(128)
+        }
+      }
+    }
+    // Pass 2: apply the validated actions in order.
+    for action in actions {
+      if action.0 == "call" {
+        handle_update_ref(action.1)
+      } else {
+        let v_ref = action.1[0]
+        let refname = normalize_update_ref_name(v_ref)
+        let refname = resolve_update_target_ref(
+          fs, actual_git_dir, refname, stdin_no_deref,
+        )
+        let current_id = read_ref_value(fs, actual_git_dir, refname)
+        let ok = if action.1.length() < 2 {
+          current_id is Some(_)
+        } else {
+          let expected_id = @bitcore.ObjectId::from_hex(action.1[1]) catch {
+            _ => @bitcore.ObjectId::zero()
+          }
+          match current_id {
+            Some(cur_id) => cur_id.to_hex() == expected_id.to_hex()
+            None => expected_id.to_hex() == @bitcore.ObjectId::zero().to_hex()
+          }
+        }
+        if !ok {
+          eprint_line("fatal: update-ref: verify failed for " + v_ref)
+          @sys.exit(1)
         }
       }
     }
@@ -701,15 +783,30 @@ fn get_author_info(
 }
 
 ///|
-fn update_ref_split_stdin_tokens(line : String) -> Array[String] {
-  let tokens : Array[String] = []
-  for token_view in line.split(" ") {
-    let token = trim_string(token_view.to_owned())
-    if token.length() > 0 {
-      tokens.push(token)
-    }
+/// Reconstruct git's "extra input" tail: the unconsumed fields, each preceded
+/// by the single separating space (so the result has a leading space, matching
+/// git which reports the remaining input pointer including its separator).
+fn update_ref_extra_input(fields : Array[String], consumed : Int) -> String {
+  let mut s = ""
+  for i = consumed; i < fields.length(); i = i + 1 {
+    s = s + " " + fields[i]
   }
-  tokens
+  s
+}
+
+///|
+/// git's stdin transaction rejects multiple updates to the same ref.
+async fn update_ref_stdin_check_dup(
+  seen : Map[String, Bool],
+  ref_tok : String,
+) -> Unit {
+  if seen.get(ref_tok).unwrap_or(false) {
+    eprint_line(
+      "fatal: multiple updates for ref '" + ref_tok + "' not allowed",
+    )
+    @sys.exit(128)
+  }
+  seen[ref_tok] = true
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/update_ref_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/update_ref_wbtest.mbt
@@ -1,12 +1,16 @@
 ///|
-test "update-ref stdin token split trims repeated spaces" {
-  let tokens = update_ref_split_stdin_tokens(
-    "  create   refs/tags/v1   deadbeef  ",
+test "update-ref stdin extra-input reconstructs the unconsumed tail" {
+  // Fields after `consumed` are rejoined with their separating space, matching
+  // git's "extra input:" report (which includes the leading separator).
+  let extra = update_ref_extra_input(
+    ["create", "refs/tags/v1", "deadbeef", "cafef00d"],
+    3,
   )
-  assert_eq(tokens.length(), 3)
-  assert_eq(tokens[0], "create")
-  assert_eq(tokens[1], "refs/tags/v1")
-  assert_eq(tokens[2], "deadbeef")
+  assert_eq(extra, " cafef00d")
+  assert_eq(
+    update_ref_extra_input(["delete", "refs/tags/v1"], 2),
+    "",
+  )
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/wbtest_env_lock_shared.mbt
+++ b/modules/bit/src/cmd/bit/wbtest_env_lock_shared.mbt
@@ -8,6 +8,7 @@ let cmd_bit_wbtest_env_lock : @async.Semaphore = @async.Semaphore::new(
 fn init {
   ignore(cmd_bit_wbtest_env_lock)
   ignore(wbtest_resolve_real_git)
+  ignore(wbtest_resolve_bit_exe)
 }
 
 ///|
@@ -20,5 +21,22 @@ fn wbtest_resolve_real_git(repo_root : String) -> String {
     third_party
   } else {
     "git"
+  }
+}
+
+///|
+/// Resolve the freshly built `bit.exe` for wbtests. The native binary lives
+/// under a debug or release build directory depending on how it was compiled,
+/// so prefer whichever exists (debug first, since that is the default build).
+fn wbtest_resolve_bit_exe(repo_root : String) -> String {
+  let fs : &@bitcore.RepoFileSystem = OsFs::new()
+  let debug_path = repo_root +
+    "/_build/native/debug/build/mizchi/bit/cmd/bit/bit.exe"
+  let release_path = repo_root +
+    "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  if fs.is_file(debug_path) {
+    debug_path
+  } else {
+    release_path
   }
 }

--- a/modules/bit/src/cmd/bit/wbtest_env_lock_shared.mbt
+++ b/modules/bit/src/cmd/bit/wbtest_env_lock_shared.mbt
@@ -9,6 +9,21 @@ fn init {
   ignore(cmd_bit_wbtest_env_lock)
   ignore(wbtest_resolve_real_git)
   ignore(wbtest_resolve_bit_exe)
+  ignore(wbtest_resolve_repo_root)
+}
+
+///|
+/// Resolve the git repo root for wbtests independently of the current working
+/// directory. `moon test` sets CWD to the module dir (`modules/bit`), so
+/// `@env.current_dir()` cannot locate repo-root-relative assets such as the
+/// git shim (`tools/git-shim/bin/git`). Derive the root from the running test
+/// executable's `/_build/` path instead, falling back to CWD when that fails.
+fn wbtest_resolve_repo_root() -> String {
+  let exe = @sys.get_cli_args()[0]
+  match exe.find("/_build/") {
+    Some(i) => String::unsafe_substring(exe, start=0, end=i)
+    None => @env.current_dir().unwrap_or(".")
+  }
 }
 
 ///|

--- a/modules/bit/src/cmd/bit/wbtest_env_lock_shared.mbt
+++ b/modules/bit/src/cmd/bit/wbtest_env_lock_shared.mbt
@@ -30,13 +30,29 @@ fn wbtest_resolve_real_git(repo_root : String) -> String {
 /// so prefer whichever exists (debug first, since that is the default build).
 fn wbtest_resolve_bit_exe(repo_root : String) -> String {
   let fs : &@bitcore.RepoFileSystem = OsFs::new()
-  let debug_path = repo_root +
-    "/_build/native/debug/build/mizchi/bit/cmd/bit/bit.exe"
-  let release_path = repo_root +
-    "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
-  if fs.is_file(debug_path) {
-    debug_path
-  } else {
-    release_path
+  let debug_rel = "/_build/native/debug/build/mizchi/bit/cmd/bit/bit.exe"
+  let release_rel = "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  // Candidate repo roots, most reliable first: a root derived from the running
+  // test executable path (independent of CWD, which `moon test` may set to the
+  // module dir), then the caller-supplied repo_root.
+  let roots : Array[String] = []
+  let exe = @sys.get_cli_args()[0]
+  match exe.find("/_build/") {
+    Some(i) => roots.push(String::unsafe_substring(exe, start=0, end=i))
+    None => ()
   }
+  roots.push(repo_root)
+  for root in roots {
+    let debug_path = root + debug_rel
+    if fs.is_file(debug_path) {
+      return debug_path
+    }
+    let release_path = root + release_rel
+    if fs.is_file(release_path) {
+      return release_path
+    }
+  }
+  // Not found anywhere: return the primary debug candidate so the caller's
+  // existence check fails with a clear, actionable path.
+  roots[0] + debug_rel
 }

--- a/modules/bit/src/cmd/bit/worktree_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/worktree_wbtest.mbt
@@ -23,12 +23,9 @@ async fn worktree_wbtest_collect_shim_git(
   // (moon run swallows non-zero exit codes)
   let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
-    let build_code = @process.run(
-      "moon",
-      ["build", "--target", "native", "--release"],
-      inherit_env=true,
+    fail(
+      "bit.exe not found at \{bit_exe}; build it with `moon build --target native modules/bit/src/cmd/bit` first",
     )
-    @test.assert_eq(build_code, 0)
   }
   fs.write_string(shim_moon, "#!/bin/sh\nset -eu\nexec '\{bit_exe}' \"$@\"\n")
   let chmod_code = @process.run("chmod", ["+x", shim_moon], inherit_env=true)

--- a/modules/bit/src/cmd/bit/worktree_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/worktree_wbtest.mbt
@@ -15,7 +15,7 @@ async fn worktree_wbtest_collect_shim_git(
 ) -> (Int, String, String) raise Error {
   worktree_wbtest_shim_lock.acquire()
   defer worktree_wbtest_shim_lock.release()
-  let repo_root = @env.current_dir().unwrap_or(".")
+  let repo_root = wbtest_resolve_repo_root()
   let shim_git = repo_root + "/tools/git-shim/bin/git"
   let shim_moon = "/tmp/bit-worktree-shim-moon.sh"
   let fs = OsFs::new()

--- a/modules/bit/src/cmd/bit/worktree_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/worktree_wbtest.mbt
@@ -21,7 +21,7 @@ async fn worktree_wbtest_collect_shim_git(
   let fs = OsFs::new()
   // Build the native binary first so exit codes propagate correctly
   // (moon run swallows non-zero exit codes)
-  let bit_exe = repo_root + "/_build/native/release/build/mizchi/bit/cmd/bit/bit.exe"
+  let bit_exe = wbtest_resolve_bit_exe(repo_root)
   if !fs.is_file(bit_exe) {
     let build_code = @process.run(
       "moon",

--- a/modules/bit_date/src/date_parse.mbt
+++ b/modules/bit_date/src/date_parse.mbt
@@ -108,10 +108,12 @@ pub fn parse_approxidate_iso8601(s : String) -> Int64 {
   let mut hour = 0
   let mut minute = 0
   let mut second = 0
-  if chars.length() >= 19 {
+  if chars.length() >= 16 {
     hour = parse_date_digits(chars, 11, 13)
     minute = parse_date_digits(chars, 14, 16)
-    second = parse_date_digits(chars, 17, 19)
+    if chars.length() >= 19 && chars[16] == ':' {
+      second = parse_date_digits(chars, 17, 19)
+    }
   }
   let days = days_since_epoch(year, month, day)
   days.to_int64() * 86400L +
@@ -137,10 +139,14 @@ pub fn parse_approxidate_iso_date(s : String) -> Int64? {
   let mut hour = 0
   let mut minute = 0
   let mut second = 0
-  if chars.length() >= 19 && (chars[10] == ' ' || chars[10] == 'T') {
+  // Accept both "HH:MM" (length >= 16) and "HH:MM:SS" (length >= 19); git
+  // permits a reflog date without an explicit seconds field.
+  if chars.length() >= 16 && (chars[10] == ' ' || chars[10] == 'T') {
     hour = parse_date_digits(chars, 11, 13)
     minute = parse_date_digits(chars, 14, 16)
-    second = parse_date_digits(chars, 17, 19)
+    if chars.length() >= 19 && chars[16] == ':' {
+      second = parse_date_digits(chars, 17, 19)
+    }
   }
   let days = days_since_epoch(year, month, day)
   Some(

--- a/modules/bit_lib/src/reflog.mbt
+++ b/modules/bit_lib/src/reflog.mbt
@@ -68,10 +68,16 @@ pub fn read_reflog(
 /// Parse a single reflog line.
 fn parse_reflog_line(line : String) -> ReflogEntry? {
   // Format: <old-sha> <new-sha> <name> <<email>> <timestamp> <tz>\t<message>
-  let tab_idx = line.find("\t")
-  guard tab_idx is Some(idx) else { return None }
-  let prefix = String::unsafe_substring(line, start=0, end=idx)
-  let message = String::unsafe_substring(line, start=idx + 1, end=line.length())
+  // git omits the tab + message entirely for messageless updates, so a line
+  // without a tab is valid and carries an empty message.
+  let (prefix, message) = match line.find("\t") {
+    Some(idx) =>
+      (
+        String::unsafe_substring(line, start=0, end=idx),
+        String::unsafe_substring(line, start=idx + 1, end=line.length()),
+      )
+    None => (line, "")
+  }
   // Parse prefix: old_sha new_sha author_name <author_email> timestamp tz
   let parts : Array[String] = []
   for p in prefix.split(" ") {
@@ -144,7 +150,15 @@ pub fn append_reflog(
     wfs.mkdir_p(parent_dir)
   }
   // Format: <old-sha> <new-sha> <name> <<email>> <timestamp> <tz>\t<message>\n
-  let entry = "\{old_id.to_hex()} \{new_id.to_hex()} \{author} <\{email}> \{timestamp} \{timezone}\t\{message}\n"
+  // git only emits the tab + message when the message is non-empty; an empty
+  // reason produces a line ending right after the timezone (matching
+  // log_ref_write_fd's `if (msg && *msg)` guard).
+  let prefix = "\{old_id.to_hex()} \{new_id.to_hex()} \{author} <\{email}> \{timestamp} \{timezone}"
+  let entry = if message.length() > 0 {
+    "\{prefix}\t\{message}\n"
+  } else {
+    "\{prefix}\n"
+  }
   // Append to file
   if rfs.is_file(reflog_path) {
     let existing = @utf8.decode_lossy(rfs.read_file(reflog_path)[:])

--- a/modules/bit_runtime/src/storage_runtime.mbt
+++ b/modules/bit_runtime/src/storage_runtime.mbt
@@ -203,11 +203,131 @@ fn storage_parse_git_env_timestamp(raw : String) -> Int64? {
         let parsed = @string.parse_int64(numeric) catch { _ => return None }
         Some(parsed)
       } else {
-        let parsed = @string.parse_int64(part) catch { _ => return None }
-        Some(parsed)
+        // Plain integer epoch first; otherwise fall back to a human-readable
+        // ISO date such as "2005-05-26 23:30" (git accepts these in
+        // GIT_AUTHOR_DATE / GIT_COMMITTER_DATE).
+        let parsed = @string.parse_int64(part) catch { _ => -1L }
+        if parsed >= 0L {
+          return Some(parsed)
+        }
+        storage_parse_iso_date_timestamp(raw)
       }
     None => None
   }
+}
+
+///|
+/// Parse a human-readable ISO date into a Unix timestamp (seconds).
+/// Formats: "2005-05-26 23:30", "2005-05-26T23:00", "2005-05-26 23:00:30",
+/// optionally followed by a timezone offset such as " -0500".
+fn storage_parse_iso_date_timestamp(raw : String) -> Int64? {
+  let s = raw.trim().to_owned()
+  if s.length() < 16 {
+    return None
+  }
+  if s[4] != '-' || s[7] != '-' {
+    return None
+  }
+  let sep = s[10]
+  if sep != ' ' && sep != 'T' {
+    return None
+  }
+  let year = @string.parse_int64(String::unsafe_substring(s, start=0, end=4)) catch {
+    _ => return None
+  }
+  let month = @string.parse_int64(String::unsafe_substring(s, start=5, end=7)) catch {
+    _ => return None
+  }
+  let day = @string.parse_int64(String::unsafe_substring(s, start=8, end=10)) catch {
+    _ => return None
+  }
+  let time_str = String::unsafe_substring(s, start=11, end=s.length())
+  let mut time_end = time_str.length()
+  for i = 0; i < time_str.length(); i = i + 1 {
+    let c = time_str[i]
+    if c == ' ' || c == '+' || c == '-' {
+      time_end = i
+      break
+    }
+  }
+  let time_part = String::unsafe_substring(time_str, start=0, end=time_end)
+  if time_part.length() < 5 || time_part[2] != ':' {
+    return None
+  }
+  let hour = @string.parse_int64(
+    String::unsafe_substring(time_part, start=0, end=2),
+  ) catch {
+    _ => return None
+  }
+  let minute = @string.parse_int64(
+    String::unsafe_substring(time_part, start=3, end=5),
+  ) catch {
+    _ => return None
+  }
+  let second = if time_part.length() >= 8 && time_part[5] == ':' {
+    @string.parse_int64(String::unsafe_substring(time_part, start=6, end=8)) catch {
+      _ => 0L
+    }
+  } else {
+    0L
+  }
+  let days = storage_days_from_epoch(year, month, day)
+  let mut ts = days * 86400L + hour * 3600L + minute * 60L + second
+  let after_time = String::unsafe_substring(s, start=11 + time_end, end=s.length())
+  ts = ts - storage_parse_iso_tz_offset_seconds(after_time)
+  Some(ts)
+}
+
+///|
+fn storage_parse_iso_tz_offset_seconds(s : String) -> Int64 {
+  let t = s.trim().to_owned()
+  if t.length() < 5 {
+    return 0L
+  }
+  let sign : Int64 = if t[0] == '-' {
+    -1L
+  } else if t[0] == '+' {
+    1L
+  } else {
+    return 0L
+  }
+  let (hh_str, mm_str) = if t.length() >= 6 && t[3] == ':' {
+    (
+      String::unsafe_substring(t, start=1, end=3),
+      String::unsafe_substring(t, start=4, end=6),
+    )
+  } else {
+    (
+      String::unsafe_substring(t, start=1, end=3),
+      String::unsafe_substring(t, start=3, end=5),
+    )
+  }
+  let hh = @string.parse_int64(hh_str) catch { _ => return 0L }
+  let mm = @string.parse_int64(mm_str) catch { _ => return 0L }
+  sign * (hh * 3600L + mm * 60L)
+}
+
+///|
+fn storage_days_from_epoch(year : Int64, month : Int64, day : Int64) -> Int64 {
+  let month_days : Array[Int64] = [
+    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
+  ]
+  let y = year
+  let m = month
+  let mut days = 365L * (y - 1970L)
+  if y > 1970L {
+    days = days + (y - 1969L) / 4L - (y - 1901L) / 100L + (y - 1601L) / 400L
+  } else {
+    days = days - (1970L - y) / 4L + (1970L - y) / 100L - (1970L - y) / 400L
+  }
+  days = days + month_days[(m - 1L).to_int()]
+  if m > 2L {
+    let is_leap = (y % 4L == 0L && y % 100L != 0L) || y % 400L == 0L
+    if is_leap {
+      days = days + 1L
+    }
+  }
+  days + day - 1L
 }
 
 ///|


### PR DESCRIPTION
#86 (git-compat) の続き。ref 系コマンドの git 非互換を実テスト（git 2.53 + bit native + strict shim）で潰した。

**結果:**
- `t6300-for-each-ref.sh`: **13 → 10**（252, 255, 256 pass）
- `t6302-for-each-ref-filter.sh`: **3 → 0**（全62 pass）
- `t1401-symbolic-ref.sh`: **7 → 1**（残りは reflog のみ）
- `t6301-for-each-ref-errors.sh`: 全6 pass（回帰なし）

## describe (t6300 252/255/256)
- `--match`/`--exclude`（2引数・`=`・複数指定）をパースし `@ignore.match_glob` でタグをフィルタ。
- タグオブジェクトを渡したらコミットまで peel してから describe（`Missing tree` 解消）。

## update-ref / symbolic-ref: 一階層 root/pseudo ref (t6302 2/4/5)
`ORIG_HEAD` 等の一階層 pseudoref を `invalid refname` で拒否していたのを、root-ref 構文（一階層・大文字/_/-）も許可。`--include-root-refs` の収集ロジックは元から正しく、fixture を作れず落ちていた。実 git と parity 確認済。

## symbolic-ref: delete/--short/recurse (t1401 5/8/9/21/23/24)
- `-d`: HEAD 削除拒否、missing/非 symbolic ref は `fatal: Cannot delete <name>, not a symbolic ref` で拒否し ref を保持（従来は任意の ref ファイルを削除・missing でも成功していた）。
- `--short`: git の prefix ルール（`refs/remotes/<x>/HEAD`→`<x>`、heads/tags/remotes、`refs/` フォールバック）で短縮。
- read: 既定で symref チェーンを辿り、`--no-recurse` で一段のみ。

## 残り（別機能・スコープ外）
- `t6300` 残り10: GPG `%(signature)` 検証一式（420–428）＋ GPG 署名 body/CRLF（317, 409）。実 GPG 検証が必要（bit は `%(signature)`→`"N"` スタブ）。
- `t1401` 残り1: `symbolic-ref -m` の reflog 書き込み（reflog 連携が必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM