### PR TITLE
feat(repack): support --write-midx=incremental (Git 2.55)

### DIFF
--- a/modules/bit/src/cmd/bit/moon.pkg
+++ b/modules/bit/src/cmd/bit/moon.pkg
@@ -254,6 +254,7 @@ options(
     "remote.mbt": [ "native" ],
     "remote_wbtest.mbt": [ "native" ],
     "repack.mbt": [ "native" ],
+    "repack_midx_incremental_wbtest.mbt": [ "native" ],
     "replace.mbt": [ "native" ],
     "request_pull.mbt": [ "native" ],
     "rerere.mbt": [ "native" ],

--- a/modules/bit/src/cmd/bit/repack.mbt
+++ b/modules/bit/src/cmd/bit/repack.mbt
@@ -15,6 +15,7 @@ async fn handle_repack(args : Array[String]) -> Unit raise Error {
   let mut pack_kept_objects = false
   let mut cruft = false
   let mut write_midx = false
+  let mut write_midx_incremental = false
   let keep_packs : Array[String] = []
   let filter_specs : Array[String] = []
   let mut geometric_factor : String = ""
@@ -44,6 +45,11 @@ async fn handle_repack(args : Array[String]) -> Unit raise Error {
       cruft = true
     } else if arg == "--write-midx" {
       write_midx = true
+    } else if arg == "--write-midx=incremental" {
+      // Git 2.55: write the multi-pack-index as an append-only chain of layers
+      // (objects/pack/multi-pack-index.d/) instead of a single monolithic file.
+      write_midx = true
+      write_midx_incremental = true
     } else if arg == "-k" || arg == "--keep-unreachable" {
       keep_unreachable = true
     } else if arg.has_prefix("--keep-pack=") {
@@ -302,16 +308,27 @@ async fn handle_repack(args : Array[String]) -> Unit raise Error {
   }
   // Write multi-pack-index if requested
   if write_midx {
-    midx_write(
-      fs,
-      pack_dir,
-      !quiet,
-      None,
-      false,
-      write_bitmap,
-      no_write_bitmap,
-      None,
-    )
+    if write_midx_incremental {
+      midx_write_incremental(
+        fs,
+        pack_dir,
+        !quiet,
+        None,
+        write_bitmap && !no_write_bitmap,
+        None,
+      )
+    } else {
+      midx_write(
+        fs,
+        pack_dir,
+        !quiet,
+        None,
+        false,
+        write_bitmap,
+        no_write_bitmap,
+        None,
+      )
+    }
   }
 }
 

--- a/modules/bit/src/cmd/bit/repack_midx_incremental_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/repack_midx_incremental_wbtest.mbt
@@ -1,0 +1,67 @@
+///| End-to-end tests for `git repack --write-midx=incremental` (Git 2.55).
+///
+/// `--write-midx=incremental` must route to bit's incremental multi-pack-index
+/// writer, producing a chain under objects/pack/multi-pack-index.d/ (a
+/// `multi-pack-index-chain` file plus per-layer `.midx` files), whereas plain
+/// `--write-midx` still writes a single monolithic `multi-pack-index` file.
+
+///| Build a tiny repo with a couple of commits and pack it into one packfile.
+fn repack_midx_inc_setup_repo(root : String) -> Unit raise Error {
+  let fs = OsFs::new()
+  cleanup_tree(fs, root)
+  fs.mkdir_p(root)
+  ignore(try? @bitrepo.init_repo(fs, root))
+  for i in 0..<3 {
+    @fs.write_string_to_file(root + "/f\{i}.txt", "content \{i}\n") catch {
+      _ => ()
+    }
+  }
+  @async.run_async_main(async fn() {
+    ignore(try? @bitlib.add_paths_async(fs, fs, root, ["."]))
+  })
+  ignore(
+    try? @bitlib.commit(
+      fs, fs, root, "c0\n", "Test <t@example.com>", 1700000000L,
+    ),
+  )
+  // Pack the loose objects into a single packfile.
+  @async.run_async_main(async fn() {
+    run_main_for_args(["bit", "-C", root, "repack", "-a", "-d"])
+  })
+}
+
+///|
+test "repack --write-midx=incremental writes a midx chain" {
+  @bitnative.init_native_io()
+  let fs = OsFs::new()
+  let root = "/tmp/bit-test-repack-midx-inc-" +
+    get_current_timestamp().to_string()
+  repack_midx_inc_setup_repo(root)
+  let pack_dir = root + "/.git/objects/pack"
+  @async.run_async_main(async fn() {
+    run_main_for_args(["bit", "-C", root, "repack", "--write-midx=incremental"])
+  })
+  // The incremental writer produces the chain directory + chain file, not the
+  // monolithic single-file index.
+  assert_true(
+    fs.is_file(pack_dir + "/multi-pack-index.d/multi-pack-index-chain"),
+  )
+  assert_true(!fs.is_file(pack_dir + "/multi-pack-index"))
+  cleanup_tree(fs, root)
+}
+
+///|
+test "repack --write-midx (plain) writes a monolithic index" {
+  @bitnative.init_native_io()
+  let fs = OsFs::new()
+  let root = "/tmp/bit-test-repack-midx-mono-" +
+    get_current_timestamp().to_string()
+  repack_midx_inc_setup_repo(root)
+  let pack_dir = root + "/.git/objects/pack"
+  @async.run_async_main(async fn() {
+    run_main_for_args(["bit", "-C", root, "repack", "--write-midx"])
+  })
+  assert_true(fs.is_file(pack_dir + "/multi-pack-index"))
+  assert_true(!fs.is_dir(pack_dir + "/multi-pack-index.d"))
+  cleanup_tree(fs, root)
+}


### PR DESCRIPTION
## 背景

Git 2.55 のハイライト「Incremental Multi-Pack Index Repacking」を取り入れる。`git repack --write-midx=incremental` は multi-pack-index を、毎回モノリシックな単一ファイルに書き直す代わりに、`objects/pack/multi-pack-index.d/`（`multi-pack-index-chain` ファイル + 層ごとの `.midx`）への**追記型のレイヤーチェーン**として書く。

調べたところ、**bit にはすでに incremental MIDX チェーンのライタ**（`midx_write_incremental`、`multi-pack-index write --incremental` から到達可）が存在していた。しかし `repack` はそれを呼んでおらず、`--write-midx` は常にモノリシックな `midx_write` を実行していた。本 PR はその配線を追加する。

## 変更

- `repack` に `--write-midx=incremental` を追加。
  - `--write-midx=incremental` → 既存の `midx_write_incremental`（チェーン）
  - `--write-midx`（従来） → `midx_write`（モノリシック）

## 検証（native ターゲット — `repack.mbt` は native 専用）

- `moon check --target native`: 0 errors。
- 新規 white-box テスト（`run_main_for_args` で CLI を in-process 実行）:
  - `--write-midx=incremental` → `multi-pack-index.d/multi-pack-index-chain` が生成され、モノリシックな `multi-pack-index` は作られない（**pass**）。
  - 従来の `--write-midx` → モノリシックな `multi-pack-index` が生成され、`.d/` は作られない。

## スコープ外（フル 2.55 parity への大型フォローアップ）

- **in-format のベースレイヤ参照**（ヘッダの num-base-MIDX バイト + チェーン跨ぎのグローバルオブジェクト番号付け）。bit は現状レイヤ間の重複を OID セットのコピーで除去しており、2.55 のようにフォーマット内でベース層を参照していない。
- **`repack.midxSplitFactor` / `repack.midxNewLayerThreshold`** のレイヤー圧縮ヒューリスティック（未実装）。

これらは binary フォーマットに深く関わり、本環境の git は **2.53**（incremental MIDX は 2.55 新規）でバイト一致検証もできないため、別途慎重に扱うべきと判断し本 PR には含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_