### PR TITLE
chore(native): adopt MOONBIT_NEW_NATIVE backend with SessionStart toolchain upgrade

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SessionStart hook: ensure a MoonBit toolchain new enough for the
+# MOONBIT_NEW_NATIVE=1 native backend (set in .claude/settings.json).
+#
+# `moon test --target native` otherwise compiles its test drivers through the
+# bundled `tcc -run`, which crashes in this environment. MOONBIT_NEW_NATIVE=1
+# routes native builds through the system `cc`/`clang` instead, but that flag
+# is only wired into moonc from toolchain 0.1.20260629 onward. This container
+# ships an older default (0.1.20260608) where the flag is inert, so upgrade to
+# the latest toolchain when needed.
+set -euo pipefail
+
+# Only relevant in Claude Code on the web (remote) environments.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+export PATH="$HOME/.moon/bin:$PATH"
+
+# First toolchain release where MOONBIT_NEW_NATIVE=1 takes effect.
+MIN_DATE=20260629
+
+extract_date() {
+  moon version 2>/dev/null | grep -oE '0\.1\.[0-9]{8}' | head -1 \
+    | grep -oE '[0-9]{8}$' || echo 0
+}
+
+cur_date="$(extract_date)"
+if [ "${cur_date:-0}" -lt "$MIN_DATE" ]; then
+  echo "moonbit ${cur_date} < ${MIN_DATE}: upgrading to latest for MOONBIT_NEW_NATIVE support..."
+  curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+  export PATH="$HOME/.moon/bin:$PATH"
+  echo "moonbit upgraded to $(extract_date)"
+else
+  echo "moonbit ${cur_date} already supports MOONBIT_NEW_NATIVE"
+fi
+
+# A freshly cloned container loses the cached module registry/deps; refresh it
+# so builds resolve on the first invocation.
+moon update >/dev/null 2>&1 || true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,17 @@
 {
   "env": {
-    "MOON_CC": "cc",
     "MOONBIT_NEW_NATIVE": "1"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,12 +11,16 @@ Run `node tools/check-layers.mjs` to validate the dependency graph.
 ## Native builds
 
 `moon test --target native` runs its test drivers through the bundled
-`tcc -run`, which can crash in some environments. Set `MOON_CC=cc` (or any
-real `cc`/`clang` driver) to compile and run native tests with the system C
-compiler instead — slower to compile, but stable. `MOONBIT_NEW_NATIVE=1`
-selects moonc's newer native backend, which likewise requires a real
-C compiler/linker driver.
+`tcc -run`, which can crash in some environments. `MOONBIT_NEW_NATIVE=1`
+selects moonc's newer native backend, which routes native builds through the
+system `cc`/`clang` driver instead — slower to compile, but stable. That flag
+only takes effect from toolchain `0.1.20260629` onward (it is inert on older
+releases such as `0.1.20260608`).
 
-Both are set in [`.claude/settings.json`](.claude/settings.json) so Claude
-Code sessions pick them up automatically. `moon build --target native
---release` (the `bit.exe` binary) already uses `cc`, so it is unaffected.
+`MOONBIT_NEW_NATIVE=1` is set in
+[`.claude/settings.json`](.claude/settings.json), and the SessionStart hook
+[`.claude/hooks/session-start.sh`](.claude/hooks/session-start.sh) upgrades the
+toolchain to the latest release when it is older than that, so Claude Code web
+sessions get a working native backend automatically. `moon build --target
+native --release` (the `bit.exe` binary) already uses `cc`, so it is
+unaffected.


### PR DESCRIPTION
## Summary

Follow-up to #134. Switches native builds from the `MOON_CC=cc` override to moonc's newer native backend (`MOONBIT_NEW_NATIVE=1`), with a SessionStart hook that guarantees a toolchain new enough to honor it.

### Why
`moon test --target native` compiles its test drivers through the bundled `tcc -run`, which crashes in the web environment. `MOONBIT_NEW_NATIVE=1` routes native builds through the system `cc`/`clang` driver instead.

The catch: that flag is only wired into `moonc` from toolchain **`0.1.20260629`** onward. On the environment's default **`0.1.20260608`** it is completely inert (verified: the native build plan is byte-identical with and without it, still 2 tcc invocations for `bit_hash`). Fresh containers here come up on `0.1.20260608`.

### Change
- **`.claude/hooks/session-start.sh`** (new): remote-only, idempotent, non-interactive. Reads `moon version`; if older than `0.1.20260629`, upgrades to the latest toolchain via the official install script, then refreshes the module registry.
- **`.claude/settings.json`**: drop `MOON_CC`, keep `MOONBIT_NEW_NATIVE=1`, register the hook.
- **`AGENTS.md`**: update the "Native builds" section to match.

## Validation
- ✅ **Hook execution**: upgraded `0.1.20260608 → 0.1.20260629`; second run is a no-op (`moonbit 20260629 already supports MOONBIT_NEW_NATIVE`).
- ✅ **Linter**: `moon check --target js` on `bit_hash` → 0 errors on the upgraded toolchain.
- ✅ **Test**: `MOONBIT_NEW_NATIVE=1 moon test --target native -p mizchi/bit_hash` → 15/15 pass, **zero tcc processes** spawned during the build.

Hook runs **synchronously** (guarantees the toolchain is ready before the agent runs native builds; adds ~1–2 min to session start only when an upgrade is actually needed). Can switch to async if faster startup is preferred. Once merged to the default branch, all future web sessions use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHFC6qxKjqjrixgjFtGihM)_