### PR TITLE
perf(status): skip per-object SHA verification on the HEAD-tree walk (#128)

### DIFF
--- a/modules/bit_lib/src/worktree.mbt
+++ b/modules/bit_lib/src/worktree.mbt
@@ -1509,6 +1509,10 @@ fn collect_staged_changes_from_head(
     Some(commit_id) => {
       let common_git_dir = resolve_worktree_common_git_dir(fs, git_dir)
       let db = ObjectDb::load_lazy(fs, common_git_dir)
+      // `git status` does not re-hash HEAD tree/commit objects on read (git
+      // trusts the object store); skip the per-object SHA verification that
+      // otherwise runs for every loose object walked here.
+      db.set_skip_verify(true)
       let commit_obj = db.get(fs, commit_id)
       match commit_obj {
         None => return


### PR DESCRIPTION
## 概要

`git status` は `collect_staged_changes_from_head` で HEAD tree 全体を walk して staged 削除を検出し、tree/commit オブジェクトを読む。その DB を `skip_verify` 無しでロードしていたため、**loose オブジェクトを読むたびに SHA-1 を再計算して照合**していた — git は read 時にこれをしない(オブジェクトストアを信頼し、整合性検査は fsck に任せる)。

status の HEAD-tree DB に `set_skip_verify(true)` を設定。status は最頻コマンドなので、**毎回 loose オブジェクトごとの SHA-1 を削減**(挙動変化なし・git 準拠)。

Partial fix for #128。

## 検証

`bit_lib` `moon test --target js`: **904/906**(残り 2 は既存の `ssh-keygen` 環境依存テストで無関係)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_