### PR TITLE
chore(deps): bump mizchi/zlib 0.4.5 → 0.4.8 (−64% pack alloc)

### DIFF
--- a/modules/bit/moon.mod.json
+++ b/modules/bit/moon.mod.json
@@ -11,7 +11,7 @@
     "mizchi/x": "0.2.0",
     "bobzhang/toml": "0.1.7",
     "mizchi/libgit2": "0.1.0",
-    "mizchi/zlib": "0.4.5",
+    "mizchi/zlib": "0.4.8",
     "mizchi/experimental_crypto": "0.0.2",
     "mizchi/bitx_openpgp": "0.42.2",
     "mizchi/bit_apply": "0.42.2",

--- a/modules/bit_lib/moon.mod.json
+++ b/modules/bit_lib/moon.mod.json
@@ -20,7 +20,7 @@
     "mizchi/bit_types": "0.42.2",
     "mizchi/bit_utils": "0.42.2",
     "mizchi/bit_vfs": "0.42.2",
-    "mizchi/zlib": "0.4.5",
+    "mizchi/zlib": "0.4.8",
     "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },

--- a/modules/bit_object/moon.mod.json
+++ b/modules/bit_object/moon.mod.json
@@ -3,7 +3,7 @@
   "version": "0.42.2",
   "deps": {
     "mizchi/bit_hash": "0.42.2",
-    "mizchi/zlib": "0.4.5"
+    "mizchi/zlib": "0.4.8"
   },
   "repository": "https://github.com/mizchi/bit-vcs",
   "license": "Apache-2.0",

--- a/modules/bit_pack/moon.mod.json
+++ b/modules/bit_pack/moon.mod.json
@@ -8,7 +8,7 @@
     "mizchi/bit_types": "0.42.2",
     "mizchi/bit_protocol": "0.42.2",
     "mizchi/tempfile": "0.1.0",
-    "mizchi/zlib": "0.4.5",
+    "mizchi/zlib": "0.4.8",
     "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },

--- a/modules/bit_vfs/moon.mod.json
+++ b/modules/bit_vfs/moon.mod.json
@@ -9,7 +9,7 @@
     "mizchi/bit_osfs": "0.42.2",
     "mizchi/bit_repo": "0.42.2",
     "mizchi/bit_types": "0.42.2",
-    "mizchi/zlib": "0.4.5",
+    "mizchi/zlib": "0.4.8",
     "moonbitlang/async": "0.19.4",
     "moonbitlang/x": "0.4.40"
   },

--- a/modules/bitx_subdir/moon.mod.json
+++ b/modules/bitx_subdir/moon.mod.json
@@ -9,7 +9,7 @@
     "mizchi/bit_lib": "0.42.2",
     "mizchi/bit_types": "0.42.2",
     "mizchi/bit_vfs": "0.42.2",
-    "mizchi/zlib": "0.4.5"
+    "mizchi/zlib": "0.4.8"
   },
   "repository": "https://github.com/mizchi/bit-vcs",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Bumps the `mizchi/zlib` pin from **0.4.5 → 0.4.8** across every module that depends on it (`bit`, `bit_object`, `bit_pack`, `bit_lib`, `bit_vfs`, `bitx_subdir`).

0.4.8 lands the deflate per-symbol allocation reductions (the same ones surfaced while profiling bit's pack path):

- the symbol encoders (`fixed_lit_code` / `fixed_dist_code` / `length_code_info` / `dist_code_info`) now return a **packed `Int`** instead of a tuple — no per-symbol tuple boxing;
- `build_tokens` produces a packed **`Array[Int]`** instead of an `Array[DeflateToken]` enum — no per-token boxing;
- plus SIMD match-finding and adler32/crc32 paths (scalar fallbacks included).

## Measured effect

Allocation profile of the pack-objects-with-delta path (500 × ~200B blobs × 20 builds), `moon-pprof memprofile-native --sample-rate 1`, same workload before/after:

| | total bytes | allocations |
|---|---|---|
| zlib 0.4.5 | 3.93MB | 388,081 |
| **zlib 0.4.8** | **2.39MB** | **140,041** |
| | **−39%** | **−64%** |

Site-level: `zlib::fixed_lit_code` (was 887kB / 113,600 allocs) is **eliminated**; `zlib::build_tokens` drops 601kB / 123,600 → 156kB / 10,000 allocs (per-token enum boxing gone). The remaining top sites are now bit_pack's own (`Bytes::from_array`, `build_block_index`, `find_best_match`), not zlib.

## Testing

- `bit_pack` **72/72** pass, including the git-oracle pack/index fixtures that compare against real `git` output → packfile bytes unchanged.
- `bit_object` **27/27** pass (object compress/decompress round-trip).

## Scope

Dependency version bump only (6 × `moon.mod.json`, zlib version line). No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)