### PR TITLE
perf(fsck): skip redundant object re-hashing in connectivity/enumeration

### DIFF
--- a/modules/bit/src/cmd/bit/fsck.mbt
+++ b/modules/bit/src/cmd/bit/fsck.mbt
@@ -48,6 +48,12 @@ async fn handle_fsck(args : Array[String]) -> Unit raise Error {
   let mut errors = 0
   let objects_dir = git_dir + "/objects"
   let db = @bitlib.ObjectDb::load(fs, git_dir)
+  // The connectivity walk (Phase 4) and the dangling/lost-found enumeration
+  // (Phase 5) read every reachable object through this db. Loose object
+  // integrity is already checked by Phase 2 (`fsck_verify_loose_objects`),
+  // and `--connectivity-only` intentionally skips content hashing (matching
+  // git), so re-hashing each object on read here is pure duplicated work.
+  db.set_skip_verify(true)
   // Phase 1: Check HEAD and get resolved OID
   let (head_errors, head_oid) = fsck_check_and_resolve_head(fs, git_dir)
   errors += head_errors


### PR DESCRIPTION
## Summary

`git fsck` loaded its `ObjectDb` without `skip_verify`, so the Phase 4 connectivity walk (`@bitlib.fsck_connectivity_check`) and the Phase 5 dangling / lost-found enumeration re-hashed **every** loose object they read. Phase 2 (`fsck_verify_loose_objects`) already verifies loose-object integrity, and `--connectivity-only` deliberately skips content hashing (matching git), so recomputing each object's SHA again on read in the later phases is pure duplicated work.

This calls `set_skip_verify(true)` on the fsck db so reachable objects are read once without being re-hashed. Phase 2's explicit hash verification is left fully intact, so `fsck` still reports hash mismatches exactly as before.

Addresses #130 via the minimum-fix path the issue calls out. The fuller optimization — reusing the already-inflated bytes across phases to avoid re-*inflation* too — needs a decoded-object cache and is deferred.

## Test plan

- `moon check --target native` — 0 errors (covers the native-only `cmd/bit/fsck.mbt`).
- Behavior preserved: default `fsck` still runs Phase 2 hash verification; `--connectivity-only` remains hash-free as in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_