### PR TITLE
feat(switch): support -m/--merge (autostash across branch switch)

### DIFF
--- a/modules/bit/src/cmd/bit/switch.mbt
+++ b/modules/bit/src/cmd/bit/switch.mbt
@@ -17,6 +17,7 @@ async fn handle_switch(args : Array[String]) -> Unit raise Error {
   let mut orphan = false
   let mut discard_changes = false
   let mut ignore_other_worktrees = false
+  let mut merge = false
   let mut quiet = false
   let mut track_mode : String? = None
   let mut guess_mode : Bool? = None
@@ -57,6 +58,7 @@ async fn handle_switch(args : Array[String]) -> Unit raise Error {
       }
       "--discard-changes" => discard_changes = true
       "--ignore-other-worktrees" => ignore_other_worktrees = true
+      "-m" | "--merge" => merge = true
       "-q" | "--quiet" => quiet = true
       "--track" => track_mode = Some("direct")
       "--guess" => guess_mode = Some(true)
@@ -216,9 +218,7 @@ async fn handle_switch(args : Array[String]) -> Unit raise Error {
         None => ()
       }
     }
-    let previous_location = current_checkout_location(rfs, git_dir)
-    ignore(checkout_with_promisor_retry(fs, root, target))
-    save_previous_checkout_location(fs, git_dir, previous_location)
+    switch_do_branch_switch(fs, rfs, root, git_dir, target, merge)
     if !quiet {
       print_line("Switched to branch '\{target}'")
     }
@@ -228,9 +228,7 @@ async fn handle_switch(args : Array[String]) -> Unit raise Error {
   if guess &&
     @bitlib.resolve_ref(rfs, git_dir, "refs/remotes/origin/" + target)
     is Some(_) {
-    let previous_location = current_checkout_location(rfs, git_dir)
-    ignore(checkout_with_promisor_retry(fs, root, target))
-    save_previous_checkout_location(fs, git_dir, previous_location)
+    switch_do_branch_switch(fs, rfs, root, git_dir, target, merge)
     if !quiet {
       print_line("Switched to branch '\{target}'")
     }
@@ -244,6 +242,34 @@ async fn handle_switch(args : Array[String]) -> Unit raise Error {
     @sys.exit(1)
   }
   raise @bitcore.GitError::InvalidObject("Invalid ref: \{target}")
+}
+
+///|
+/// Switch to `target`, optionally autostashing local changes across the
+/// switch (`-m`/`--merge`). Mirrors `checkout -m`: uncommitted changes are
+/// stashed before the worktree is rewritten and re-applied afterwards, so
+/// they survive the branch switch instead of being overwritten.
+fn switch_do_branch_switch(
+  fs : OsFs,
+  rfs : &@bitcore.RepoFileSystem,
+  root : String,
+  git_dir : String,
+  target : String,
+  merge : Bool,
+) -> Unit raise Error {
+  let previous_location = current_checkout_location(rfs, git_dir)
+  let mut did_autostash = false
+  if merge {
+    let author = get_author_string()
+    let timestamp = get_commit_timestamp()
+    let stash_id = @bitlib.stash_push(fs, fs, root, "", author, timestamp)
+    did_autostash = stash_id is Some(_)
+  }
+  ignore(checkout_with_promisor_retry(fs, root, target))
+  save_previous_checkout_location(fs, git_dir, previous_location)
+  if did_autostash {
+    @bitlib.stash_apply(fs, fs, root, 0, true)
+  }
 }
 
 ///|


### PR DESCRIPTION
## 背景

Git 2.55 のハイライトの一つ「Safer Checkout with Merge」（`checkout -m` を autostash 化してローカル変更を保護）に倣い、`git switch` にも `-m`/`--merge` を追加する。

bit ではすでに `checkout -m` が autostash 実装（`stash_push` → 切り替え → `stash_apply`）として存在していたが、`git switch` は `-m` を受け付けず `warn_unimplemented_arg` にフォールバックしていた。さらに bit の素のブランチ切り替えはローカル変更の保護チェックを持たず**上書き**する挙動だったため、`switch` で変更を保持する手段が無かった。

## 変更

- `switch` に `-m`/`--merge` フラグを追加。
- ブランチ切り替え本体を `switch_do_branch_switch` に切り出し、`merge` 時は切り替え前に `stash_push`、切り替え後に `stash_apply` する（`checkout -m` と同一パターン）。
- 既存ローカルブランチへの切り替え経路と `--guess`（remote-tracking 推測）経路の両方に配線。

## 補足 / スコープ

- bit の `checkout -m` 同様、git 内部の 3-way マージではなく **stash-and-reapply の近似**（bit の既存方針に合わせている）。
- `-m` は素のブランチ切り替え経路のみに作用。`-c`（作成）/`--orphan`/`--detach` との併用時の挙動は変更していない。

## 検証

- `bit` モジュール `moon check --target js`: **0 errors**。
- 実装は既存のテスト済み `checkout -m` 経路（同じ `stash_push`/`stash_apply` プリミティブ）の忠実なミラー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_