### PR TITLE
perf(hub): cache ObjectDb in OsObjectStore to avoid re-parsing pack indexes

### DIFF
--- a/modules/bit/src/cmd/bit/hub_stores.mbt
+++ b/modules/bit/src/cmd/bit/hub_stores.mbt
@@ -1,12 +1,37 @@
 ///|
 struct OsObjectStore {
   git_dir : String
+  // Cached lazily-loaded ObjectDb. Reused across get/has calls so pack
+  // indexes are parsed at most once per store instance.
+  mut cached_db : @bitlib.ObjectDb?
+}
+
+///|
+/// Return a cached ObjectDb, building it lazily on first use.
+///
+/// Rebuilding the ObjectDb on every `get`/`has` re-parsed each pack `.idx`
+/// from scratch, and parsing an index hex-encodes every object id it
+/// contains. Once `bit issue` blobs were packed by gc, every object read
+/// re-hashed the entire pack index, making hub operations extremely slow.
+/// Caching the db lets `LazyPackIndex` keep its parsed index between reads.
+fn OsObjectStore::object_db(
+  self : OsObjectStore,
+  fs : OsFs,
+) -> @bitlib.ObjectDb raise @bitcore.GitError {
+  match self.cached_db {
+    Some(db) => db
+    None => {
+      let db = @bitlib.ObjectDb::load_lazy(fs, self.git_dir)
+      self.cached_db = Some(db)
+      db
+    }
+  }
 }
 
 ///|
 impl @bitlib.ObjectStore for OsObjectStore with get(self, id) {
   let fs = OsFs::new()
-  let db = @bitlib.ObjectDb::load_lazy(fs, self.git_dir)
+  let db = self.object_db(fs)
   db.get(fs, id)
 }
 
@@ -27,7 +52,7 @@ impl @bitlib.ObjectStore for OsObjectStore with put(self, obj_type, content) {
 ///|
 impl @bitlib.ObjectStore for OsObjectStore with has(self, id) {
   let fs = OsFs::new()
-  let db = @bitlib.ObjectDb::load_lazy(fs, self.git_dir)
+  let db = self.object_db(fs)
   let obj = db.get(fs, id)
   obj is Some(_)
 }
@@ -367,7 +392,7 @@ fn resolve_hub_git_dir(root : String) -> String {
 fn make_hub_stores(
   git_dir : String,
 ) -> (&@bitlib.ObjectStore, &@bitlib.RefStore, &@bitlib.Clock) {
-  let objects : OsObjectStore = { git_dir, }
+  let objects : OsObjectStore = { git_dir, cached_db: None }
   let refs : OsRefStore = { git_dir, }
   let clock : OsClock = { time: get_commit_timestamp() }
   (objects, refs, clock)

--- a/modules/bit/src/cmd/git-bit/hub_stores.mbt
+++ b/modules/bit/src/cmd/git-bit/hub_stores.mbt
@@ -1,12 +1,37 @@
 ///|
 struct OsObjectStore {
   git_dir : String
+  // Cached lazily-loaded ObjectDb. Reused across get/has calls so pack
+  // indexes are parsed at most once per store instance.
+  mut cached_db : @bitlib.ObjectDb?
+}
+
+///|
+/// Return a cached ObjectDb, building it lazily on first use.
+///
+/// Rebuilding the ObjectDb on every `get`/`has` re-parsed each pack `.idx`
+/// from scratch, and parsing an index hex-encodes every object id it
+/// contains. Once `bit issue` blobs were packed by gc, every object read
+/// re-hashed the entire pack index, making hub operations extremely slow.
+/// Caching the db lets `LazyPackIndex` keep its parsed index between reads.
+fn OsObjectStore::object_db(
+  self : OsObjectStore,
+  fs : OsFs,
+) -> @bitlib.ObjectDb raise @bitcore.GitError {
+  match self.cached_db {
+    Some(db) => db
+    None => {
+      let db = @bitlib.ObjectDb::load_lazy(fs, self.git_dir)
+      self.cached_db = Some(db)
+      db
+    }
+  }
 }
 
 ///|
 impl @bitlib.ObjectStore for OsObjectStore with get(self, id) {
   let fs = OsFs::new()
-  let db = @bitlib.ObjectDb::load_lazy(fs, self.git_dir)
+  let db = self.object_db(fs)
   db.get(fs, id)
 }
 
@@ -27,7 +52,7 @@ impl @bitlib.ObjectStore for OsObjectStore with put(self, obj_type, content) {
 ///|
 impl @bitlib.ObjectStore for OsObjectStore with has(self, id) {
   let fs = OsFs::new()
-  let db = @bitlib.ObjectDb::load_lazy(fs, self.git_dir)
+  let db = self.object_db(fs)
   let obj = db.get(fs, id)
   obj is Some(_)
 }
@@ -267,7 +292,7 @@ fn detect_hub_current_branch_name(root : String) -> String? {
 fn make_hub_stores(
   git_dir : String,
 ) -> (&@bitlib.ObjectStore, &@bitlib.RefStore, &@bitlib.Clock) {
-  let objects : OsObjectStore = { git_dir, }
+  let objects : OsObjectStore = { git_dir, cached_db: None }
   let refs : OsRefStore = { git_dir, }
   let clock : OsClock = { time: get_commit_timestamp() }
   (objects, refs, clock)


### PR DESCRIPTION
## 問題

`bit issue`（hub 系）が、対象 blob が gc で pack 化されると**極端に遅くなる**。

原因は `OsObjectStore::get` / `has` が**呼び出しごとに `ObjectDb` を作り直していた**こと:

```moonbit
// 修正前
impl @bitlib.ObjectStore for OsObjectStore with get(self, id) {
  let fs = OsFs::new()
  let db = @bitlib.ObjectDb::load_lazy(fs, self.git_dir)  // ← 毎回作り直し
  db.get(fs, id)
}
```

`LazyPackIndex` はパース済みインデックスを `self.loaded` にキャッシュするが、`ObjectDb` ごと毎回新規生成されるためそのキャッシュは即座に捨てられていた。そして `parse_pack_index` は **pack 内の全エントリを 1 件ずつ `ObjectId::new(bytes).to_hex()` で hex 化**する。

結果、issue blob が pack に入ると **オブジェクト読み込み 1 回ごとに pack index 全体を再パース＝全エントリを再 hex 化**し、コストが `O(読み込み回数 × pack エントリ数)` に膨れ上がっていた。

## 修正

`OsObjectStore` に `mut cached_db : @bitlib.ObjectDb?` を持たせ、`ObjectDb` をストアインスタンス単位で一度だけ遅延構築するようにした。これで `LazyPackIndex` のキャッシュがコマンド実行中ずっと効き、pack index のパースはコマンドあたり最大 1 回になる。

- `bit` / `git-bit` 両バリアントの `hub_stores.mbt` に同一適用。
- `put` が書く新規 loose object は `get_loose_by_hex` の直接パス構築で従来どおり発見されるため、put→get の整合性は保たれる（負のキャッシュはしていない）。
- gc の pack 化はコマンドをまたぐので、キャッシュ寿命（コマンド単位）とは競合しない。

## 検証

- `moon check --target native`: エラー 0（既存の `try?` deprecation 警告のみ）。

## スコープ / 補足

初回アクセス時の index パース 1 回分（N 件の hex 化）は正確性のため残る。さらに削るなら「hex ではなく生バイト列で二分探索する」根本策もあるが、本 PR のスコープ（キャッシュ未ヒット問題）からは外れるため別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_