### PR TITLE
perf(hub): cache ObjectDb in HubJsObjectStore (JS bit issue backend)

### DIFF
--- a/modules/bitx_hub/src/js_hub_exports.mbt
+++ b/modules/bitx_hub/src/js_hub_exports.mbt
@@ -16,11 +16,34 @@ fn[T] hub_wrap_error(f : () -> T raise @bit.GitError) -> Result[T, String] {
 priv struct HubJsObjectStore {
   fs : HubJsHostFs
   git_dir : String
+  // Cached lazily-loaded ObjectDb. Reused across get/has calls so pack
+  // indexes are parsed at most once per store instance.
+  mut cached_db : @lib.ObjectDb?
+}
+
+///|
+/// Return a cached ObjectDb, building it lazily on first use.
+///
+/// Rebuilding it on every `get`/`has` re-parsed each pack `.idx` from
+/// scratch (hex-encoding every object id it contains), so once `bit issue`
+/// blobs were packed by gc, every read re-hashed the whole pack index.
+/// Caching lets `LazyPackIndex` keep its parsed index between reads.
+fn HubJsObjectStore::object_db(
+  self : HubJsObjectStore,
+) -> @lib.ObjectDb raise @bit.GitError {
+  match self.cached_db {
+    Some(db) => db
+    None => {
+      let db = @lib.ObjectDb::load_lazy(self.fs, self.git_dir)
+      self.cached_db = Some(db)
+      db
+    }
+  }
 }
 
 ///|
 impl @lib.ObjectStore for HubJsObjectStore with get(self, id) {
-  let db = @lib.ObjectDb::load_lazy(self.fs, self.git_dir)
+  let db = self.object_db()
   db.get(self.fs, id)
 }
 
@@ -39,7 +62,7 @@ impl @lib.ObjectStore for HubJsObjectStore with put(self, obj_type, content) {
 
 ///|
 impl @lib.ObjectStore for HubJsObjectStore with has(self, id) {
-  let db = @lib.ObjectDb::load_lazy(self.fs, self.git_dir)
+  let db = self.object_db()
   let obj = db.get(self.fs, id)
   obj is Some(_)
 }
@@ -142,7 +165,7 @@ fn hub_make_stores(
 ) -> (HubJsObjectStore, HubJsRefStore, HubJsClock) raise @bit.GitError {
   let fs = hub_make_host_fs(host_id)
   let git_dir = hub_resolve_git_dir(fs, root)
-  let objects = HubJsObjectStore::{ fs, git_dir }
+  let objects = HubJsObjectStore::{ fs, git_dir, cached_db: None }
   let refs = HubJsRefStore::{ fs, git_dir }
   let now = hub_js_date_now().to_int64() / 1000L
   let clock = HubJsClock::{ timestamp: now }


### PR DESCRIPTION
## 背景

#110 で native の `OsObjectStore`（`bit issue` の hub バックエンド）が `get`/`has` ごとに `ObjectDb` を作り直して `LazyPackIndex` のキャッシュを捨てていた性能バグを修正した。

同じ視点でコードベースを見直したところ、**JS/npm ビルド（`@mizchi/bit`）の hub バックエンド `HubJsObjectStore` が全く同じバグ**を持っていた。native と共通の hub ロジックを JS の ObjectStore で駆動しており、`get`/`has` が毎回 `@lib.ObjectDb::load_lazy` を呼んでいた。

```moonbit
// 修正前
impl @lib.ObjectStore for HubJsObjectStore with get(self, id) {
  let db = @lib.ObjectDb::load_lazy(self.fs, self.git_dir)  // ← 毎回作り直し
  db.get(self.fs, id)
}
```

そのため JS 版でも、issue blob が gc で pack 化されると **オブジェクト読み込み 1 回ごとに pack index 全体を再パース＝全エントリ再 hex 化**し、`O(reads × pack エントリ数)` に膨れ上がる。

## 修正

`HubJsObjectStore` に `mut cached_db : @lib.ObjectDb?` を持たせ、`ObjectDb` をストアインスタンス単位で一度だけ遅延構築するようにした。#110（native）および既存の `bit_vfs` の `Fs::get_db` と同じキャッシュ方式に揃えている。

## 調査範囲と結果

hub の ObjectStore バックエンドは 3 つ:
- `OsObjectStore`（native）— #110 で修正済み
- **`HubJsObjectStore`（JS）— 本 PR で修正**
- `TestObjectStore`（テストアダプタ）— テスト専用のため性能影響なし、対象外

その他の `ObjectDb::load*` 呼び出し（`revparse` / `notes` / `diff` / `storage_runtime` など多数）はいずれも**コマンドあたり 1 回ロードして使い回す**形で、per-object の再ロードにはなっていないことを確認。`bit_vfs` は既に `Fs::get_db` でキャッシュ済み。

## 検証

- `moon check --target js`（`bitx_hub` モジュール）: エラー 0（既存の deprecation 警告のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_