### PR TITLE
bit-issue skill overhaul + agent-environment fixes for bit issue

### DIFF
--- a/.claude/skills/bit-issue/SKILL.md
+++ b/.claude/skills/bit-issue/SKILL.md
@@ -7,13 +7,55 @@ description: "Manage tasks with bit issue — Git-native issue tracking without 
 
 `bit issue` is a Git-native issue tracker. Issues are stored as Git notes (`refs/notes/bit-hub`) inside the repository — no external service required.
 
+**Agent environments: invoke as `bit --no-git-fallback issue …`.** When any `GIT_CONFIG_*` environment variable is set (Claude Code sessions set `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`), the `bit` shim delegates to real git, which fails with `git: 'issue' is not a git command`. `--no-git-fallback` forces native handling. Examples below omit the flag for brevity.
+
+## Agent Workflow (TL;DR)
+
+1. **Session start**: `git fetch origin '+refs/notes/bit-hub:refs/notes/bit-hub'` to get the latest issues (see [Syncing issues](#syncing-issues)).
+2. **Before starting work**: check the backlog — `bit issue list --open`. Pick up or create an issue for non-trivial work.
+3. **Create** with a priority label and an area label (see [Label conventions](#label-conventions)).
+4. **During work**: record findings with `update --body-append`, progress with `comment add`.
+5. **On completion**: add a closing comment (what was done, commit hash), then `close`. Close sub-issues before their parent.
+6. **Session end**: `git push origin 'refs/notes/bit-hub:refs/notes/bit-hub'` so issues reach the remote.
+
+For session coordination (declaring target files, avoiding conflicts with parallel sessions), use the **start-work** skill. For triaging the backlog, use the **triage-issue** skill.
+
 ## Setup
 
 ```bash
 bit issue init
 ```
 
-This configures `refs/notes/bit-hub` refspecs on origin so issues travel with `git push`/`git fetch`.
+Creates hub metadata and `.git/hub/policy.toml`, and offers to configure `refs/notes/bit-hub` refspecs on origin so issues travel with `git push`/`git fetch`.
+
+**Agent gotcha**: the refspec configuration is an interactive `[y/N]` prompt, gated by TTY (`BIT_HUB_INIT_PROMPT=1` forces the prompt, `=0` suppresses it). In non-interactive sessions the prompt is skipped and **the refspecs are NOT configured** — metadata is initialized, but issues will not sync automatically. Use the explicit refspec commands below instead.
+
+## Syncing issues
+
+Issues live in `refs/notes/bit-hub`, which plain `git push`/`git fetch` does **not** transfer unless refspecs were configured at init. Explicit commands always work:
+
+```bash
+# Get issues from the remote (do this at session start)
+git fetch origin '+refs/notes/bit-hub:refs/notes/bit-hub'
+
+# Send issues to the remote (do this after creating/updating/closing)
+git push origin 'refs/notes/bit-hub:refs/notes/bit-hub'
+```
+
+Caveat: the notes ref is a single history — if two machines update issues concurrently, the push is rejected as non-fast-forward (and a `+` fetch overwrites local-only changes). Fetch before you write, push soon after. For real multi-machine coordination use the **relay-sync** skill.
+
+## Label conventions
+
+Labels observed/established in this repository:
+
+| Kind | Values | Notes |
+|------|--------|-------|
+| Priority | `P0` `P0.5` `P1` `P2` `P3` `P4` | `P0` = now, `P0.5` = next, `P4` = someday. Every backlog issue should carry exactly one. |
+| Area | `merge` `test` `hub` `perf` `wasm` `object` `relay` `sparse` … | Free-form, lowercase, matches subsystem names. |
+| Type | `bug` `edge-case` `epic` | Optional. |
+| Reserved | `session:<branch>` | Session-coordination issues created by the **start-work** skill. Not backlog items — exclude them when triaging. |
+
+When updating priority, remember `--label` **replaces** the whole set — re-pass area/type labels too.
 
 ## Core Workflow
 
@@ -21,7 +63,7 @@ This configures `refs/notes/bit-hub` refspecs on origin so issues travel with `g
 
 ```bash
 bit issue create --title "Add error handling to parser" \
-  --label "bug" --label "priority:high" \
+  --label "bug" --label "P1" --label "parser" \
   --body "Parser panics on malformed input at line 42"
 # Output:
 #   issue abc12345
@@ -31,21 +73,27 @@ bit issue create --title "Add error handling to parser" \
 
 The first line of output is `issue <id>` — extract the ID from there (e.g., `abc12345`).
 
+Short flags: `-t` (title), `-b`/`-m` (body), `-l` (label), `-p` (parent), `-a` (assignee).
+
 ### List issues
 
-By default, `list` shows **top-level** issues (no parent) in **all states** (open + closed). Use `--all` to include sub-issues, `--state` to filter by state.
+By default, `list` shows **top-level** issues (no parent) in **all states** (open + closed). Use `--all` to include sub-issues, `--open`/`--closed` (or `--state open|closed|all`) to filter by state.
 
 ```bash
 bit issue list                          # top-level issues, all states (default)
-bit issue list --state open             # open top-level only
+bit issue list --open                   # open top-level only (= --state open)
 bit issue list --all                    # include sub-issues
-bit issue list --state closed --all     # closed including sub-issues
-bit issue list --label "bug"            # filter by label
+bit issue list --closed --all           # closed including sub-issues
+bit issue list --label "bug"            # filter by label (repeatable, AND)
+bit issue list --limit 10               # cap output (-L also works)
 bit issue list --format json            # JSON output (useful for parsing)
 bit issue list --format json --all      # all issues as JSON
 bit issue list --parent <id>            # children of a specific issue (all states)
-bit issue list --parent <id> --state open  # open children only
+bit issue list --parent <id> --open     # open children only
+bit issue list --tree                   # parent/child tree (children indented)
 ```
+
+Issues with children show a `(sub: N)` suffix; with `--all`, children show `(parent: <id>)`. `--tree` requires bit v0.44+ — older builds render it as a flat list.
 
 ### View an issue
 
@@ -54,15 +102,17 @@ bit issue get <id>                      # or: bit issue view <id>
 bit issue comment list <id>             # read comments (not shown in get output)
 ```
 
-Note: `get` shows issue detail and sub-issue list, but does **not** include comments inline. Use `comment list` separately.
+`get` shows issue detail and its sub-issue list, but does **not** include comments inline. Use `comment list` separately.
 
 ### Update and close
 
 ```bash
-bit issue update <id> --label "in-progress"       # or: bit issue edit <id>
+bit issue update <id> --label "bug" --label "in-progress"   # or: bit issue edit <id>
 bit issue update <id> --body-append "Found root cause: off-by-one in tokenizer"
 bit issue comment add <id> --body "Fixed in commit abc123"
+bit issue comment <id> --body "..."     # gh-style alias for comment add
 bit issue close <id>                    # idempotent
+bit issue reopen <id>                   # idempotent
 ```
 
 **Label behavior**: `--label` **replaces** the entire label set. To add a label while keeping existing ones, include all labels:
@@ -74,42 +124,54 @@ bit issue update <id> --label "in-progress"
 bit issue update <id> --label "bug" --label "in-progress"
 ```
 
+**Closing convention**: add a comment stating the resolution (what changed, commit hash) before closing, so the record survives without chat context.
+
 ## Sub-issues
 
 Break complex tasks into smaller items:
 
 ```bash
 # Create parent
-bit issue create --title "Refactor HTTP client" --label "epic"
+bit issue create --title "Refactor HTTP client" --label "epic" --label "P1"
 # => abc12345
 
 # Create sub-issues
 bit issue create --title "Extract connection pool" --parent abc12345
-bit issue create --title "Add retry logic" --parent abc12345
+bit issue create --title "Add retry logic" -p abc12345
 
 # View children (all states by default)
 bit issue list --parent abc12345
-bit issue list --parent abc12345 --state open        # open children only
+bit issue list --parent abc12345 --open              # open children only
 bit issue list --parent abc12345 --label "bug"       # filter children by label
 ```
 
-Note: Closing a parent does **not** auto-close its children. Close each sub-issue individually.
+Conventions:
+
+- Sub-issues inherit context from the parent — a short title is enough; put shared background in the parent body.
+- Closing a parent does **not** auto-close children. Close each sub-issue as it completes, and close the parent only when all children are closed.
+- One level of nesting is usually enough; prefer labels over deep hierarchies.
+
+## Dependencies (blocked-by)
+
+Record that an issue is blocked by another:
+
+```bash
+bit issue dep add <id> <blocked-by-id>      # mark <id> as blocked by <blocked-by-id>
+bit issue dep list <id>                     # show blockers
+bit issue dep remove <id> <blocked-by-id>   # remove dependency
+```
+
+`get` shows a `blocked-by <id>` line. Dependencies are informational only — `close` does **not** check for open blockers, and `list`/JSON output do not surface them. Check `dep list` before picking up an issue.
 
 ## Search
 
 Search returns both open and closed issues by default.
 
 ```bash
-bit issue search "parser error"                     # title/body search
-bit issue search --label "bug" --state open          # filtered search
+bit issue search "parser error"                      # title/body search
+bit issue search --label "bug" --open                # filtered search
 bit issue search --type issue-comment "workaround"   # search comments
-```
-
-## Import from GitHub
-
-```bash
-bit issue import --repo owner/repo                  # import all issues
-bit issue import --repo owner/repo --state open     # open only
+bit issue search "parser" --limit 5 --format json    # JSON output
 ```
 
 ## Cross-repo References
@@ -121,32 +183,17 @@ Link issues across local repositories using `owner/repo#id` format.
 Resolution order: alias → ghq path (`~/ghq/github.com/owner/repo`) → error.
 
 ```bash
-# Register an alias for a local repo
-bit issue remote add myapp ~/ghq/github.com/owner/app
+bit issue remote add myapp ~/ghq/github.com/owner/app   # register alias
 bit issue remote list
 bit issue remote remove myapp
 ```
 
-### Link cross-repo issues
+### Link, read, create across repos
 
 ```bash
-# Link a remote issue to a local issue
-bit issue link <local-id> owner/repo#remote-id
-bit issue link <local-id> myapp#remote-id       # using alias
-```
-
-### Read remote issues
-
-```bash
+bit issue link <local-id> owner/repo#remote-id  # link remote issue to local issue
 bit issue get owner/repo#issue-id               # read from another local repo
-bit issue get myapp#issue-id                     # using alias
-```
-
-### Create in remote repo
-
-```bash
-bit issue create --repo owner/repo --title "Fix bug in shared lib"
-bit issue create --repo myapp --title "Fix bug"  # using alias
+bit issue create --repo myapp --title "Fix bug" # create in remote repo (alias OK)
 ```
 
 ### Working set (active issues)
@@ -238,7 +285,8 @@ This creates `.git/hooks/post-push` that auto-pushes after `git push`.
 ### Import (one-way, no SyncLink)
 
 ```bash
-bit issue import --repo owner/repo                                 # import without tracking
+bit issue import --repo owner/repo                                 # import all issues
+bit issue import --repo owner/repo --state open                    # open only
 ```
 
 Note: `import` does NOT create SyncLink mappings. Use `sync pull` for tracked sync.
@@ -258,16 +306,17 @@ bit issue watch                         # stream claim/unclaim events in real-ti
 
 | Command | Description |
 |---------|-------------|
-| `bit issue init` | Setup hub metadata and refspecs |
-| `bit issue create` | Create issue (`--title`, `--body`, `--label`, `--parent`, `--link`) |
-| `bit issue list` | List top-level issues (`--state`, `--all`, `--parent`, `--label`, `--format json`) |
+| `bit issue init` | Setup hub metadata and refspecs (interactive; see Setup) |
+| `bit issue create` | Create issue (`--title/-t`, `--body/-b`, `--label/-l`, `--parent/-p`, `--assignee/-a`, `--link`, `--repo`) |
+| `bit issue list` | List top-level issues (`--open`, `--closed`, `--state`, `--all`, `--parent`, `--label`, `--limit/-L`, `--format json`) |
 | `bit issue get <id>` | View issue detail (alias: `view`) |
-| `bit issue update <id>` | Update issue (`--title`, `--body`, `--body-append`, `--label`; alias: `edit`) |
+| `bit issue update <id>` | Update issue (`--title`, `--body`, `--body-append`, `--label`, `--assignee`; alias: `edit`) |
 | `bit issue close <id>` | Close issue (idempotent) |
 | `bit issue reopen <id>` | Reopen issue (idempotent) |
-| `bit issue comment add <id>` | Add comment (`--body`, `--reply-to`) |
-| `bit issue comment list <id>` | List comments |
-| `bit issue search` | Search issues (`--type`, `--state`, `--author`, `--label`, `--limit`) |
+| `bit issue comment add <id>` | Add comment (`--body`, `--reply-to`; gh-style alias: `comment <id> --body`) |
+| `bit issue comment list <id>` | List comments (oldest first) |
+| `bit issue dep add\|remove\|list` | Manage blocked-by dependencies (informational only) |
+| `bit issue search` | Search issues (`--type`, `--state`/`--open`/`--closed`, `--author`, `--label`, `--limit`, `--format json`) |
 | `bit issue import` | Import from GitHub (`--repo`, `--state`, `--limit`, `--provider`) |
 | `bit issue link <issue> <target>` | Link PR or cross-repo issue (`owner/repo#id`) |
 | `bit issue remote add\|list\|remove` | Manage repo aliases for cross-repo refs |
@@ -298,7 +347,7 @@ bit issue watch                         # stream claim/unclaim events in real-ti
   "created_at": 1774856949,
   "updated_at": 1774856949,
   "body": "Issue body text",
-  "labels": ["bug", "priority:high"],
+  "labels": ["bug", "P1"],
   "assignees": [],
   "linked_prs": [],
   "parent_id": null
@@ -309,21 +358,29 @@ Timestamps are Unix epoch seconds. `parent_id` is `null` for top-level issues.
 
 ## Gotchas
 
-- **`list` shows all states by default**: Use `--state open` or `--state closed` to filter. Without `--state`, both open and closed issues are shown.
+- **`list` shows all states by default**: Use `--open`/`--closed` (or `--state open|closed`) to filter. Without a state filter, both open and closed issues are shown.
 - **`list` hides sub-issues by default**: Use `--all` to include them. `--parent <id>` shows all states of children by default.
 - **`get` does not show comments**: Use `bit issue comment list <id>` separately to read comments.
-- **`search` returns all states**: Open and closed issues are both returned unless `--state` is specified.
+- **`search` returns all states**: Open and closed issues are both returned unless a state filter is given.
 - **`update --label` replaces all labels**: Pass all desired labels every time. Omitting an existing label removes it.
 - **Closing a parent does not close children**: Each sub-issue must be closed individually.
 - **`close` is idempotent but messages differ**: First call prints `Closed issue #<id>`, subsequent calls print `Issue #<id> is already closed`. Both are success (exit 0).
 - **`comment list` is oldest-first**: Comments are returned in chronological order (oldest first).
-- **`--tree` is unreliable**: The flag is accepted but currently renders a flat list without indentation. Use `--parent <id>` for reliable sub-issue listing.
-- **CLI `--help` is incomplete**: Some flags (`--all`, `--body-append`, `--format`, `--parent`) work but are not shown in `--help` output. This skill doc is the authoritative reference.
+- **Issues don't sync on plain `git push` unless refspecs are configured**: In non-interactive sessions `bit issue init` never applies the refspecs. Use the explicit fetch/push commands in [Syncing issues](#syncing-issues).
+- **`GIT_CONFIG_*` env vars break `bit issue`**: The shim delegates to real git when config-injection env vars are present. Always pass `--no-git-fallback` in agent environments (see top of this doc).
+- **CLI `--help` misses some flags**: `--format json`, `--body-append`, and `--label` filtering on `list` work but are not shown in `--help`. This skill doc is the authoritative reference.
+- **`dep` is informational only**: `close` does not check for open blockers.
 
 ## Data Model
 
 - Storage: `refs/notes/bit-hub` (Git notes)
 - ID format: `<8-char hex hash>` (e.g., `bec2b506`)
 - States: `open`, `closed`
-- Sync: automatic via `git push`/`git fetch` after `bit issue init`
+- Sync: `git push`/`git fetch` with `refs/notes/bit-hub` refspecs (see Syncing issues)
 - Relay: optional, for real-time sync across machines (`bit relay sync push/fetch`)
+
+## Related Skills
+
+- **start-work** — session coordination protocol (declare target files via `session:<branch>` issues, detect conflicts with parallel sessions).
+- **triage-issue** — backlog triage flow (categorize, assess complexity, assign labels).
+- **relay-sync** — multi-machine issue sync via a relay server.

--- a/.claude/skills/bit-issue/SKILL.md
+++ b/.claude/skills/bit-issue/SKILL.md
@@ -372,7 +372,7 @@ Timestamps are Unix epoch seconds. `parent_id` is `null` for top-level issues.
 - **`comment list` is oldest-first**: Comments are returned in chronological order (oldest first).
 - **Issues don't sync on plain `git push` unless refspecs are configured**: With bit ≤ v0.44.0, non-interactive `bit issue init` never applies the refspecs (fixed after v0.44.0 for explicit init). Use the explicit fetch/push commands in [Syncing issues](#syncing-issues) when unsure.
 - **`GIT_CONFIG_*` env vars break `bit issue` on bit ≤ v0.44.0**: The shim delegates to real git when config-injection env vars are present (fixed after v0.44.0). Pass `--no-git-fallback` when the binary may be older (see top of this doc).
-- **CLI `--help` misses some flags**: `--format json`, `--body-append`, and `--label` filtering on `list` work but are not shown in `--help`. This skill doc is the authoritative reference.
+- **CLI `--help` misses some flags on bit ≤ v0.44.0**: `--format json`, `--body-append`, and `--label` filtering on `list` work but are not shown in `--help` (fixed after v0.44.0). This skill doc is the authoritative reference.
 - **`dep` is informational only**: `close` does not check for open blockers.
 
 ## Data Model

--- a/.claude/skills/bit-issue/SKILL.md
+++ b/.claude/skills/bit-issue/SKILL.md
@@ -7,7 +7,7 @@ description: "Manage tasks with bit issue — Git-native issue tracking without 
 
 `bit issue` is a Git-native issue tracker. Issues are stored as Git notes (`refs/notes/bit-hub`) inside the repository — no external service required.
 
-**Agent environments: invoke as `bit --no-git-fallback issue …`.** When any `GIT_CONFIG_*` environment variable is set (Claude Code sessions set `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`), the `bit` shim delegates to real git, which fails with `git: 'issue' is not a git command`. `--no-git-fallback` forces native handling. Examples below omit the flag for brevity.
+**Agent environments (bit ≤ v0.44.0): invoke as `bit --no-git-fallback issue …`.** When any `GIT_CONFIG_*` environment variable is set (Claude Code sessions set `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`), the `bit` shim delegates to real git, which fails with `git: 'issue' is not a git command`. `--no-git-fallback` forces native handling. Fixed after v0.44.0 (bit-only commands never delegate), but keep the flag when the installed binary may be older. Examples below omit the flag for brevity.
 
 ## Agent Workflow (TL;DR)
 
@@ -28,7 +28,7 @@ bit issue init
 
 Creates hub metadata and `.git/hub/policy.toml`, and offers to configure `refs/notes/bit-hub` refspecs on origin so issues travel with `git push`/`git fetch`.
 
-**Agent gotcha**: the refspec configuration is an interactive `[y/N]` prompt, gated by TTY (`BIT_HUB_INIT_PROMPT=1` forces the prompt, `=0` suppresses it). In non-interactive sessions the prompt is skipped and **the refspecs are NOT configured** — metadata is initialized, but issues will not sync automatically. Use the explicit refspec commands below instead.
+**Agent gotcha (bit ≤ v0.44.0)**: the refspec configuration is an interactive `[y/N]` prompt, gated by TTY (`BIT_HUB_INIT_PROMPT=1` forces the prompt, `=0` suppresses it). In non-interactive sessions the prompt is skipped and **the refspecs are NOT configured** — metadata is initialized, but issues will not sync automatically. Fixed after v0.44.0: an explicit `bit issue init` applies the refspecs directly in non-interactive sessions (implicit auto-init on first `issue create` still skips them). With older binaries, use the explicit refspec commands below instead.
 
 ## Syncing issues
 
@@ -42,7 +42,10 @@ git fetch origin '+refs/notes/bit-hub:refs/notes/bit-hub'
 git push origin 'refs/notes/bit-hub:refs/notes/bit-hub'
 ```
 
-Caveat: the notes ref is a single history — if two machines update issues concurrently, the push is rejected as non-fast-forward (and a `+` fetch overwrites local-only changes). Fetch before you write, push soon after. For real multi-machine coordination use the **relay-sync** skill.
+Caveats:
+
+- The notes ref is a single history — if two machines update issues concurrently, the push is rejected as non-fast-forward, and a `+` fetch **overwrites local-only changes** (recover via `git fsck --unreachable` if this bites). Fetch **before** you write locally, not after, and push soon after writing. For real multi-machine coordination use the **relay-sync** skill.
+- Claude Code web sessions can usually **fetch** the notes ref but get HTTP 403 on **push** (the session proxy only allows pushing the designated branch). Record issue updates locally anyway and hand them off: `git bundle create issues.bundle refs/notes/bit-hub`, send the bundle to the user, who imports with `git fetch <bundle> '+refs/notes/bit-hub:refs/notes/bit-hub'` and pushes from their machine.
 
 ## Label conventions
 
@@ -161,7 +164,7 @@ bit issue dep list <id>                     # show blockers
 bit issue dep remove <id> <blocked-by-id>   # remove dependency
 ```
 
-`get` shows a `blocked-by <id>` line. Dependencies are informational only — `close` does **not** check for open blockers, and `list`/JSON output do not surface them. Check `dep list` before picking up an issue.
+`get` shows a `blocked-by <id>` line, and JSON output (after v0.44.0) includes a `blocked_by` array. Dependencies are informational only — `close` does **not** check for open blockers, and plain `list` lines do not mark blocked issues. Check `dep list` (or the JSON field) before picking up an issue.
 
 ## Search
 
@@ -350,6 +353,7 @@ bit issue watch                         # stream claim/unclaim events in real-ti
   "labels": ["bug", "P1"],
   "assignees": [],
   "linked_prs": [],
+  "blocked_by": [],
   "parent_id": null
 }]
 ```
@@ -366,8 +370,8 @@ Timestamps are Unix epoch seconds. `parent_id` is `null` for top-level issues.
 - **Closing a parent does not close children**: Each sub-issue must be closed individually.
 - **`close` is idempotent but messages differ**: First call prints `Closed issue #<id>`, subsequent calls print `Issue #<id> is already closed`. Both are success (exit 0).
 - **`comment list` is oldest-first**: Comments are returned in chronological order (oldest first).
-- **Issues don't sync on plain `git push` unless refspecs are configured**: In non-interactive sessions `bit issue init` never applies the refspecs. Use the explicit fetch/push commands in [Syncing issues](#syncing-issues).
-- **`GIT_CONFIG_*` env vars break `bit issue`**: The shim delegates to real git when config-injection env vars are present. Always pass `--no-git-fallback` in agent environments (see top of this doc).
+- **Issues don't sync on plain `git push` unless refspecs are configured**: With bit ≤ v0.44.0, non-interactive `bit issue init` never applies the refspecs (fixed after v0.44.0 for explicit init). Use the explicit fetch/push commands in [Syncing issues](#syncing-issues) when unsure.
+- **`GIT_CONFIG_*` env vars break `bit issue` on bit ≤ v0.44.0**: The shim delegates to real git when config-injection env vars are present (fixed after v0.44.0). Pass `--no-git-fallback` when the binary may be older (see top of this doc).
 - **CLI `--help` misses some flags**: `--format json`, `--body-append`, and `--label` filtering on `list` work but are not shown in `--help`. This skill doc is the authoritative reference.
 - **`dep` is informational only**: `close` does not check for open blockers.
 

--- a/.claude/skills/start-work/SKILL.md
+++ b/.claude/skills/start-work/SKILL.md
@@ -9,6 +9,13 @@ Coordinate coding sessions using `bit issue`. Each session declares its Target F
 
 This protocol works with any workflow — single-repo, worktrees, or branches.
 
+Issue storage/sync details and label conventions live in the **bit-issue** skill. In fresh clones (e.g. Claude Code web sessions) fetch the issue notes first, and push them when you update issues:
+
+```bash
+git fetch origin '+refs/notes/bit-hub:refs/notes/bit-hub'   # before reading
+git push origin 'refs/notes/bit-hub:refs/notes/bit-hub'     # after writing
+```
+
 ## Decide: New Session or Resume
 
 ```bash

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -15,13 +15,13 @@ Analyze and triage issues.
 
 ## Steps
 
-1. **Read the issue**: `bit issue get <id>`
+1. **Read the issue**: `bit issue get <id>` (skip `session:<branch>` labeled issues — they are session-coordination records, not backlog)
 2. **Categorize**: Determine type (bug, feature, question, improvement, docs)
 3. **Assess complexity**: Estimate as small/medium/large based on:
    - Number of files likely affected
    - Whether it requires new architecture
    - Test coverage implications
-4. **Suggest labels**: Based on category and affected area
+4. **Suggest labels**: Follow the label conventions in the **bit-issue** skill — one priority (`P0`, `P0.5`, `P1`, `P2`, `P3`, `P4`) + area (`merge`, `test`, `hub`, `perf`, `wasm`, `object`, `relay`, `sparse`, …) + optional type (`bug`, `edge-case`, `epic`)
 5. **Propose approach**: Brief implementation plan if applicable
 6. **Update issue**: Add labels and comment with analysis
 
@@ -32,8 +32,8 @@ Analyze and triage issues.
 
 **Type**: bug | feature | question | improvement
 **Complexity**: small | medium | large
-**Labels**: label1, label2
-**Area**: src/cmd/bit, src/lib, src/pack, etc.
+**Labels**: P1, merge, bug
+**Area**: modules/bit_core, modules/bit/cmd/bit, modules/bitx_hub, etc.
 
 ## Analysis
 Brief description of what needs to be done.
@@ -47,7 +47,8 @@ Brief description of what needs to be done.
 ## Commands
 
 ```bash
-bit issue update <id> --label "bug" --label "priority:medium"
+# --label replaces the whole set: pass priority + area + type together
+bit issue update <id> --label "P1" --label "merge" --label "bug"
 bit issue comment add <id> --body "Triage: ..."
 ```
 

--- a/modules/bit/cmd/bit/hub_helpers.mbt
+++ b/modules/bit/cmd/bit/hub_helpers.mbt
@@ -396,6 +396,11 @@ fn format_issue_json(issue : @hub.Issue) -> String {
   for p in linked {
     linked_parts.push(json_escape_string(p))
   }
+  let blocked_by = issue.blocked_by()
+  let blocked_by_parts : Array[String] = []
+  for b in blocked_by {
+    blocked_by_parts.push(json_escape_string(b))
+  }
   let parent = match issue.parent_id {
     Some(pid) => json_escape_string(pid)
     None => "null"
@@ -414,6 +419,7 @@ fn format_issue_json(issue : @hub.Issue) -> String {
   buf.write_string(",\"labels\":[" + label_parts.join(",") + "]")
   buf.write_string(",\"assignees\":[" + assignee_parts.join(",") + "]")
   buf.write_string(",\"linked_prs\":[" + linked_parts.join(",") + "]")
+  buf.write_string(",\"blocked_by\":[" + blocked_by_parts.join(",") + "]")
   buf.write_string(",\"parent_id\":" + parent)
   buf.write_string("}")
   buf.to_string()

--- a/modules/bit/cmd/bit/hub_issue.mbt
+++ b/modules/bit/cmd/bit/hub_issue.mbt
@@ -4,7 +4,7 @@ fn print_hub_issue_usage() -> Unit {
   println("")
   println("Subcommands:")
   println(
-    "  list [--state <open|closed> | --open | --closed] [--limit <n>] [--all | --tree | --parent <id>]",
+    "  list [--state <open|closed> | --open | --closed] [--label <name>...] [--limit <n>] [--all | --tree | --parent <id>] [--format json]",
   )
   println(
     "  import [--repo <owner/repo>] [--state <open|closed|all>] [--limit <n>]",
@@ -12,10 +12,10 @@ fn print_hub_issue_usage() -> Unit {
   println("  get <id>")
   println("  view <id>                             (alias: get)")
   println(
-    "  create --title <title> [--body <body>] [--label <label>...] [--assignee <user>...]",
+    "  create --title <title> [--body <body>] [--label <label>...] [--assignee <user>...] [--parent <id>] [--link <url>] [--repo <alias>]",
   )
   println(
-    "  update <id> [--title <title>] [--body <body>] [--label <label>...] [--assignee <user>...]",
+    "  update <id> [--title <title>] [--body <body>] [--body-append <text>] [--label <label>...] [--assignee <user>...]",
   )
   println("  edit <id> ...                         (alias: update)")
   println("  close <id>")
@@ -35,7 +35,9 @@ fn print_hub_issue_usage() -> Unit {
     "  claims [--stale-hours <n>] [--remote <url>] [--auth-token <token>]",
   )
   println("  watch [--stale-hours <n>] [--remote <url>] [--auth-token <token>]")
-  println("  search [<query>...] [<options>]")
+  println(
+    "  search [<query>...] [--type <issue|issue-comment>] [--state <s> | --open | --closed] [--author <a>] [--label <name>] [--limit <n>] [--format json]",
+  )
   println("  note <subcommand> [<args>]")
   println("  start <ref>                           (add to working set)")
   println("  stop <ref>                            (remove from working set)")

--- a/modules/bit/cmd/bit/hub_stores.mbt
+++ b/modules/bit/cmd/bit/hub_stores.mbt
@@ -295,6 +295,28 @@ async fn print_hub_init_metadata_prompt(
 }
 
 ///|
+async fn print_hub_init_sync_applied(
+  command_name : String,
+  plan : HubOriginSyncPlan,
+) -> Unit {
+  eprint_line(
+    "bit \{command_name}: configured local git sync for hub metadata on 'origin'",
+  )
+  if plan.add_fetch_notes {
+    eprint_line("  remote.origin.fetch += " + hub_notes_fetch_refspec())
+  }
+  if plan.add_default_push_refspec {
+    eprint_line("  remote.origin.push += " + hub_default_push_refspec())
+    eprint_line(
+      "  note: this makes plain `git push origin` use explicit refspecs",
+    )
+  }
+  if plan.add_push_notes {
+    eprint_line("  remote.origin.push += " + hub_notes_push_refspec())
+  }
+}
+
+///|
 async fn print_hub_init_sync_prompt(
   command_name : String,
   plan : HubOriginSyncPlan,
@@ -350,6 +372,14 @@ async fn ensure_hub_initialized(
     return ()
   }
   if !interactive {
+    // Explicit `bit issue init` / `bit pr init` in a non-interactive session
+    // (CI, agents): apply the sync config directly — prompting is impossible,
+    // and skipping silently would leave hub metadata unsynced even though the
+    // user asked for init. Implicit auto-init keeps skipping as before.
+    if explicit {
+      apply_hub_origin_sync_plan(fs, git_dir, plan)
+      print_hub_init_sync_applied(command_name, plan)
+    }
     return ()
   }
   print_hub_init_sync_prompt(command_name, plan)

--- a/modules/bit/cmd/bit/main.mbt
+++ b/modules/bit/cmd/bit/main.mbt
@@ -1013,6 +1013,26 @@ fn can_handle_global_config_in_shim(opts : GlobalOptions) -> Bool {
 }
 
 ///|
+/// Commands that exist only in bit. Real git cannot handle them, so config
+/// injection (-c / GIT_CONFIG_*) must never route them to a real git binary.
+fn is_bit_only_command(cmd : String) -> Bool {
+  match normalize_dispatch_command(cmd) {
+    "hub"
+    | "pr"
+    | "issue"
+    | "relay"
+    | "workspace"
+    | "repo"
+    | "hq"
+    | "subdir-clone"
+    | "ai"
+    | "rebase-ai"
+    | "debug" => true
+    _ => false
+  }
+}
+
+///|
 fn should_delegate_to_real_git(
   args : Array[String],
   opts : GlobalOptions,
@@ -1043,7 +1063,10 @@ fn should_delegate_to_real_git(
       // config/status are handled natively by default; like every other
       // command they only fall back when global config injection (-c /
       // GIT_CONFIG_*) is present and the shim cannot apply it itself.
-      if cmd == "worktree" || cmd == "submodule" || cmd == "submodule--helper" {
+      if cmd == "worktree" ||
+        cmd == "submodule" ||
+        cmd == "submodule--helper" ||
+        is_bit_only_command(cmd) {
         false
       } else if shim_handles_config {
         false

--- a/modules/bit/cmd/bit/main_wbtest.mbt
+++ b/modules/bit/cmd/bit/main_wbtest.mbt
@@ -93,6 +93,20 @@ test "main: config and status stay native without config injection" {
 }
 
 ///|
+test "main: bit-only commands stay native under config injection" {
+  let prev = @sys.get_env_var("GIT_CONFIG_PARAMETERS")
+  @sys.set_env_var("GIT_CONFIG_PARAMETERS", "'core.editor'='vim'")
+  for cmd in ["issue", "pr", "hub", "relay", "workspace", "ws", "hq"] {
+    let opts = parse_global_options(["bit", cmd, "list"])
+    assert_false(should_delegate_to_real_git(["bit", cmd, "list"], opts))
+  }
+  match prev {
+    Some(value) => @sys.set_env_var("GIT_CONFIG_PARAMETERS", value)
+    None => @sys.unset_env_var("GIT_CONFIG_PARAMETERS")
+  }
+}
+
+///|
 test "main: config and status still delegate under config injection" {
   let prev = @sys.get_env_var("GIT_CONFIG_PARAMETERS")
   @sys.set_env_var("GIT_CONFIG_PARAMETERS", "'core.editor'='vim'")


### PR DESCRIPTION
## Summary

Two related pieces of work: an overhaul of the `bit-issue` Claude Code skill (verified against real CLI behavior, plus operational conventions), and four fixes in bit itself for problems the verification uncovered in agent/non-interactive environments.

### Skill / workflow changes (`.claude/skills/`)

- **bit-issue**: rewrote around an agent workflow TL;DR (fetch notes → pick/create issue → record progress → close with comment → push notes). Added label conventions observed in the existing hub data (P0–P4 priority, area, type, reserved `session:<branch>`), explicit `refs/notes/bit-hub` fetch/push commands, notes-divergence recovery, and previously undocumented commands (`dep add|remove|list`, gh-style `comment`, `--open`/`--closed`, `--limit/-L`, short flags). Dropped the stale "`--tree` is unreliable" gotcha (v0.44 renders an indented tree with `(sub: N)` counts).
- **triage-issue**: aligned labels to the P0–P4 + area scheme, noted `--label` replace semantics, skip `session:*` issues, fixed module paths.
- **start-work**: added notes fetch/push for fresh clones (web sessions).

### bit fixes (`modules/bit/cmd/bit/`)

1. **`GIT_CONFIG_*` env vars broke every bit-only command** — the git-shim delegated to real git whenever config-injection env vars were present (Claude Code sessions always set `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`), so `bit issue list` failed with `git: 'issue' is not a git command`. Added `is_bit_only_command()` (`hub`, `pr`, `issue`, `relay`, `workspace`, `repo`, `hq`, `subdir-clone`, `ai`, `rebase-ai`, `debug`) which never delegates. Regression test in `main_wbtest.mbt`. (bit issue `aa4ce887`)
2. **Non-interactive `bit issue init` silently skipped sync setup** — the origin refspec config sat behind a TTY-gated `[y/N]` prompt, so agent/CI sessions ended up with issues that never sync. An explicit `bit issue init` now applies the sync plan directly when non-interactive and reports what it configured on stderr; implicit auto-init (first `issue create`) still skips it. (bit issue `e306a0a2`)
3. **`--format json` now includes `blocked_by`** — dependencies recorded via `bit issue dep add` were only visible in `get` text output; `list`/`search` JSON now expose the array. (bit issue `7670c9bb`)
4. **`bit issue --help` now documents all implemented flags** — added `--label`/`--format json` to `list`, `--parent`/`--link`/`--repo` to `create`, `--body-append` to `update`, and concrete options for `search`. (bit issue `02900d90`)

## Testing

- `moon test --target native modules/bit/cmd/bit/main_wbtest.mbt` (CI-style, `MOON_CC=gcc`): **11/11 passed**, including the new delegation regression test. (Note: in an environment where `GIT_CONFIG_*` leaks into the test process, 3 pre-existing delegation tests fail for that reason alone; clean env passes.)
- `moon check`: 0 errors.
- Runtime-verified on a freshly built binary: `bit issue list` works with `GIT_CONFIG_*` set and no `--no-git-fallback`; non-interactive `bit issue init` writes both refspecs to `.git/config` while implicit auto-init does not; `blocked_by` appears in `list`/`search` JSON; `issue --help` shows the added flags.

The four fixes are tracked as bit issues (closed with resolution comments referencing the fixing commits). The notes ref (`refs/notes/bit-hub`) cannot be pushed from this session (proxy allows only the PR branch), so the issue records were handed off as a git bundle separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6