### PR TITLE
chore(native): use system cc for native builds to avoid tcc crashes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "env": {
+    "MOON_CC": "cc",
+    "MOONBIT_NEW_NATIVE": "1"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,16 @@ flow only downward. See [`docs/package-layout.md`](docs/package-layout.md) for
 the package-by-package classification.
 
 Run `node tools/check-layers.mjs` to validate the dependency graph.
+
+## Native builds
+
+`moon test --target native` runs its test drivers through the bundled
+`tcc -run`, which can crash in some environments. Set `MOON_CC=cc` (or any
+real `cc`/`clang` driver) to compile and run native tests with the system C
+compiler instead — slower to compile, but stable. `MOONBIT_NEW_NATIVE=1`
+selects moonc's newer native backend, which likewise requires a real
+C compiler/linker driver.
+
+Both are set in [`.claude/settings.json`](.claude/settings.json) so Claude
+Code sessions pick them up automatically. `moon build --target native
+--release` (the `bit.exe` binary) already uses `cc`, so it is unaffected.


### PR DESCRIPTION
## Summary

`moon test --target native` runs its per-test C drivers through the bundled `tcc -run`, which crashes in the web/remote build environment. This wires native builds to use the system C compiler instead.

### What I found
- **`moon build --target native --release`** (the `bit.exe` binary) already links via `/usr/bin/cc` — no tcc, unaffected.
- **`moon test --target native`** (debug) uses **119 `tcc -run`** drivers → the crashing path.
- **`MOONBIT_NEW_NATIVE=1` alone is inert** in the pinned toolchain (`moon 0.1.20260608` / `moonc 0.10.0`): the build plan is byte-identical with and without it. Its own error string points at the real lever: *"new native backend requires a C compiler/linker driver; ... set MOON_CC"*.
- **`MOON_CC=cc`** switches the test drivers from `tcc -run` to compile-and-run via `cc`: the native test plan drops to **0 tcc invocations**, and a sample native suite (`mizchi/bit_hash`) passes **15/15 end-to-end through gcc with no tcc process spawned**.

### Change
- Add `.claude/settings.json` setting `MOON_CC=cc` and `MOONBIT_NEW_NATIVE=1` so Claude Code sessions pick them up automatically. `MOONBIT_NEW_NATIVE=1` is harmless today and future-proofs for when the toolchain wires the new backend into the planner.
- Document the rationale under a new "Native builds" section in `AGENTS.md` (aliased by `CLAUDE.md`).

Committed to the repo (not `settings.local.json`) because the remote environment re-clones fresh each session, so only tracked files persist.

## Test plan
- `MOON_CC=cc moon test --target native -p mizchi/bit_hash` → 15/15 pass, `pgrep tcc` empty during the run.
- `moon test --target native --dry-run` vs `MOON_CC=cc …` → tcc-driver count 119 → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_