### PR TITLE
refactor(fallback): drop product-side git fallback for config/status, expiry-date, and log simplification

### DIFF
--- a/docs/git-compatibility.md
+++ b/docs/git-compatibility.md
@@ -110,8 +110,22 @@ The following are intentionally rejected with explicit standalone-mode errors (c
 
 ## Where Git Fallback Exists
 
-- Main `bit` command dispatch in `src/cmd/bit/main.mbt` does not auto-delegate unknown commands to system git.
-- Git fallback/delegation is implemented in the shim layer `tools/git-shim/bin/git`.
+The product binary is being moved off git fallback entirely; the shim layer is
+the only place fallback is expected to remain (for compatibility testing).
+
+- Main `bit` command dispatch in `src/cmd/bit/main.mbt` does not auto-delegate
+  unknown commands to system git. `config` and `status` are handled natively by
+  default; `should_delegate_to_real_git` only falls back when global config
+  injection (`-c` / `GIT_CONFIG_*`) is present and the shim cannot apply it.
+- `--no-git-fallback` is authoritative: it forbids every per-command delegation
+  (`blame`, `config`, `fetch`, `log`, `rebase`, `show`, `filter-branch`,
+  `add -i/-p`), which abort with an explicit standalone-mode error instead.
+- A few per-command paths still delegate when fallback is allowed: `config`
+  `--get-urlmatch` / `--blob` / `--includes`, `log`/`show` signature display and
+  SSH-format signatures, `rebase` complex/interactive-state modes, `blame`
+  unsupported args, `fetch` relative `--deepen`, and deprecated `filter-branch`.
+- Git fallback/delegation is otherwise implemented in the shim layer
+  `tools/git-shim/bin/git`.
   - The shim delegates to `SHIM_REAL_GIT` by default.
   - CI `git-compat` (`.github/workflows/ci.yml`) runs upstream `git/t` via this shim (`SHIM_REAL_GIT`, `SHIM_MOON`, `SHIM_CMDS`).
 

--- a/modules/bit/src/cmd/bit/blame.mbt
+++ b/modules/bit/src/cmd/bit/blame.mbt
@@ -13,6 +13,9 @@ fn resolve_real_git_for_blame() -> String {
 
 ///|
 async fn delegate_blame_to_real_git(args : Array[String], cwd : String) -> Unit {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git blame")
+  }
   let argv : Array[String] = ["blame"]
   for arg in args {
     argv.push(arg)

--- a/modules/bit/src/cmd/bit/config.mbt
+++ b/modules/bit/src/cmd/bit/config.mbt
@@ -2126,6 +2126,9 @@ fn resolve_real_git_for_config() -> String {
 
 ///|
 async fn delegate_config_to_real_git(args : Array[String]) -> Unit {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git config")
+  }
   let real_git = resolve_real_git_for_config()
   let argv : Array[String] = ["config"]
   for arg in args {

--- a/modules/bit/src/cmd/bit/config.mbt
+++ b/modules/bit/src/cmd/bit/config.mbt
@@ -218,10 +218,6 @@ async fn handle_config(args : Array[String]) -> Unit raise Error {
     Some("color") => get_color = true
     _ => ()
   }
-  if get_expiry_date {
-    delegate_config_to_real_git(args)
-    return
-  }
   if saw_get_mode && saw_get_all_mode {
     eprint_line(
       "error: options '--get-all' and '--get' cannot be used together",
@@ -2014,17 +2010,27 @@ fn format_config_output_value(
       val
     }
   } else if get_expiry_date {
-    let trimmed = val.trim().to_owned().to_lower()
-    if trimmed == "never" || trimmed == "false" {
+    let trimmed = val.trim().to_owned()
+    let normalized = trimmed.to_lower()
+    if normalized == "never" || normalized == "false" {
       "0"
+    } else if normalized == "now" || normalized == "all" {
+      // git maps "now"/"all" to TIME_MAX so that everything is treated as
+      // expired; mirror its decimal representation of UINT64_MAX.
+      "18446744073709551615"
     } else {
-      let key_for_error = match key {
-        Some(k) => k
-        None => ""
+      match @date_parse.parse_approxidate(trimmed, get_current_timestamp()) {
+        Some(ts) => ts.to_string()
+        None => {
+          let key_for_error = match key {
+            Some(k) => k
+            None => ""
+          }
+          raise @bitcore.GitError::InvalidObject(
+            "'\{val}' for '\{key_for_error}' is not a valid timestamp",
+          )
+        }
       }
-      raise @bitcore.GitError::InvalidObject(
-        "'\{val}' for '\{key_for_error}' is not a valid timestamp",
-      )
     }
   } else if get_color {
     match parse_config_color(val) {

--- a/modules/bit/src/cmd/bit/diff.mbt
+++ b/modules/bit/src/cmd/bit/diff.mbt
@@ -77,37 +77,6 @@ fn get_config_override(key : String) -> String? {
 }
 
 ///|
-fn resolve_real_git_for_diff() -> String {
-  match @sys.get_env_var("SHIM_REAL_GIT") {
-    Some(path) =>
-      if path.length() > 0 {
-        path
-      } else {
-        @sys.get_env_var("GIT_SHIM_REAL_GIT").unwrap_or("/usr/bin/git")
-      }
-    None => @sys.get_env_var("GIT_SHIM_REAL_GIT").unwrap_or("/usr/bin/git")
-  }
-}
-
-///|
-async fn delegate_diff_to_real_git(args : Array[String]) -> Unit {
-  let real_git = resolve_real_git_for_diff()
-  let argv : Array[String] = ["diff"]
-  for arg in args {
-    argv.push(arg)
-  }
-  let code = @process.run(
-    real_git,
-    argv,
-    inherit_env=true,
-    stdin=@stdio.stdin,
-    stdout=@stdio.stdout,
-    stderr=@stdio.stderr,
-  )
-  @sys.exit(code)
-}
-
-///|
 fn diff_last_config_value(
   fs : &@bitcore.RepoFileSystem,
   config_path : String,
@@ -142,14 +111,6 @@ fn diff_noprefix_enabled_from_config(
       }
     }
   }
-}
-
-///|
-fn diff_need_real_git(
-  _fs : &@bitcore.RepoFileSystem,
-  _git_dir : String,
-) -> Bool {
-  false
 }
 
 ///|
@@ -1624,10 +1585,6 @@ async fn handle_diff(args : Array[String]) -> Unit raise Error {
   let fs = OsFs::new()
   let rfs : &@bitcore.RepoFileSystem = fs
   let git_dir = resolve_git_dir(rfs, root)
-  if diff_need_real_git(rfs, git_dir) {
-    delegate_diff_to_real_git(args)
-    return
-  }
   let repo_git_dir = resolve_submodule_common_git_dir(rfs, git_dir)
   let mut submodule_mode = false
   let mut range_spec : String? = None

--- a/modules/bit/src/cmd/bit/fetch.mbt
+++ b/modules/bit/src/cmd/bit/fetch.mbt
@@ -543,6 +543,9 @@ fn collect_commit_tree_modes(
 
 ///|
 async fn delegate_fetch_to_real_git(args : Array[String]) -> Unit raise Error {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git fetch")
+  }
   let argv : Array[String] = ["fetch"]
   for arg in args {
     argv.push(arg)

--- a/modules/bit/src/cmd/bit/filter_branch.mbt
+++ b/modules/bit/src/cmd/bit/filter_branch.mbt
@@ -2,6 +2,9 @@
 
 ///|
 async fn handle_filter_branch(args : Array[String]) -> Unit raise Error {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git filter-branch")
+  }
   eprint_line(
     "WARNING: git filter-branch is deprecated. Use git-filter-repo instead.",
   )

--- a/modules/bit/src/cmd/bit/interactive.mbt
+++ b/modules/bit/src/cmd/bit/interactive.mbt
@@ -54,6 +54,9 @@ async fn run_add_interactive(
   args : Array[String],
   runner? : (async (Array[String]) -> Int noraise)? = None,
 ) -> Unit raise Error {
+  if runner is None && git_fallback_disabled() {
+    exit_no_git_fallback("git add --interactive")
+  }
   let code = match runner {
     Some(run) => run(args)
     None => default_add_interactive_runner(args)

--- a/modules/bit/src/cmd/bit/log.mbt
+++ b/modules/bit/src/cmd/bit/log.mbt
@@ -303,6 +303,8 @@ fn log_need_real_git(args : Array[String], git_dir? : String = "") -> Bool {
   // --ancestry-path (with/without =<rev>, including the --graph combination) and
   // --simplify-by-decoration are implemented natively by the walker. The
   // remaining flags below are not yet supported and still fall back.
+  // --show-pulls needs git's full parent-rewriting simplification to decide
+  // which "pull" merges to re-include, which the native walker does not do yet.
   for arg in args {
     if arg == "--show-pulls" || arg == "--full-diff" {
       return true
@@ -2786,6 +2788,48 @@ fn log_commit_matches_simplify_merges(
 }
 
 ///|
+/// Decide whether a merge is visible under default path-limited history
+/// simplification. Returns None for non-merge commits (caller falls back to the
+/// regular first-parent pathspec test). For a merge, git hides it when it is
+/// TREESAME to any parent on the pathspec (history follows that parent instead).
+fn log_merge_pathspec_visibility(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  db : @bitlib.ObjectDb,
+  commit_id : @bitcore.ObjectId,
+  pathspecs : Array[String],
+) -> Bool? raise Error {
+  let obj = db.get(rfs, commit_id)
+  guard obj is Some(o) else { return None }
+  if o.obj_type != @bitcore.ObjectType::Commit {
+    return None
+  }
+  let info = @bitcore.parse_commit(o.data)
+  let parents = log_resolve_parents(rfs, git_dir, commit_id, info.parents)
+  if parents.length() < 2 {
+    return None
+  }
+  for parent in parents {
+    match log_get_commit_tree(db, rfs, parent) {
+      Some(parent_tree) =>
+        if log_trees_same_for_pathspecs(
+            rfs,
+            db,
+            parent_tree,
+            info.tree,
+            pathspecs,
+          ) {
+          // TREESAME to this parent on the pathspec: history follows it and the
+          // merge itself is simplified away.
+          return Some(false)
+        }
+      None => ()
+    }
+  }
+  Some(true)
+}
+
+///|
 fn log_commit_matches_history_filters(
   rfs : &@bitcore.RepoFileSystem,
   git_dir : String,
@@ -2797,11 +2841,30 @@ fn log_commit_matches_history_filters(
   detect_renames : Bool,
   detect_copies : Bool,
   simplify_merges : Bool,
+  full_history~ : Bool = false,
 ) -> Bool raise Error {
   if !log_commit_matches_simplify_merges(
       rfs, git_dir, db, commit_id, pathspecs, simplify_merges,
     ) {
     return false
+  }
+  // Default path-limited history simplification hides merges that are TREESAME
+  // to a parent on the pathspec; --full-history disables it. For non-merges this
+  // returns None and we fall back to the regular first-parent pathspec test.
+  if pathspecs.length() > 0 && !full_history {
+    match
+      log_merge_pathspec_visibility(rfs, git_dir, db, commit_id, pathspecs) {
+      Some(visible) => {
+        if !visible {
+          return false
+        }
+        return log_commit_matches_diff_filter(
+          rfs, git_dir, db, commit_id, include_bits, exclude, detect_renames,
+          detect_copies,
+        )
+      }
+      None => ()
+    }
   }
   if !log_commit_matches_pathspecs(rfs, git_dir, db, commit_id, pathspecs) {
     return false
@@ -4761,6 +4824,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         if !log_commit_matches_history_filters(
             rfs, git_dir, db, id, pathspecs, diff_filter_include, diff_filter_exclude,
             detect_renames, detect_copies, simplify_merges,
+            full_history~,
           ) {
           continue
         }
@@ -4938,6 +5002,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
             detect_renames,
             detect_copies,
             simplify_merges,
+            full_history~,
           ) {
           continue
         }
@@ -5122,6 +5187,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         if !log_commit_matches_history_filters(
             rfs, git_dir, db, id, pathspecs, diff_filter_include, diff_filter_exclude,
             detect_renames, detect_copies, simplify_merges,
+            full_history~,
           ) {
           continue
         }
@@ -5186,6 +5252,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         if !log_commit_matches_history_filters(
             rfs, git_dir, db, id, pathspecs, diff_filter_include, diff_filter_exclude,
             detect_renames, detect_copies, simplify_merges,
+            full_history~,
           ) {
           continue
         }
@@ -5498,6 +5565,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
             detect_renames,
             detect_copies,
             simplify_merges,
+            full_history~,
           ) {
           continue
         }
@@ -5582,6 +5650,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
             detect_renames,
             detect_copies,
             simplify_merges,
+            full_history~,
           ) {
           continue
         }

--- a/modules/bit/src/cmd/bit/log.mbt
+++ b/modules/bit/src/cmd/bit/log.mbt
@@ -155,6 +155,9 @@ fn is_short_count_flag(arg : String) -> Bool {
 
 ///|
 async fn delegate_log_to_real_git(args : Array[String], cwd : String) -> Unit {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git log")
+  }
   let argv : Array[String] = ["log"]
   for arg in args {
     argv.push(arg)

--- a/modules/bit/src/cmd/bit/log.mbt
+++ b/modules/bit/src/cmd/bit/log.mbt
@@ -300,25 +300,11 @@ fn log_need_real_git(args : Array[String], git_dir? : String = "") -> Bool {
       return true
     }
   }
-  let mut has_graph = false
-  let mut has_ancestry_path = false
+  // --ancestry-path (with/without =<rev>, including the --graph combination) and
+  // --simplify-by-decoration are implemented natively by the walker. The
+  // remaining flags below are not yet supported and still fall back.
   for arg in args {
-    if arg.has_prefix("--ancestry-path=") {
-      return true
-    }
-    if arg == "--graph" {
-      has_graph = true
-    }
-    if arg == "--ancestry-path" {
-      has_ancestry_path = true
-    }
-  }
-  if has_graph && has_ancestry_path {
-    return true
-  }
-  for arg in args {
-    if arg == "--simplify-by-decoration" ||
-      arg == "--show-pulls" ||
+    if arg == "--show-pulls" ||
       arg == "--exclude-first-parent-only" ||
       arg == "--full-diff" {
       return true

--- a/modules/bit/src/cmd/bit/log.mbt
+++ b/modules/bit/src/cmd/bit/log.mbt
@@ -304,9 +304,7 @@ fn log_need_real_git(args : Array[String], git_dir? : String = "") -> Bool {
   // --simplify-by-decoration are implemented natively by the walker. The
   // remaining flags below are not yet supported and still fall back.
   for arg in args {
-    if arg == "--show-pulls" ||
-      arg == "--exclude-first-parent-only" ||
-      arg == "--full-diff" {
+    if arg == "--show-pulls" || arg == "--full-diff" {
       return true
     }
   }
@@ -4060,6 +4058,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
   let decoration_exclude_patterns : Array[String] = []
   let mut clear_decorations = false
   let mut simplify_by_decoration = false
+  let mut exclude_first_parent_only = false
   let mut full_history = false
   let mut simplify_merges = false
   let diff_filter_include : Map[String, Bool] = {}
@@ -4153,6 +4152,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         clear_decorations = true
       }
       "--simplify-by-decoration" => simplify_by_decoration = true
+      "--exclude-first-parent-only" => exclude_first_parent_only = true
       "--raw" => show_raw = true
       "--stat" => show_stat = true
       "-p" | "--patch" => show_patch = true
@@ -4834,7 +4834,14 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
       let exclude_ids : Map[String, Bool] = {}
       for spec in range_excludes {
         match @bitrepo.rev_parse(rfs, git_dir, spec) {
-          Some(id) => walk_commits_to_map(fs, git_dir, id, exclude_ids)
+          Some(id) =>
+            walk_commits_to_map(
+              fs,
+              git_dir,
+              id,
+              exclude_ids,
+              first_parent=exclude_first_parent_only,
+            )
           None if ignore_missing => ()
           None =>
             raise @bitcore.GitError::InvalidObject("Unknown revision: " + spec)
@@ -4851,7 +4858,13 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
           (Some(left_id), Some(right_id)) =>
             match log_find_merge_base(rfs, git_dir, left_id, right_id) {
               Some(base_id) =>
-                walk_commits_to_map(fs, git_dir, base_id, exclude_ids)
+                walk_commits_to_map(
+                  fs,
+                  git_dir,
+                  base_id,
+                  exclude_ids,
+                  first_parent=exclude_first_parent_only,
+                )
               None => ()
             }
           _ if ignore_missing => ()
@@ -5334,7 +5347,14 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
     let exclude_ids : Map[String, Bool] = {}
     for spec in range_excludes {
       match @bitrepo.rev_parse(rfs, git_dir, spec) {
-        Some(id) => walk_commits_to_map(fs, git_dir, id, exclude_ids)
+        Some(id) =>
+          walk_commits_to_map(
+            fs,
+            git_dir,
+            id,
+            exclude_ids,
+            first_parent=exclude_first_parent_only,
+          )
         None if ignore_missing => ()
         None =>
           raise @bitcore.GitError::InvalidObject("Unknown revision: " + spec)
@@ -5351,7 +5371,13 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         (Some(left_id), Some(right_id)) =>
           match log_find_merge_base(rfs, git_dir, left_id, right_id) {
             Some(base_id) =>
-              walk_commits_to_map(fs, git_dir, base_id, exclude_ids)
+              walk_commits_to_map(
+                fs,
+                git_dir,
+                base_id,
+                exclude_ids,
+                first_parent=exclude_first_parent_only,
+              )
             None => ()
           }
         _ if ignore_missing => ()

--- a/modules/bit/src/cmd/bit/log_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/log_wbtest.mbt
@@ -185,13 +185,13 @@ test "log: ancestry and remaining simplify options fallback boundaries" {
   assert_false(log_need_real_git(["--stdin"]))
   assert_false(log_need_real_git(["--boundary"]))
   assert_false(log_need_real_git(["--ancestry-path", "A..B"]))
-  assert_true(log_need_real_git(["--ancestry-path=topic", "B"]))
-  assert_true(log_need_real_git(["--graph", "--ancestry-path", "A..B"]))
-  assert_true(log_need_real_git(["--simplify-by-decoration"]))
+  assert_false(log_need_real_git(["--ancestry-path=topic", "B"]))
+  assert_false(log_need_real_git(["--graph", "--ancestry-path", "A..B"]))
+  assert_false(log_need_real_git(["--simplify-by-decoration"]))
   assert_false(log_need_real_git(["--simplify-merges"]))
   assert_false(log_need_real_git(["--full-history"]))
   assert_true(log_need_real_git(["--show-pulls"]))
-  assert_true(log_need_real_git(["--exclude-first-parent-only"]))
+  assert_false(log_need_real_git(["--exclude-first-parent-only"]))
   assert_false(log_need_real_git(["--show-signature", "HEAD"]))
   assert_true(log_need_real_git(["--show-signature", "--oneline", "HEAD"]))
   assert_true(log_need_real_git(["--show-signature", "--graph", "HEAD"]))
@@ -268,7 +268,11 @@ async test "log: simplify-merges drops path merge that is TREESAME to a parent" 
   guard base_id is Some(base_commit) else { fail("expected base commit") }
   let include_bits : Map[String, Bool] = {}
   let exclude_bits : Map[String, Bool] = {}
-  assert_true(
+  // Default path-limited history simplification also drops the merge: it is
+  // TREESAME to its second parent (side) on `target`, so history follows that
+  // parent. (--full-history would keep it; that is covered by the git oracle
+  // assertions above.)
+  assert_false(
     log_commit_matches_history_filters(
       fs,
       git_dir,
@@ -282,6 +286,7 @@ async test "log: simplify-merges drops path merge that is TREESAME to a parent" 
       false,
     ),
   )
+  // --simplify-merges drops it as well.
   assert_false(
     log_commit_matches_history_filters(
       fs,

--- a/modules/bit/src/cmd/bit/main.mbt
+++ b/modules/bit/src/cmd/bit/main.mbt
@@ -1042,9 +1042,10 @@ fn should_delegate_to_real_git(
     can_handle_global_config_in_shim(opts)
   match opts.subcmd {
     Some(cmd) =>
-      if cmd == "config" || cmd == "status" {
-        true
-      } else if cmd == "worktree" ||
+      // config/status are handled natively by default; like every other
+      // command they only fall back when global config injection (-c /
+      // GIT_CONFIG_*) is present and the shim cannot apply it itself.
+      if cmd == "worktree" ||
         cmd == "submodule" ||
         cmd == "submodule--helper" {
         false

--- a/modules/bit/src/cmd/bit/main.mbt
+++ b/modules/bit/src/cmd/bit/main.mbt
@@ -751,6 +751,14 @@ async fn run_main_for_args(args : Array[String]) -> Unit {
       _ => continue
     }
   }
+  // Record `--no-git-fallback` so per-command handlers can refuse to delegate
+  // to a real git binary instead of silently falling back.
+  for arg in args {
+    if arg == "--no-git-fallback" {
+      @sys.set_env_var("BIT_NO_GIT_FALLBACK", "1")
+      break
+    }
+  }
   let opts = parse_global_options(args)
   if should_delegate_to_real_git(args, opts) {
     delegate_to_real_git_original_args(args)
@@ -876,6 +884,27 @@ fn missing_global_cwd_error(
   }
 }
 
+///| Returns true when the user passed `--no-git-fallback`, forbidding any
+/// delegation to a real `git` binary. The flag is recorded as an environment
+/// variable by `run_main_for_args` so per-command handlers can consult it
+/// without threading global options through every dispatch path.
+fn git_fallback_disabled() -> Bool {
+  match @sys.get_env_var("BIT_NO_GIT_FALLBACK") {
+    Some(value) => value == "1"
+    None => false
+  }
+}
+
+///| Abort with an explicit standalone-mode error instead of delegating to a
+/// real `git` binary. Called from per-command delegation paths when
+/// `--no-git-fallback` forbids fallback.
+async fn exit_no_git_fallback(what : String) -> Unit {
+  eprint_line(
+    "fatal: '\{what}' requires falling back to real git, which is disabled by --no-git-fallback (not supported in standalone mode)",
+  )
+  @sys.exit(128)
+}
+
 ///|
 fn resolve_real_git_for_dispatch() -> String {
   match @sys.get_env_var("SHIM_REAL_GIT") {
@@ -891,6 +920,9 @@ fn resolve_real_git_for_dispatch() -> String {
 
 ///|
 async fn delegate_to_real_git_original_args(args : Array[String]) -> Unit {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git")
+  }
   if args.length() <= 1 {
     return
   }
@@ -987,10 +1019,8 @@ fn should_delegate_to_real_git(
   args : Array[String],
   opts : GlobalOptions,
 ) -> Bool {
-  for arg in args {
-    if arg == "--no-git-fallback" {
-      return false
-    }
+  if git_fallback_disabled() {
+    return false
   }
   let has_global_config = has_global_config_injection(args)
   let has_env_parameters = match @sys.get_env_var("GIT_CONFIG_PARAMETERS") {

--- a/modules/bit/src/cmd/bit/main_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/main_wbtest.mbt
@@ -85,6 +85,28 @@ test "main: unsupported -c overrides still delegate" {
 }
 
 ///|
+test "main: config and status stay native without config injection" {
+  for cmd in ["config", "status"] {
+    let opts = parse_global_options(["bit", cmd])
+    assert_false(should_delegate_to_real_git(["bit", cmd], opts))
+  }
+}
+
+///|
+test "main: config and status still delegate under config injection" {
+  let prev = @sys.get_env_var("GIT_CONFIG_PARAMETERS")
+  @sys.set_env_var("GIT_CONFIG_PARAMETERS", "'core.editor'='vim'")
+  for cmd in ["config", "status"] {
+    let opts = parse_global_options(["bit", cmd])
+    assert_true(should_delegate_to_real_git(["bit", cmd], opts))
+  }
+  match prev {
+    Some(value) => @sys.set_env_var("GIT_CONFIG_PARAMETERS", value)
+    None => @sys.unset_env_var("GIT_CONFIG_PARAMETERS")
+  }
+}
+
+///|
 test "main: worktree stays in shim without config overrides" {
   let opts = parse_global_options(["bit", "worktree", "add", "wt", "-"])
   assert_false(

--- a/modules/bit/src/cmd/bit/merge.mbt
+++ b/modules/bit/src/cmd/bit/merge.mbt
@@ -1,14 +1,4 @@
 ///|
-fn merge_requires_real_git(
-  args : Array[String],
-  git_dir? : String = "",
-) -> Bool {
-  ignore(args)
-  ignore(git_dir)
-  false
-}
-
-///|
 async fn merge_write_commit_object(
   fs : OsFs,
   root : String,
@@ -73,23 +63,6 @@ async fn merge_rewrite_signed_commit(
 }
 
 ///|
-async fn delegate_merge_to_real_git(args : Array[String]) -> Unit {
-  let argv : Array[String] = ["merge"]
-  for arg in args {
-    argv.push(arg)
-  }
-  let code = @process.run(
-    resolve_real_git_for_dispatch(),
-    argv,
-    inherit_env=true,
-    stdin=@stdio.stdin,
-    stdout=@stdio.stdout,
-    stderr=@stdio.stderr,
-  )
-  @sys.exit(code)
-}
-
-///|
 fn merge_write_pending_state(
   fs : &@bitcore.FileSystem,
   git_dir : String,
@@ -106,10 +79,6 @@ fn merge_write_pending_state(
 async fn handle_merge(args : Array[String]) -> Unit raise Error {
   let root = get_work_root()
   let git_dir = root + "/.git"
-  if merge_requires_real_git(args, git_dir~) {
-    delegate_merge_to_real_git(args)
-    return
-  }
   let fs = OsFs::new()
   let rfs : &@bitcore.RepoFileSystem = fs
   check_and_exit_unsupported_attrs(root)

--- a/modules/bit/src/cmd/bit/merge_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/merge_wbtest.mbt
@@ -11,15 +11,6 @@ test "split_cmdline quote validation" {
 }
 
 ///|
-test "merge: signing args handled natively" {
-  assert_false(merge_requires_real_git(["-S", "side"]))
-  assert_false(merge_requires_real_git(["--gpg-sign", "side"]))
-  assert_false(merge_requires_real_git(["--gpg-sign=key", "side"]))
-  assert_false(merge_requires_real_git(["--no-gpg-sign", "side"]))
-  assert_false(merge_requires_real_git(["side"]))
-}
-
-///|
 async test "merge: -S stores gpgsig header on merge commit" {
   @bitnative.init_native_io()
   cmd_bit_wbtest_env_lock.acquire()

--- a/modules/bit/src/cmd/bit/rebase.mbt
+++ b/modules/bit/src/cmd/bit/rebase.mbt
@@ -3,6 +3,9 @@ async fn delegate_rebase_to_real_git(
   args : Array[String],
   cwd : String,
 ) -> Unit {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git rebase")
+  }
   let argv : Array[String] = ["rebase"]
   for arg in args {
     argv.push(arg)

--- a/modules/bit/src/cmd/bit/rev_list.mbt
+++ b/modules/bit/src/cmd/bit/rev_list.mbt
@@ -1260,6 +1260,7 @@ fn walk_commits_to_map(
   git_dir : String,
   start : @bitcore.ObjectId,
   out : Map[String, Bool],
+  first_parent? : Bool = false,
 ) -> Unit {
   let db = @bitlib.ObjectDb::load(fs, git_dir) catch { _ => return () }
   let queue : Array[@bitcore.ObjectId] = [start]
@@ -1271,13 +1272,21 @@ fn walk_commits_to_map(
     }
     out[hex] = true
     match rev_list_commit_parents(db, fs, id) {
-      Some(parents) =>
-        for parent in parents {
+      Some(parents) => {
+        // For --exclude-first-parent-only the exclusion walk follows only the
+        // first parent when crossing a merge.
+        let parents_to_walk = if first_parent && parents.length() > 0 {
+          [parents[0]]
+        } else {
+          parents
+        }
+        for parent in parents_to_walk {
           let phex = parent.to_hex()
           if !out.contains(phex) {
             queue.push(parent)
           }
         }
+      }
       None => ()
     }
   }

--- a/modules/bit/src/cmd/bit/rev_list.mbt
+++ b/modules/bit/src/cmd/bit/rev_list.mbt
@@ -1,33 +1,6 @@
 ///| Pack handlers: rev-list, verify-pack, unpack-objects, bundle
 
 ///|
-async fn delegate_rev_list_to_real_git(
-  args : Array[String],
-  cwd : String,
-) -> Unit {
-  let argv : Array[String] = ["rev-list"]
-  for arg in args {
-    argv.push(arg)
-  }
-  let code = @process.run(
-    resolve_real_git_for_dispatch(),
-    argv,
-    inherit_env=true,
-    cwd~,
-    stdin=@stdio.stdin,
-    stdout=@stdio.stdout,
-    stderr=@stdio.stderr,
-  )
-  @sys.exit(code)
-}
-
-///|
-fn rev_list_requires_real_git(args : Array[String]) -> Bool {
-  ignore(args)
-  false
-}
-
-///|
 fn rev_list_config_get(
   git_dir : String,
   dotted_key : String,
@@ -76,11 +49,6 @@ async fn rev_list_write_text(
 
 ///|
 async fn handle_rev_list(args : Array[String]) -> Unit raise Error {
-  let cwd = @env.current_dir().unwrap_or(".")
-  if rev_list_requires_real_git(args) {
-    delegate_rev_list_to_real_git(args, cwd)
-    return
-  }
   let fs = OsFs::new()
   let git_dir = find_git_dir(fs)
   check_commit_graph_paranoia(fs, git_dir)

--- a/modules/bit/src/cmd/bit/rev_list_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/rev_list_wbtest.mbt
@@ -22,14 +22,6 @@ test "rev-list: negative max-count is treated as unlimited" {
 }
 
 ///|
-test "rev-list: cherry options stay on native implementation" {
-  assert_false(rev_list_requires_real_git(["--cherry-pick", "A...B"]))
-  assert_false(rev_list_requires_real_git(["--cherry-mark", "A...B"]))
-  assert_false(rev_list_requires_real_git(["--cherry", "A...B"]))
-  assert_false(rev_list_requires_real_git(["--left-right", "A...B"]))
-}
-
-///|
 async fn rev_list_test_init_repo(
   root : String,
   repo_dir : String,

--- a/modules/bit/src/cmd/bit/show.mbt
+++ b/modules/bit/src/cmd/bit/show.mbt
@@ -135,6 +135,9 @@ fn show_requires_real_git(args : Array[String], git_dir? : String = "") -> Bool 
 
 ///|
 async fn delegate_show_to_real_git(args : Array[String]) -> Unit {
+  if git_fallback_disabled() {
+    exit_no_git_fallback("git show")
+  }
   let argv = ["show"]
   for arg in args {
     argv.push(arg)

--- a/modules/bit_date/src/date_parse.mbt
+++ b/modules/bit_date/src/date_parse.mbt
@@ -261,11 +261,46 @@ pub fn parse_approxidate_relative(s : String, now : Int64) -> Int64? {
   None
 }
 
+///| Parse git's raw epoch date form `@<seconds>`, optionally followed by a
+/// timezone such as ` +0000`. The timezone offset does not change the epoch
+/// value git reports, so it is accepted but ignored. Returns None when the
+/// string is not in this form.
+pub fn parse_approxidate_epoch(s : String) -> Int64? {
+  let chars = s.to_array()
+  if chars.length() < 2 || chars[0] != '@' {
+    return None
+  }
+  let mut i = 1
+  let mut result = 0L
+  let mut found = false
+  while i < chars.length() && chars[i] >= '0' && chars[i] <= '9' {
+    result = result * 10L + (chars[i].to_int() - '0'.to_int()).to_int64()
+    found = true
+    i += 1
+  }
+  if !found {
+    return None
+  }
+  // Skip whitespace before an optional timezone, then ensure the only trailing
+  // content is a +HHMM / -HHMM offset.
+  while i < chars.length() && (chars[i] == ' ' || chars[i] == '\t') {
+    i += 1
+  }
+  if i < chars.length() && chars[i] != '+' && chars[i] != '-' {
+    return None
+  }
+  Some(result)
+}
+
 ///|
 /// Parse a date string trying multiple formats: ISO 8601, relative, human-readable, YYYY-MM-DD.
 /// Takes the current timestamp for relative date resolution.
 pub fn parse_approxidate(date_str : String, now : Int64) -> Int64? {
   let s = date_str
+  match parse_approxidate_epoch(s) {
+    Some(ts) => return Some(ts)
+    None => ()
+  }
   if s.find("T") is Some(_) {
     let ts = parse_approxidate_iso8601(s)
     if ts > 0L {

--- a/modules/bit_date/src/date_parse_test.mbt
+++ b/modules/bit_date/src/date_parse_test.mbt
@@ -55,3 +55,22 @@ test "parse_approxidate human readable" {
   let expected = @bit_date.days_since_epoch(2000, 1, 1).to_int64() * 86400L
   @test.assert_eq(result.unwrap(), expected)
 }
+
+///|
+test "parse_approxidate_epoch" {
+  @test.assert_eq(@bit_date.parse_approxidate_epoch("@1234567890"), Some(1234567890L))
+  @test.assert_eq(
+    @bit_date.parse_approxidate_epoch("@1234567890 +0000"),
+    Some(1234567890L),
+  )
+  @test.assert_eq(
+    @bit_date.parse_approxidate_epoch("@1117150200 -0500"),
+    Some(1117150200L),
+  )
+  // Not the epoch form.
+  @test.assert_eq(@bit_date.parse_approxidate_epoch("1234567890"), None)
+  @test.assert_eq(@bit_date.parse_approxidate_epoch("@"), None)
+  @test.assert_eq(@bit_date.parse_approxidate_epoch("@12abc"), None)
+  // parse_approxidate dispatches to the epoch form.
+  @test.assert_eq(@bit_date.parse_approxidate("@1234567890", 0L), Some(1234567890L))
+}

--- a/modules/bit_date/src/pkg.generated.mbti
+++ b/modules/bit_date/src/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub fn month_name_to_number(String) -> Int?
 
 pub fn parse_approxidate(String, Int64) -> Int64?
 
+pub fn parse_approxidate_epoch(String) -> Int64?
+
 pub fn parse_approxidate_human(String) -> Int64?
 
 pub fn parse_approxidate_iso8601(String) -> Int64

--- a/t/t0005-fallback.sh
+++ b/t/t0005-fallback.sh
@@ -607,6 +607,19 @@ test_expect_success 'filter-branch is explicitly unsupported with --no-git-fallb
     )
 '
 
+test_expect_success 'config --type=expiry-date is handled natively with --no-git-fallback' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        git_cmd config gc.x never &&
+        test "$(git_cmd config --type=expiry-date --get gc.x)" = "0" &&
+        git_cmd config gc.y now &&
+        test "$(git_cmd config --type=expiry-date --get gc.y)" = "18446744073709551615" &&
+        git_cmd config gc.z "@1234567890 +0000" &&
+        test "$(git_cmd config --type=expiry-date --get gc.z)" = "1234567890"
+    )
+'
+
 test_expect_success 'config --get-urlmatch is explicitly unsupported with --no-git-fallback' '
     git_cmd init repo &&
     (

--- a/t/t0005-fallback.sh
+++ b/t/t0005-fallback.sh
@@ -683,4 +683,37 @@ test_expect_success 'log --full-diff stays explicitly unsupported with --no-git-
     )
 '
 
+test_expect_success 'log -- <path> simplifies away a pull merge (default history simplification)' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        echo 0 >base && git_cmd add base && git_cmd commit -q -m c0 &&
+        main="$(git_cmd rev-parse --abbrev-ref HEAD)" &&
+        git_cmd checkout -q -b topic &&
+        echo a >foo && git_cmd add foo && git_cmd commit -q -m t_foo &&
+        git_cmd checkout -q "$main" &&
+        echo 1 >base && git_cmd add base && git_cmd commit -q -m m_base &&
+        git_cmd merge -q --no-ff topic -m merge_pulls_foo &&
+        echo 2 >base && git_cmd add base && git_cmd commit -q -m m_base2 &&
+        git_cmd log --pretty=%s -- foo >foo.out &&
+        printf "t_foo\n" >foo.expect &&
+        test_cmp foo.expect foo.out &&
+        # --full-history keeps the pull merge visible.
+        git_cmd log --pretty=%s --full-history -- foo >full.out &&
+        grep -qx merge_pulls_foo full.out
+    )
+'
+
+test_expect_success 'log --show-pulls stays explicitly unsupported with --no-git-fallback' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        echo hello >a.txt &&
+        git_cmd add a.txt &&
+        git_cmd commit -m "first commit" &&
+        test_must_fail git_cmd log --show-pulls -- a.txt >out 2>err &&
+        grep -Eiq "standalone|not supported|no-git-fallback" err
+    )
+'
+
 test_done

--- a/t/t0005-fallback.sh
+++ b/t/t0005-fallback.sh
@@ -629,14 +629,31 @@ test_expect_success 'config --get-urlmatch is explicitly unsupported with --no-g
     )
 '
 
-test_expect_success 'log --simplify-by-decoration is explicitly unsupported with --no-git-fallback' '
+test_expect_success 'log --simplify-by-decoration and --ancestry-path are handled natively with --no-git-fallback' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        echo a >f && git_cmd add f && git_cmd commit -q -m a &&
+        echo b >f && git_cmd add f && git_cmd commit -q -m b && git_cmd tag t-b &&
+        echo c >f && git_cmd add f && git_cmd commit -q -m c &&
+        echo d >f && git_cmd add f && git_cmd commit -q -m d &&
+        git_cmd log --pretty=%s --simplify-by-decoration >dec.out &&
+        printf "d\nb\na\n" >dec.expect &&
+        test_cmp dec.expect dec.out &&
+        git_cmd log --pretty=%s --ancestry-path t-b..HEAD >anc.out &&
+        printf "d\nc\n" >anc.expect &&
+        test_cmp anc.expect anc.out
+    )
+'
+
+test_expect_success 'log --full-diff stays explicitly unsupported with --no-git-fallback' '
     git_cmd init repo &&
     (
         cd repo &&
         echo hello >a.txt &&
         git_cmd add a.txt &&
         git_cmd commit -m "first commit" &&
-        test_must_fail git_cmd log --simplify-by-decoration >out 2>err &&
+        test_must_fail git_cmd log --full-diff -- a.txt >out 2>err &&
         grep -Eiq "standalone|not supported|no-git-fallback" err
     )
 '

--- a/t/t0005-fallback.sh
+++ b/t/t0005-fallback.sh
@@ -595,4 +595,37 @@ test_expect_success 'write-tree on non-sha1 repo is explicitly unsupported if SH
     )
 '
 
+test_expect_success 'filter-branch is explicitly unsupported with --no-git-fallback' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        echo hello >a.txt &&
+        git_cmd add a.txt &&
+        git_cmd commit -m "first commit" &&
+        test_must_fail git_cmd filter-branch --tree-filter true HEAD >out 2>err &&
+        grep -Eiq "standalone|not supported|no-git-fallback" err
+    )
+'
+
+test_expect_success 'config --get-urlmatch is explicitly unsupported with --no-git-fallback' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        test_must_fail git_cmd config --get-urlmatch http https://example.com >out 2>err &&
+        grep -Eiq "standalone|not supported|no-git-fallback" err
+    )
+'
+
+test_expect_success 'log --simplify-by-decoration is explicitly unsupported with --no-git-fallback' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        echo hello >a.txt &&
+        git_cmd add a.txt &&
+        git_cmd commit -m "first commit" &&
+        test_must_fail git_cmd log --simplify-by-decoration >out 2>err &&
+        grep -Eiq "standalone|not supported|no-git-fallback" err
+    )
+'
+
 test_done

--- a/t/t0005-fallback.sh
+++ b/t/t0005-fallback.sh
@@ -646,6 +646,31 @@ test_expect_success 'log --simplify-by-decoration and --ancestry-path are handle
     )
 '
 
+test_expect_success 'log --exclude-first-parent-only is handled natively with --no-git-fallback' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        echo base >base && git_cmd add base && git_cmd commit -q -m base &&
+        main="$(git_cmd rev-parse --abbrev-ref HEAD)" &&
+        git_cmd checkout -q -b topic &&
+        echo t1 >t1 && git_cmd add t1 && git_cmd commit -q -m t1 &&
+        git_cmd checkout -q "$main" &&
+        echo m1 >m1 && git_cmd add m1 && git_cmd commit -q -m m1 &&
+        git_cmd merge -q --no-ff topic -m M1 &&
+        git_cmd tag mark &&
+        git_cmd checkout -q topic &&
+        echo t2 >t2 && git_cmd add t2 && git_cmd commit -q -m t2 &&
+        git_cmd checkout -q "$main" &&
+        echo m2 >m2 && git_cmd add m2 && git_cmd commit -q -m m2 &&
+        git_cmd merge -q --no-ff topic -m M2 &&
+        # Plain exclusion drops t1 (in mark ancestry); first-parent-only keeps it.
+        git_cmd log --pretty=%s mark..HEAD >plain.out &&
+        ! grep -qx t1 plain.out &&
+        git_cmd log --pretty=%s --exclude-first-parent-only mark..HEAD >efp.out &&
+        grep -qx t1 efp.out
+    )
+'
+
 test_expect_success 'log --full-diff stays explicitly unsupported with --no-git-fallback' '
     git_cmd init repo &&
     (


### PR DESCRIPTION
## Summary

製品バイナリから git フォールバックを段階的に排除する一連の作業。git へのフォールバックは「テストで互換性を検証するときのみ」(shim layer) に限定し、`bit` 本体は native で完結させていく方針。

各コマンドの native 出力は**実 git と byte 一致**を確認済み（`--no-git-fallback` 下での挙動 + 直接比較）。

## Changes

1. **dead-code 掃除 + `--no-git-fallback` の徹底**
   - `diff` / `merge` / `rev_list` の委譲述語は既に `false` 固定で到達不能だった委譲関数・呼び出しを削除。
   - 従来 `--no-git-fallback` はトップレベル dispatch しか抑制せず、per-command 委譲 (`blame`/`config`/`fetch`/`log`/`rebase`/`show`/`filter-branch`/`add -i`) は実 git を起動していた。`BIT_NO_GIT_FALLBACK` で全委譲点を抑止し、委譲の代わりに明示的な standalone エラー (exit 128) を返すよう統一。

2. **`config --type=expiry-date` を native 化**
   - `never/false → 0`、`now/all → TIME_MAX`、その他は `bit_date` の approxidate で解決。git の raw epoch 形式 `@<sec> [tz]` 用に `parse_approxidate_epoch` を追加。

3. **`config` / `status` を native 既定化（最大の変更）**
   - `should_delegate_to_real_git` が `config`/`status` を常に実 git へ委譲していたのを撤廃。グローバル config 注入 (`-c` / `GIT_CONFIG_*`) があり shim が処理できない場合のみフォールバック。
   - porcelain v1 / `--short --branch` / long status（clean/staged/削除/リネーム/未追跡ディレクトリ/ignore/コンフリクト/detached/ahead-behind/空リポ/非リポエラー）/ config get/get-all/get-regexp/`--type`/欠損 を実 git と byte 一致確認。

4. **`log` の委譲フラグを native 化**
   - `--ancestry-path`（`=<rev>`・`--graph` 併用含む）と `--simplify-by-decoration`：native walker が実装済みだったため委譲を撤廃。
   - `--exclude-first-parent-only`：除外集合の祖先辿りを first-parent 限定にする `walk_commits_to_map` オプションを追加して実装。
   - **既定 path 限定 log のマージ簡約バグを修正**：従来 `log -- <path>` は TREESAME マージを簡約せず「取り込みマージ」を git と違って表示していた。`--full-history` 時を除き TREESAME マージを隠すよう修正。pull/real/octopus/crisscross/二重マージ/linear で実 git と byte 一致。
   - `--show-pulls` / `--full-diff` は引き続き委譲（前者は git の親リライト簡約が必要なため）。

## Testing

- `moon check --target native`: **0 errors**（警告は既存の `try?` deprecation のみ）。
- `node tools/check-layers.mjs`: layering clean。
- `t/t0005-fallback.sh`: **全 51 pass**（native 動作 + 未実装フラグの委譲エラーを追加）。
- `bit_date` unit tests + 各コマンドの実 git 比較マトリクス（config/status/log）すべて byte 一致。

## Notes / 要監視

- `config`/`status` の native 既定化と log の既定マージ簡約はいずれも heavily-used path を変更する。従来 git-compat スイートはこれらを shim 経由で実 git に委譲していたため、本 PR で **初めて native 実装が git/t で検証**される。git-compat の結果を注視。
- 調査中に判明した別の既存バグ（本 PR 対象外・未修正）: `log --pretty=%s --oneline` のハッシュ接頭辞欠落、`log --full-history -- <path>` のマージ判定が第1親しか見ない点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_