### PR TITLE
perf(object_db): index pack offsets instead of linear scans

### DIFF
--- a/modules/bit_lib/src/object_db.mbt
+++ b/modules/bit_lib/src/object_db.mbt
@@ -18,6 +18,13 @@ pub struct PackIndex {
   offsets : Array[Int64]
   version : Int
   mut hex_ids_cache : Array[String]?
+  // Lazily-built offset -> entry-index map, so `find_id_by_offset` is O(1)
+  // instead of scanning every offset on each delta-base resolution.
+  mut offset_index_cache : Map[Int64, Int]?
+  // Lazily-built ascending copy of `offsets`, so locating the next-higher
+  // offset (an object's on-disk end) is a binary search instead of a full
+  // linear scan of every entry.
+  mut sorted_offsets_cache : Array[Int64]?
 }
 
 ///|
@@ -171,17 +178,69 @@ pub fn PackIndex::find_offset_hex(self : PackIndex, hex : String) -> Int64? {
 }
 
 ///|
-/// Find object id (hex) by offset (linear scan).
+/// Return (building lazily on first use) a map from pack offset to the
+/// entry index at that offset. Pack offsets are unique, so the map is exact.
+fn PackIndex::offset_index(self : PackIndex) -> Map[Int64, Int] {
+  match self.offset_index_cache {
+    Some(m) => m
+    None => {
+      let m : Map[Int64, Int] = {}
+      for i in 0..<self.offsets.length() {
+        m[self.offsets[i]] = i
+      }
+      self.offset_index_cache = Some(m)
+      m
+    }
+  }
+}
+
+///|
+/// Return (building lazily on first use) an ascending copy of the pack
+/// offsets, for binary-searching the next-higher offset.
+fn PackIndex::sorted_offsets(self : PackIndex) -> Array[Int64] {
+  match self.sorted_offsets_cache {
+    Some(a) => a
+    None => {
+      let a = self.offsets.copy()
+      a.sort()
+      self.sorted_offsets_cache = Some(a)
+      a
+    }
+  }
+}
+
+///|
+/// Smallest offset strictly greater than `offset`, or None if `offset` is
+/// the last object in the pack. Binary search over the sorted offsets.
+fn PackIndex::next_offset_after(self : PackIndex, offset : Int64) -> Int64? {
+  let sorted = self.sorted_offsets()
+  let mut lo = 0
+  let mut hi = sorted.length()
+  while lo < hi {
+    let mid = lo + (hi - lo) / 2
+    if sorted[mid] <= offset {
+      lo = mid + 1
+    } else {
+      hi = mid
+    }
+  }
+  if lo < sorted.length() {
+    Some(sorted[lo])
+  } else {
+    None
+  }
+}
+
+///|
+/// Find object id (hex) by offset, via the lazily-built offset->index map.
 pub fn PackIndex::find_id_by_offset(
   self : PackIndex,
   offset : Int64,
 ) -> String? {
-  for i in 0..<self.offsets.length() {
-    if self.offsets[i] == offset {
-      return Some(self.id_hex_at(i))
-    }
+  match self.offset_index().get(offset) {
+    Some(i) => Some(self.id_hex_at(i))
+    None => None
   }
-  None
 }
 
 ///|
@@ -530,18 +589,7 @@ fn pack_object_disk_size_at(
   if data.length() <= 32 {
     return None
   }
-  let mut next_offset : Int64? = None
-  for candidate in pack.offsets {
-    if candidate > offset {
-      match next_offset {
-        Some(current) =>
-          if candidate < current {
-            next_offset = Some(candidate)
-          }
-        None => next_offset = Some(candidate)
-      }
-    }
-  }
+  let next_offset = pack.next_offset_after(offset)
   let end_offset = match next_offset {
     Some(found) => found
     None => (data.length() - 20).to_int64() // TODO: use hash_size for SHA-256 packs
@@ -1057,6 +1105,8 @@ fn parse_pack_index_v1(
     offsets,
     version: 1,
     hex_ids_cache: None,
+    offset_index_cache: None,
+    sorted_offsets_cache: None,
   }
 }
 
@@ -1133,7 +1183,16 @@ fn parse_pack_index(
       large_idx += 1
     }
   }
-  { pack_path, id_bytes, hash_size, offsets, version: 2, hex_ids_cache: None }
+  {
+    pack_path,
+    id_bytes,
+    hash_size,
+    offsets,
+    version: 2,
+    hex_ids_cache: None,
+    offset_index_cache: None,
+    sorted_offsets_cache: None,
+  }
 }
 
 ///|

--- a/modules/bit_lib/src/pkg.generated.mbti
+++ b/modules/bit_lib/src/pkg.generated.mbti
@@ -930,6 +930,8 @@ pub struct PackIndex {
   offsets : Array[Int64]
   version : Int
   mut hex_ids_cache : Array[String]?
+  mut offset_index_cache : Map[Int64, Int]?
+  mut sorted_offsets_cache : Array[Int64]?
 }
 pub fn PackIndex::find_id_by_offset(Self, Int64) -> String?
 pub fn PackIndex::find_offset(Self, @object.ObjectId) -> Int64?


### PR DESCRIPTION
## Summary

`PackIndex::find_id_by_offset` scanned every offset in the pack on each call, and `pack_object_disk_size_at` did a full linear pass to find the next-higher offset. Both are hit repeatedly while resolving `OFS_DELTA` bases and computing on-disk object sizes, so a large pack turned each delta-chain resolution / size query into O(N) work over the whole index.

This adds two lazily-built caches to `PackIndex`:

- **offset → entry-index map** — pack offsets are unique, so `find_id_by_offset` becomes an O(1) map lookup instead of an O(N) scan.
- **ascending copy of the offsets** — the "next-higher offset" used to size an object on disk becomes an O(log N) binary search instead of an O(N) pass.

Both caches are built at most once per index instance (same lazy pattern as the existing `hex_ids_cache`) and preserve the exact existing behavior.

Closes #129.

## Test plan

- `moon check --target js` — 0 errors.
- `moon test --target js` — 907 passed; the only 2 failures are the pre-existing `ssh-keygen`-not-available environment failures, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_