### PR TITLE
fix(log): route --oneline -N through the full walk (drop first-parent shortcut)

### DIFF
--- a/modules/bit/src/cmd/bit/log.mbt
+++ b/modules/bit/src/cmd/bit/log.mbt
@@ -470,72 +470,6 @@ async fn log_emit_commit_signature_output_lines(
 }
 
 ///|
-fn log_storage_runtime_delegate_args(
-  args : Array[String],
-) -> @runtime.StorageLogArgs? {
-  if log_need_real_git(args) {
-    return None
-  }
-  let mut seen_oneline = false
-  let mut seen_limit = false
-  let mut i = 0
-  while i < args.length() {
-    let arg = args[i]
-    match arg {
-      "--oneline" => seen_oneline = true
-      "-n" | "--max-count" => {
-        seen_limit = true
-        if i + 1 < args.length() {
-          i += 1
-        } else {
-          return None
-        }
-      }
-      _ if arg.has_prefix("--max-count=") => seen_limit = true
-      _ if is_short_count_flag(arg) => seen_limit = true
-      _ => return None
-    }
-    i += 1
-  }
-  if !seen_oneline || !seen_limit {
-    return None
-  }
-  let parsed = storage_runtime_parse_command("log", args) catch {
-    _ => return None
-  }
-  match parsed {
-    @runtime.StorageCommand::Log(log_args) if log_args.oneline => Some(log_args)
-    _ => None
-  }
-}
-
-///|
-fn log_should_use_storage_runtime(args : Array[String]) -> Bool {
-  log_storage_runtime_delegate_args(args) is Some(_)
-}
-
-///|
-fn log_storage_runtime_blocked_by_repo_config(
-  rfs : &@bitcore.RepoFileSystem,
-  git_dir : String,
-) -> Bool {
-  log_read_config_entries(rfs, git_dir, "log", "decorate").length() > 0 ||
-  log_read_config_entries(rfs, git_dir, "log", "excludeDecoration").length() > 0 ||
-  log_read_config_entries(rfs, git_dir, "log", "abbrevCommit").length() > 0 ||
-  log_read_config_entries(rfs, git_dir, "core", "abbrev").length() > 0
-}
-
-///|
-fn log_should_use_storage_runtime_in_repo(
-  rfs : &@bitcore.RepoFileSystem,
-  git_dir : String,
-  args : Array[String],
-) -> Bool {
-  log_should_use_storage_runtime(args) &&
-  !log_storage_runtime_blocked_by_repo_config(rfs, git_dir)
-}
-
-///|
 fn log_parse_stdin_input(
   rfs : &@bitcore.RepoFileSystem,
   git_dir : String,
@@ -4269,20 +4203,6 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
     return
   }
   validate_commit_graph_hash_version(fs, git_dir)
-  if log_should_use_storage_runtime_in_repo(rfs, git_dir, args) {
-    match log_storage_runtime_delegate_args(args) {
-      Some(log_args) => {
-        @runtime.run_storage_command(
-          fs,
-          rfs,
-          root,
-          @runtime.StorageCommand::Log(log_args),
-        )
-        return
-      }
-      None => ()
-    }
-  }
   let mut oneline = false
   let mut graph = false
   let mut all_refs = false

--- a/modules/bit/src/cmd/bit/log_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/log_wbtest.mbt
@@ -1,31 +1,4 @@
 ///|
-test "log: storage runtime routing only for oneline subset" {
-  assert_true(log_should_use_storage_runtime(["--oneline", "-n", "3"]))
-  assert_true(log_should_use_storage_runtime(["--oneline", "--max-count=2"]))
-  assert_true(log_should_use_storage_runtime(["--oneline", "-3"]))
-
-  assert_false(log_should_use_storage_runtime(["--oneline"]))
-  assert_false(log_should_use_storage_runtime(["-n", "3"]))
-  assert_false(log_should_use_storage_runtime(["--graph", "--oneline"]))
-  assert_false(log_should_use_storage_runtime(["HEAD"]))
-  assert_false(log_should_use_storage_runtime(["--oneline", "HEAD"]))
-  assert_false(log_should_use_storage_runtime(["--oneline", "--source", "v1"]))
-}
-
-///|
-test "log: storage runtime not used for --all, --decorate, ranges" {
-  // --all is not --oneline alone, so storage runtime should be false
-  assert_false(log_should_use_storage_runtime(["--all"]))
-  assert_false(log_should_use_storage_runtime(["--all", "--oneline"]))
-  assert_false(log_should_use_storage_runtime(["--decorate"]))
-  assert_false(log_should_use_storage_runtime(["--decorate", "--oneline"]))
-  // positional args (including ranges) are not pure --oneline
-  assert_false(log_should_use_storage_runtime(["main..develop"]))
-  assert_false(log_should_use_storage_runtime(["HEAD~3"]))
-  assert_false(log_should_use_storage_runtime(["main"]))
-}
-
-///|
 test "log: raw rotate uses first path after target when absent" {
   let zero = @bitcore.ObjectId::zero()
   let raw_results : Array[LogRawResult] = [
@@ -74,36 +47,6 @@ test "log: raw rotate uses first path after target when absent" {
     Some("sample3.t"),
   )
   @test.assert_eq(skipped.map(item => item.new_path), ["sample4.t"])
-}
-
-///|
-test "log: storage runtime disabled by repo config overrides" {
-  let fs = @bitcore.TestFs::new()
-  ignore(try? @bitlib.init_repo(fs, "/repo"))
-  let base_config = fs.read_string("/repo/.git/config")
-
-  assert_true(
-    log_should_use_storage_runtime_in_repo(fs, "/repo/.git", [
-      "--oneline", "-n", "3",
-    ]),
-  )
-
-  fs.write_string("/repo/.git/config", base_config + "\n[log]\n\tdecorate\n")
-  assert_false(
-    log_should_use_storage_runtime_in_repo(fs, "/repo/.git", [
-      "--oneline", "-n", "3",
-    ]),
-  )
-
-  fs.write_string(
-    "/repo/.git/config",
-    base_config + "\n[core]\n\tabbrev = 12\n",
-  )
-  assert_false(
-    log_should_use_storage_runtime_in_repo(fs, "/repo/.git", [
-      "--oneline", "-n", "3",
-    ]),
-  )
 }
 
 ///|


### PR DESCRIPTION
## Summary

`bit log --oneline -N` was delegated to the **storage-runtime** fast path, whose log handler walks **first-parent only** (`log_head_oneline`), so it dropped merged-in commits and mis-truncated over merge history. Plain `--oneline` (no count) already skipped the shortcut and was correct — which is why only the `-N` form diverged.

## What changed

- Remove the log storage-runtime routing (`log_should_use_storage_runtime*` predicates and the delegate) so `--oneline -N` falls through to the same committer-ordered **full-DAG** walk the rest of `bit log` uses.
- The walk is still bounded by `max_count`, so the common `--oneline -3` case stays cheap.
- Drop the now-dead predicate helpers and their white-box tests (the shared helpers they used — `is_short_count_flag`, `storage_runtime_parse_command`, `log_read_config_entries` — remain, used elsewhere).

## Verification

- `bit log --oneline -N` (`-5`, `-27`, `-100`, `-130`, `-n 3`, `--max-count=10`) is now **byte-identical to git** across the real repo history (merges included).
- Full-format `bit log`, `--graph`, `--oneline` (unbounded), and `--all` unaffected.
- t0005: 56 tests pass. `moon check` clean (0 errors). `tools/check-layers.mjs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_