### PR TITLE
fix(switch): make switch_do_branch_switch async (native build break from #113)

### DIFF
--- a/modules/bit/src/cmd/bit/switch.mbt
+++ b/modules/bit/src/cmd/bit/switch.mbt
@@ -249,7 +249,7 @@ async fn handle_switch(args : Array[String]) -> Unit raise Error {
 /// switch (`-m`/`--merge`). Mirrors `checkout -m`: uncommitted changes are
 /// stashed before the worktree is rewritten and re-applied afterwards, so
 /// they survive the branch switch instead of being overwritten.
-fn switch_do_branch_switch(
+async fn switch_do_branch_switch(
   fs : OsFs,
   rfs : &@bitcore.RepoFileSystem,
   root : String,


### PR DESCRIPTION
## 問題

#113（`switch -m`）で追加したヘルパ `switch_do_branch_switch` が async 関数（`@bitlib.stash_push` / `checkout_with_promisor_retry`）を呼んでいるのに、通常の `fn` として宣言していたため、**native ビルドが error [4149]「cannot call async function in non-async function」で失敗**していた。

`switch.mbt` は `moon.pkg` で `["native"]` 指定（native ターゲット専用）のため、#113 を js ターゲットでしか検証しておらず、この破壊を見落としていた。

## 修正

ヘルパを `async fn` に変更。呼び出し元は既に async の `handle_switch` のみなので影響なし。

## 検証

- `moon check --target native`: **0 errors**。
- `moon test --target native -f "log:*"`: 45/45 pass（回帰なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_