### PR TITLE
feat(rev-list): add --max-count-oldest=&lt;n&gt; (Git 2.55)

### DIFF
--- a/modules/bit/src/cmd/bit/rev_list.mbt
+++ b/modules/bit/src/cmd/bit/rev_list.mbt
@@ -53,6 +53,7 @@ async fn handle_rev_list(args : Array[String]) -> Unit raise Error {
   let git_dir = find_git_dir(fs)
   check_commit_graph_paranoia(fs, git_dir)
   let mut max_count : Int? = None
+  let mut max_count_oldest : Int? = None
   let mut skip_count = 0
   let mut count_only = false
   let mut objects = false
@@ -96,6 +97,11 @@ async fn handle_rev_list(args : Array[String]) -> Unit raise Error {
     match arg {
       "-n" | "--max-count" if i + 1 < args.length() => {
         max_count = Some(rev_list_parse_int_or_die(args[i + 1]))
+        i += 2
+        continue
+      }
+      "--max-count-oldest" if i + 1 < args.length() => {
+        max_count_oldest = Some(rev_list_parse_int_or_die(args[i + 1]))
         i += 2
         continue
       }
@@ -295,6 +301,10 @@ async fn handle_rev_list(args : Array[String]) -> Unit raise Error {
       _ if arg.has_prefix("--max-count=") => {
         let val = String::unsafe_substring(arg, start=12, end=arg.length())
         max_count = Some(rev_list_parse_int_or_die(val))
+      }
+      _ if arg.has_prefix("--max-count-oldest=") => {
+        let val = String::unsafe_substring(arg, start=19, end=arg.length())
+        max_count_oldest = Some(rev_list_parse_int_or_die(val))
       }
       _ if arg.has_prefix("--skip=") => {
         let val = String::unsafe_substring(arg, start=7, end=arg.length())
@@ -717,6 +727,27 @@ async fn handle_rev_list(args : Array[String]) -> Unit raise Error {
   } else {
     // Default: date order (same as git's default chronological ordering)
     rev_list_date_sort(db, fs, result)
+  }
+  // --max-count-oldest=<n>: keep only the N oldest commits. `result` is
+  // newest-first here, so the oldest N are its tail; preserve their
+  // newest-first relative order, matching git's output order before
+  // --reverse is applied.
+  match max_count_oldest {
+    Some(n) => {
+      let keep = if n < 0 { 0 } else { n }
+      if result.length() > keep {
+        let start = result.length() - keep
+        let tail : Array[@bitcore.ObjectId] = []
+        for idx in start..<result.length() {
+          tail.push(result[idx])
+        }
+        result.clear()
+        for id in tail {
+          result.push(id)
+        }
+      }
+    }
+    None => ()
   }
   if reverse {
     result.rev_in_place()


### PR DESCRIPTION
## 背景

Git 2.55 のハイライト「Oldest Commits Selection」を取り入れる。`git rev-list --max-count-oldest=<n>` は、範囲のうち**最も古い N 件**を選ぶ。`-n`/`--max-count`（最新 N 件）の対になるオプション。

## 変更

- `rev-list` に `--max-count-oldest=<n>` / `--max-count-oldest <n>` を追加。
- rev-list は到達集合を materialize してから newest-first にソートし窓を適用するため、**最古 N 件はその末尾**に当たる。ソート後・`--reverse` 前に末尾 N 件へ切り詰めることで:
  - 既定出力は reverse-chronological（新しい順）のまま最古 N 件に限定、
  - `--reverse` でそれらが oldest-first になる、
  という git の順序に一致させている。

## 検証

- `bit` モジュール `moon check --target js`: **0 errors**。
- 注意: 本環境の git は **2.53**（本フラグは 2.55 新規）のため、実 git とのバイト一致比較は不可。セマンティクスは 2.55 の仕様（最古 N = 新しい順ウォークの末尾、`--reverse` 前に適用）に基づき実装。

## スコープ

`log` ファミリの同オプションは**別対応**。log は複数の filter/render ループを持つ compat critical なコマンドで、正しく最古 N 件を取り出すにはレンダリングループのリファクタが必要なため、本 PR には含めず、慎重に別 PR で扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_