### PR TITLE
feat(repack): repack.midxSplitFactor / midxNewLayerThreshold compaction (Git 2.55)

### DIFF
--- a/modules/bit/src/cmd/bit/multi_pack_index.mbt
+++ b/modules/bit/src/cmd/bit/multi_pack_index.mbt
@@ -2750,6 +2750,166 @@ fn midx_relink_monolithic_to_chain(fs : OsFs, pack_dir : String) -> String {
 }
 
 ///|
+/// repack.midxSplitFactor (Git 2.55): a multi-pack-index chain layer must be at
+/// least this many times larger than the layer above it; otherwise incremental
+/// writes compact the two together. Default 2, minimum 2.
+fn midx_repack_split_factor(pack_dir : String) -> Int {
+  let git_dir = parent_dir(parent_dir(pack_dir))
+  match bit_config_get(git_dir, "repack", "midxsplitfactor") {
+    Some(v) => {
+      let n = @string.parse_int(v.trim()) catch {
+        _ => 2
+      }
+      if n < 2 {
+        2
+      } else {
+        n
+      }
+    }
+    None => 2
+  }
+}
+
+///|
+/// repack.midxNewLayerThreshold (Git 2.55): an incremental multi-pack-index
+/// write whose new layer holds fewer than this many objects is folded into the
+/// chain's tip instead of forming its own layer. Default 8, minimum 1.
+fn midx_repack_new_layer_threshold(pack_dir : String) -> Int {
+  let git_dir = parent_dir(parent_dir(pack_dir))
+  match bit_config_get(git_dir, "repack", "midxnewlayerthreshold") {
+    Some(v) => {
+      let n = @string.parse_int(v.trim()) catch {
+        _ => 8
+      }
+      if n < 1 {
+        1
+      } else {
+        n
+      }
+    }
+    None => 8
+  }
+}
+
+///|
+/// Enforce the incremental multi-pack-index layer invariants
+/// (repack.midxSplitFactor / repack.midxNewLayerThreshold). Repeatedly merge the
+/// two top-most chain layers whenever the tip holds fewer than
+/// `new_layer_threshold` objects, or is not at least `split_factor` times
+/// smaller than the layer below it. This keeps the layer count logarithmic
+/// instead of growing by one on every incremental write.
+///
+/// Operates on bit's chain format (each layer an independent MIDX, deduped
+/// against the layers below it); it does not touch bitmap sidecars, so callers
+/// skip it when writing bitmaps.
+async fn midx_compact_chain(
+  fs : OsFs,
+  pack_dir : String,
+  split_factor : Int,
+  new_layer_threshold : Int,
+  oid_version : Int,
+) -> Unit raise Error {
+  let inc_dir = pack_dir + "/multi-pack-index.d"
+  let mut rounds = 0
+  while rounds < 4096 {
+    rounds += 1
+    let hashes = midx_read_chain_hashes(fs, pack_dir)
+    if hashes.length() < 2 {
+      return
+    }
+    // Per-layer object counts and pack lists.
+    let sizes : Array[Int] = []
+    let layer_packs : Array[Array[String]] = []
+    for h in hashes {
+      let p = inc_dir + "/multi-pack-index-" + h + ".midx"
+      let d = fs.read_file(p) catch { _ => Bytes::new(0) }
+      sizes.push(midx_read_oids_from_midx_data(d).size())
+      layer_packs.push(midx_read_packs_from_midx_data(d))
+    }
+    let k = hashes.length() - 1
+    let need_merge = sizes[k] < new_layer_threshold ||
+      sizes[k] * split_factor > sizes[k - 1]
+    if !need_merge {
+      return
+    }
+    // Merge layers[k-1] and layers[k]; base layers are [0, k-1).
+    let base_oids : Map[String, Bool] = {}
+    for i in 0..<(k - 1) {
+      let p = inc_dir + "/multi-pack-index-" + hashes[i] + ".midx"
+      let d = fs.read_file(p) catch { _ => Bytes::new(0) }
+      for oid, _ in midx_read_oids_from_midx_data(d) {
+        base_oids[oid] = true
+      }
+    }
+    let merged_packs : Array[String] = []
+    for pk in layer_packs[k - 1] {
+      if !midx_array_has_string(merged_packs, pk) {
+        merged_packs.push(pk)
+      }
+    }
+    for pk in layer_packs[k] {
+      if !midx_array_has_string(merged_packs, pk) {
+        merged_packs.push(pk)
+      }
+    }
+    midx_sort_strings_lex_in_place(merged_packs)
+    let all_entries : Array[MidxEntry] = []
+    for pack_idx, pack_name in merged_packs {
+      let idx_path = pack_dir +
+        "/" +
+        String::unsafe_substring(pack_name, start=0, end=pack_name.length() - 5) +
+        ".idx"
+      if !fs.is_file(idx_path) {
+        continue
+      }
+      for entry in midx_read_pack_index(fs, idx_path, pack_idx, 0) {
+        all_entries.push(entry)
+      }
+    }
+    all_entries.sort_by(fn(a, b) {
+      let cmp = midx_compare_oid(a.id, b.id)
+      if cmp != 0 {
+        return cmp
+      }
+      a.pack_idx - b.pack_idx
+    })
+    let unique : Array[MidxEntry] = []
+    let mut last : @bitcore.ObjectId? = None
+    for entry in all_entries {
+      match last {
+        Some(lid) if lid == entry.id => continue
+        _ =>
+          if !base_oids.contains(entry.id.to_hex()) {
+            unique.push(entry)
+            last = Some(entry.id)
+          } else {
+            last = Some(entry.id)
+          }
+      }
+    }
+    let merged_bytes = midx_build(merged_packs, unique, false, oid_version, None)
+    let merged_hash = midx_checksum_hex(merged_bytes)
+    // Remove the two merged layers (and any sidecars), write the merged layer.
+    for h in [hashes[k - 1], hashes[k]] {
+      for ext in [".midx", ".bitmap", ".rev"] {
+        fs.remove_file(inc_dir + "/multi-pack-index-" + h + ext) catch {
+          _ => ()
+        }
+      }
+    }
+    fs.write_file(
+      inc_dir + "/multi-pack-index-" + merged_hash + ".midx", merged_bytes,
+    )
+    let new_hashes : Array[String] = []
+    for i in 0..<(k - 1) {
+      new_hashes.push(hashes[i])
+    }
+    new_hashes.push(merged_hash)
+    midx_write_chain_file(fs, pack_dir, new_hashes)
+  }
+}
+
+///|
 async fn midx_write_incremental(
   fs : OsFs,
   pack_dir : String,
@@ -3007,6 +3167,18 @@ async fn midx_write_incremental(
   // Update chain file
   hashes.push(new_hash)
   midx_write_chain_file(fs, pack_dir, hashes)
+  // Compact the chain to keep the layer count bounded (Git 2.55's
+  // repack.midxSplitFactor / repack.midxNewLayerThreshold). Skipped when
+  // writing bitmaps, whose sidecars are keyed to specific layer hashes.
+  if !bitmap {
+    midx_compact_chain(
+      fs,
+      pack_dir,
+      midx_repack_split_factor(pack_dir),
+      midx_repack_new_layer_threshold(pack_dir),
+      oid_version,
+    )
+  }
   // Remove monolithic midx if it still exists
   let monolithic = pack_dir + "/multi-pack-index"
   if fs.is_file(monolithic) {

--- a/modules/bit/src/cmd/bit/repack_midx_incremental_wbtest.mbt
+++ b/modules/bit/src/cmd/bit/repack_midx_incremental_wbtest.mbt
@@ -50,6 +50,97 @@ test "repack --write-midx=incremental writes a midx chain" {
   cleanup_tree(fs, root)
 }
 
+///| Commit a new file, pack the new loose objects into their own packfile
+/// (keeping existing packs), then add them to the incremental multi-pack-index.
+fn midx_inc_commit_and_pack(root : String, tag : String) -> Unit raise Error {
+  let fs = OsFs::new()
+  @fs.write_string_to_file(root + "/file_\{tag}.txt", "data \{tag}\n") catch {
+    _ => ()
+  }
+  @async.run_async_main(async fn() {
+    ignore(try? @bitlib.add_paths_async(fs, fs, root, ["."]))
+  })
+  ignore(
+    try? @bitlib.commit(
+      fs, fs, root, "c\{tag}\n", "Test <t@example.com>", 1700000000L,
+    ),
+  )
+  @async.run_async_main(async fn() {
+    run_main_for_args(["bit", "-C", root, "repack", "-d"])
+  })
+  @async.run_async_main(async fn() {
+    run_main_for_args(["bit", "-C", root, "repack", "--write-midx=incremental"])
+  })
+}
+
+///|
+test "midx repack config readers honor git config with clamping" {
+  @bitnative.init_native_io()
+  let fs = OsFs::new()
+  let root = "/tmp/bit-test-midx-cfg-" + get_current_timestamp().to_string()
+  cleanup_tree(fs, root)
+  fs.mkdir_p(root)
+  ignore(try? @bitrepo.init_repo(fs, root))
+  let pack_dir = root + "/.git/objects/pack"
+  @async.run_async_main(async fn() {
+    run_main_for_args([
+      "bit", "-C", root, "config", "repack.midxSplitFactor", "5",
+    ])
+  })
+  @async.run_async_main(async fn() {
+    run_main_for_args([
+      "bit", "-C", root, "config", "repack.midxNewLayerThreshold", "20",
+    ])
+  })
+  @test.assert_eq(midx_repack_split_factor(pack_dir), 5)
+  @test.assert_eq(midx_repack_new_layer_threshold(pack_dir), 20)
+  // Values below the documented minimums clamp (splitFactor>=2, threshold>=1).
+  @async.run_async_main(async fn() {
+    run_main_for_args([
+      "bit", "-C", root, "config", "repack.midxSplitFactor", "1",
+    ])
+  })
+  @async.run_async_main(async fn() {
+    run_main_for_args([
+      "bit", "-C", root, "config", "repack.midxNewLayerThreshold", "0",
+    ])
+  })
+  @test.assert_eq(midx_repack_split_factor(pack_dir), 2)
+  @test.assert_eq(midx_repack_new_layer_threshold(pack_dir), 1)
+  cleanup_tree(fs, root)
+}
+
+///|
+test "repack --write-midx=incremental keeps the chain compacted" {
+  @bitnative.init_native_io()
+  let fs = OsFs::new()
+  let root = "/tmp/bit-test-midx-compact-" + get_current_timestamp().to_string()
+  cleanup_tree(fs, root)
+  fs.mkdir_p(root)
+  ignore(try? @bitrepo.init_repo(fs, root))
+  let pack_dir = root + "/.git/objects/pack"
+  // Five rounds, each creating a new pack + incremental midx write. With the
+  // default new-layer threshold (8), each tiny layer folds into the tip, so
+  // the chain stays compact instead of growing one layer per round.
+  for r in 0..<5 {
+    midx_inc_commit_and_pack(root, r.to_string())
+  }
+  let packs = midx_find_pack_files(fs, pack_dir)
+  let layers = midx_read_chain_hashes(fs, pack_dir)
+  // Multiple packs were created, but compaction kept the layer count small.
+  assert_true(packs.length() >= 2)
+  assert_true(layers.length() <= 2)
+  // Every hash in the compacted chain resolves to a real layer file.
+  for h in layers {
+    assert_true(
+      fs.is_file(
+        pack_dir + "/multi-pack-index.d/multi-pack-index-" + h + ".midx",
+      ),
+    )
+  }
+  cleanup_tree(fs, root)
+}
+
 ///|
 test "repack --write-midx (plain) writes a monolithic index" {
   @bitnative.init_native_io()


### PR DESCRIPTION
## 背景

Git 2.55 の incremental multi-pack-index repacking の**レイヤー圧縮ヒューリスティック**を取り入れる。`repack --write-midx=incremental`（#117）はこれまで呼び出しごとにチェーン層を 1 つ追加するだけで、層が無制限に増えていた。Git 2.55 は 2 つの config でこれを抑える:

- **`repack.midxSplitFactor`**（既定 2、最小 2）: 各層は上の層より最低これだけ大きくなければならない。
- **`repack.midxNewLayerThreshold`**（既定 8、最小 1）: 新層のオブジェクト数がこれ未満なら、独立層にせず tip に畳み込む。

## 変更

- 上記 config を読む `midx_repack_split_factor` / `midx_repack_new_layer_threshold`（最小値クランプ付き）。
- `midx_compact_chain`: 各 incremental write の**後段**で、tip が threshold 未満、または下の層より split_factor 倍小さくない限り、最上位 2 層を繰り返しマージ。層数を対数的に保つ。
  - bit の既存チェーン形式（層ごと独立 MIDX、下位層に対し OID 除外）上の post-write ステップ。既存のレイヤー書き込み経路は不変。bitmap 書き込み時はスキップ（sidecar が層ハッシュに紐づくため）。

## 見送り（スコープ外・別途）

in-format のベースレイヤ参照 / グローバルオブジェクト番号付け（bit の incremental MIDX を実 git 2.55 とバイト互換にするもの）。本環境の git は 2.53 でバイト検証できないため見送り。

## 検証（native ターゲット）

- **cmd/bit native スイート全体: 1328/1328 pass**（回帰なし）。
- 新規 white-box テスト:
  - config readers が `git config` を honor し最小値クランプする。
  - 5 ラウンドの incremental write で複数 pack が作られるが、チェーンは圧縮され層数 <= 2、各チェーンハッシュが実在の層ファイルに解決する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_