### PR TITLE
fix(log): keep --full-history merges that change the path vs a later parent

### DIFF
--- a/modules/bit/src/cmd/bit/log.mbt
+++ b/modules/bit/src/cmd/bit/log.mbt
@@ -2838,6 +2838,44 @@ fn log_merge_pathspec_visibility(
   Some(true)
 }
 
+///| Whether a merge is visible under --full-history for a path-limited log.
+/// Returns None for non-merge commits. git keeps a merge whenever it differs
+/// from any parent on the pathspec (not only its first parent).
+fn log_full_history_merge_visible(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  db : @bitlib.ObjectDb,
+  commit_id : @bitcore.ObjectId,
+  pathspecs : Array[String],
+) -> Bool? raise Error {
+  let obj = db.get(rfs, commit_id)
+  guard obj is Some(o) else { return None }
+  if o.obj_type != @bitcore.ObjectType::Commit {
+    return None
+  }
+  let info = @bitcore.parse_commit(o.data)
+  let parents = log_resolve_parents(rfs, git_dir, commit_id, info.parents)
+  if parents.length() < 2 {
+    return None
+  }
+  for parent in parents {
+    match log_get_commit_tree(db, rfs, parent) {
+      Some(parent_tree) =>
+        if !log_trees_same_for_pathspecs(
+            rfs,
+            db,
+            parent_tree,
+            info.tree,
+            pathspecs,
+          ) {
+          return Some(true)
+        }
+      None => ()
+    }
+  }
+  Some(false)
+}
+
 ///| Whether a tree contains any path matching the pathspec. Used to decide if a
 /// root commit introduces the path under --show-pulls.
 fn log_tree_has_pathspec(
@@ -2976,6 +3014,24 @@ fn log_commit_matches_history_filters(
   if pathspecs.length() > 0 && !full_history {
     match
       log_merge_pathspec_visibility(rfs, git_dir, db, commit_id, pathspecs) {
+      Some(visible) => {
+        if !visible {
+          return false
+        }
+        return log_commit_matches_diff_filter(
+          rfs, git_dir, db, commit_id, include_bits, exclude, detect_renames,
+          detect_copies,
+        )
+      }
+      None => ()
+    }
+  }
+  // --full-history: keep a merge if it differs from any parent on the pathspec
+  // (the regular first-parent test below would miss merges that only change the
+  // path relative to a later parent).
+  if pathspecs.length() > 0 && full_history {
+    match
+      log_full_history_merge_visible(rfs, git_dir, db, commit_id, pathspecs) {
       Some(visible) => {
         if !visible {
           return false

--- a/t/t0005-fallback.sh
+++ b/t/t0005-fallback.sh
@@ -742,4 +742,24 @@ test_expect_success 'log --graph --show-pulls still falls back (explicit error u
     )
 '
 
+test_expect_success 'log --full-history -- <path> keeps a merge that changes the path vs a later parent' '
+    git_cmd init repo &&
+    (
+        cd repo &&
+        echo 0 >base && git_cmd add base && git_cmd commit -q -m c0 &&
+        main="$(git_cmd rev-parse --abbrev-ref HEAD)" &&
+        git_cmd checkout -q -b side &&
+        echo s >bar && git_cmd add bar && git_cmd commit -q -m side_bar &&
+        git_cmd checkout -q "$main" &&
+        echo m >foo && git_cmd add foo && git_cmd commit -q -m main_foo &&
+        git_cmd merge -q --no-ff side -m themerge &&
+        # The merge is TREESAME to its first parent on foo but differs from the
+        # side parent: default simplification hides it, --full-history keeps it.
+        git_cmd log --pretty=%s -- foo >plain.out &&
+        ! grep -qx themerge plain.out &&
+        git_cmd log --pretty=%s --full-history -- foo >full.out &&
+        grep -qx themerge full.out
+    )
+'
+
 test_done


### PR DESCRIPTION
## Summary

`bit log --full-history -- <path>` が、第1親としか diff を取らないためマージを取りこぼすバグを修正。git は「いずれかの親と path 上で異なるマージ」を残すが、bit は第1親に TREESAME なら隠していた（criss-cross 等で顕在化）。

## Changes

- `log_full_history_merge_visible` を追加：マージは pathspec 上で**いずれかの親と異なれば表示**（None=非マージ）。
- `log_commit_matches_history_filters` で `--full-history` 時にマージをこの判定で可視化。非マージの挙動は不変。

## Testing

- 実 git と一致を確認：criss-cross / pull マージ / path 無関係マージ、`--full-history`・default・`--full-history --topo-order`。
- `t/t0005-fallback.sh`: 全 53 pass（第1親に TREESAME・後続親と異なるマージが default で隠れ `--full-history` で出ることを検証）。
- `moon check --target native` 0 errors、layering clean。

## Scope

`log` の残る既知バグのうち、この PR は `--full-history` のマージ判定のみ。未対応として据え置き（規模・リスクの都合）：
- `--graph --show-pulls`（graph 描画経路が pathspec 簡約に非対応で委譲のまま）
- `--pretty=<fmt> --oneline` の last-wins 順序（多用される `--oneline` 経路への回帰リスク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_