### PR TITLE
history: implement git history reword (git 2.55 EXPERIMENTAL)

### DIFF
--- a/modules/bit/cmd/bit/history.mbt
+++ b/modules/bit/cmd/bit/history.mbt
@@ -1,6 +1,7 @@
 ///|
 /// git history: EXPERIMENTAL history-rewriting command group (git 2.55).
-/// Currently only the `fixup` subcommand is implemented.
+/// Implemented subcommands: `fixup`, `reword`. `split` requires interactive
+/// hunk selection and is not implemented yet.
 
 ///|
 async fn handle_history(args : Array[String]) -> Unit raise Error {
@@ -11,9 +12,14 @@ async fn handle_history(args : Array[String]) -> Unit raise Error {
   let rest = args[1:].to_array()
   match sub {
     "fixup" => handle_history_fixup(rest)
+    "reword" => handle_history_reword(rest)
+    "split" =>
+      raise @bitcore.GitError::InvalidObject(
+        "git history split is not implemented yet (requires interactive hunk selection)",
+      )
     _ =>
       raise @bitcore.GitError::InvalidObject(
-        "git history: unknown subcommand '\{sub}' (only 'fixup' is supported)",
+        "git history: unknown subcommand '\{sub}' (supported: fixup, reword)",
       )
   }
 }
@@ -99,42 +105,9 @@ async fn handle_history_fixup(args : Array[String]) -> Unit raise Error {
     raise @bitcore.GitError::InvalidObject("nothing to fixup: no staged changes")
   }
 
-  // Collect the tips to consider: all branches (+ HEAD) or just HEAD.
-  let (head_ref, branches) = @bitlib.list_branches(rfs, git_dir)
-  let tips : Array[@bitlib.HistoryRefUpdate] = []
-  if only_head {
-    // Only rewrite HEAD's branch; error if target is not in HEAD ancestry.
-    if not(@bitlib.merge_base_is_ancestor(db, rfs, target, head)) {
-      raise @bitcore.GitError::InvalidObject(
-        "rewritten commit must be an ancestor of HEAD when using --update-refs=head",
-      )
-    }
-    match head_ref {
-      Branch(name) =>
-        tips.push({
-          refname: "refs/heads/" + name,
-          old_id: head,
-          new_id: head,
-        })
-      Detached(_) =>
-        tips.push({ refname: "HEAD", old_id: head, new_id: head })
-    }
-  } else {
-    for b in branches {
-      tips.push({
-        refname: "refs/heads/" + b.name,
-        old_id: b.id,
-        new_id: b.id,
-      })
-    }
-  }
-
-  // Reject histories containing merges between target and any tip.
-  for tip in tips {
-    if @bitlib.merge_base_is_ancestor(db, rfs, target, tip.new_id) {
-      history_reject_merges_cmd(db, rfs, target, tip.new_id)
-    }
-  }
+  let (head_ref, tips) = history_collect_tips_cmd(
+    db, rfs, git_dir, target, head, only_head,
+  )
 
   let reedit_message : String? = if reedit {
     // Open the target's message in the editor and use whatever comes back.
@@ -167,14 +140,195 @@ async fn handle_history_fixup(args : Array[String]) -> Unit raise Error {
   }
 
   // Apply the ref updates, recording a reflog entry for each.
+  let new_head = history_apply_updates_cmd(
+    ffs, rfs, git_dir, result.updates, head_ref, "fixup: updating " + spec,
+  )
+
+  // Reset the index to the new HEAD so staged changes are consumed, while
+  // leaving unstaged worktree changes in place (mixed reset semantics).
+  // Best-effort: a failure here must not abort the (already applied) rewrite.
+  match new_head {
+    Some(nh) =>
+      try
+        ignore(
+          @bitlib.reset(ffs, rfs, root, nh.to_hex(), @bitlib.ResetMode::Mixed),
+        )
+      catch {
+        _ => ()
+      }
+    None => ()
+  }
+}
+
+///|
+/// git history reword <commit> [--dry-run] [--update-refs=(branches|head)]
+/// Rewrite the target commit's message via the editor and replay descendants.
+async fn handle_history_reword(args : Array[String]) -> Unit raise Error {
+  let root = get_work_root()
+  let fs = OsFs::new()
+  let rfs : &@bitcore.RepoFileSystem = fs
+  let ffs : &@bitcore.FileSystem = fs
+  let git_dir = resolve_git_dir(rfs, root)
+
+  // -- parse arguments ------------------------------------------------------
+  let mut dry_run = false
+  let mut only_head = false
+  let mut target_spec : String? = None
+  let mut i = 0
+  while i < args.length() {
+    let arg = args[i]
+    match arg {
+      "-n" | "--dry-run" => dry_run = true
+      "--" => ()
+      _ =>
+        if arg.has_prefix("--update-refs=") {
+          let v = String::unsafe_substring(arg, start=14, end=arg.length())
+          match v {
+            "branches" => only_head = false
+            "head" => only_head = true
+            _ =>
+              raise @bitcore.GitError::InvalidObject(
+                "invalid --update-refs value: \{v}",
+              )
+          }
+        } else if arg.has_prefix("-") {
+          raise @bitcore.GitError::InvalidObject(
+            "unknown history reword argument: \{arg}",
+          )
+        } else if target_spec is None {
+          target_spec = Some(arg)
+        } else {
+          raise @bitcore.GitError::InvalidObject(
+            "command expects a single revision",
+          )
+        }
+    }
+    i += 1
+  }
+  guard target_spec is Some(spec) else {
+    raise @bitcore.GitError::InvalidObject("command expects a single revision")
+  }
+  let db = @bitlib.ObjectDb::load(rfs, git_dir)
+
+  // Resolve target and HEAD.
+  guard @bitrepo.rev_parse(rfs, git_dir, spec) is Some(target) else {
+    raise @bitcore.GitError::InvalidObject("commit cannot be found: \{spec}")
+  }
+  guard @bitrepo.rev_parse(rfs, git_dir, "HEAD") is Some(head) else {
+    raise @bitcore.GitError::InvalidObject("cannot look up HEAD")
+  }
+  let (head_ref, tips) = history_collect_tips_cmd(
+    db, rfs, git_dir, target, head, only_head,
+  )
+
+  // Obtain the new message: original body + hint comments, via the editor.
+  let orig_msg = history_commit_message_cmd(db, rfs, target)
+  guard resolve_commit_editor() is Some(editor) else {
+    raise @bitcore.GitError::InvalidObject(
+      "no editor configured; set GIT_EDITOR (or VISUAL/EDITOR)",
+    )
+  }
+  let msg_path = git_dir + "/COMMIT_EDITMSG"
+  let template = orig_msg +
+    "\n# Please enter the new commit message for the reworded commit.\n" +
+    "# Lines starting with '#' will be ignored, and an empty message\n" +
+    "# aborts the operation.\n"
+  ffs.write_string(msg_path, template)
+  let code = run_editor_on_path(editor, msg_path)
+  if code != 0 {
+    raise @bitcore.GitError::InvalidObject("editor exited with \{code}")
+  }
+  let new_message = history_clean_editmsg(decode_bytes(rfs.read_file(msg_path)))
+  if new_message == "" {
+    raise @bitcore.GitError::InvalidObject(
+      "Aborting commit due to empty commit message.",
+    )
+  }
+
+  let result = @bitlib.history_reword(
+    db, ffs, rfs, git_dir, target, new_message, tips,
+  )
+
+  if dry_run {
+    for u in result.updates {
+      print_line("update \{u.refname} \{u.new_id.to_hex()} \{u.old_id.to_hex()}")
+    }
+    return
+  }
+  ignore(
+    history_apply_updates_cmd(
+      ffs, rfs, git_dir, result.updates, head_ref, "reword: updating " + spec,
+    ),
+  )
+}
+
+///|
+/// Collect the ref tips a history rewrite should consider (all branches, or
+/// just HEAD's branch with --update-refs=head), and reject histories that
+/// contain merges between the target and any tip.
+fn history_collect_tips_cmd(
+  db : @bitlib.ObjectDb,
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  target : @bitcore.ObjectId,
+  head : @bitcore.ObjectId,
+  only_head : Bool,
+) -> (@bitlib.HeadRef, Array[@bitlib.HistoryRefUpdate]) raise Error {
+  let (head_ref, branches) = @bitlib.list_branches(rfs, git_dir)
+  let tips : Array[@bitlib.HistoryRefUpdate] = []
+  if only_head {
+    // Only rewrite HEAD's branch; error if target is not in HEAD ancestry.
+    if not(@bitlib.merge_base_is_ancestor(db, rfs, target, head)) {
+      raise @bitcore.GitError::InvalidObject(
+        "rewritten commit must be an ancestor of HEAD when using --update-refs=head",
+      )
+    }
+    match head_ref {
+      Branch(name) =>
+        tips.push({
+          refname: "refs/heads/" + name,
+          old_id: head,
+          new_id: head,
+        })
+      Detached(_) => tips.push({ refname: "HEAD", old_id: head, new_id: head })
+    }
+  } else {
+    for b in branches {
+      tips.push({
+        refname: "refs/heads/" + b.name,
+        old_id: b.id,
+        new_id: b.id,
+      })
+    }
+  }
+
+  // Reject histories containing merges between target and any tip.
+  for tip in tips {
+    if @bitlib.merge_base_is_ancestor(db, rfs, target, tip.new_id) {
+      history_reject_merges_cmd(db, rfs, target, tip.new_id)
+    }
+  }
+  (head_ref, tips)
+}
+
+///|
+/// Write the rewritten refs and reflog entries; returns the new HEAD commit
+/// when HEAD's branch was among the updated refs.
+async fn history_apply_updates_cmd(
+  ffs : &@bitcore.FileSystem,
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  updates : Array[@bitlib.HistoryRefUpdate],
+  head_ref : @bitlib.HeadRef,
+  reflog_msg : String,
+) -> @bitcore.ObjectId? raise Error {
   let mut new_head : @bitcore.ObjectId? = None
   let head_branch = match head_ref {
     Branch(name) => Some("refs/heads/" + name)
     Detached(_) => None
   }
   let (rl_author, rl_email, rl_ts, rl_tz) = get_committer_identity()
-  let reflog_msg = "fixup: updating " + spec
-  for u in result.updates {
+  for u in updates {
     history_write_ref_cmd(ffs, git_dir, u.refname, u.new_id)
     try
       @bitlib.append_reflog(
@@ -196,24 +350,9 @@ async fn handle_history_fixup(args : Array[String]) -> Unit raise Error {
       new_head = Some(u.new_id)
     }
   }
-
-  // Reset the index to the new HEAD so staged changes are consumed, while
-  // leaving unstaged worktree changes in place (mixed reset semantics).
-  // Best-effort: a failure here must not abort the (already applied) rewrite.
-  match new_head {
-    Some(nh) =>
-      try
-        ignore(
-          @bitlib.reset(ffs, rfs, root, nh.to_hex(), @bitlib.ResetMode::Mixed),
-        )
-      catch {
-        _ => ()
-      }
-    None => ()
-  }
+  new_head
 }
 
-///|
 ///|
 fn history_is_blank_line(s : String) -> Bool {
   for c in s {

--- a/modules/bit_lib/src/history_fixup.mbt
+++ b/modules/bit_lib/src/history_fixup.mbt
@@ -179,6 +179,57 @@ pub fn history_fixup(
     rewrite_map[target_id.to_hex()] = id
   }
 
+  let updates = history_replay_descendants(
+    db, fs, rfs, git_dir, target_id, rewrite_map, tips, empty, "fixup",
+  )
+  { updates, rewritten: rewritten_target }
+}
+
+///|
+/// Rewrite a commit's message in place (same tree, parents, author, and
+/// committer) and replay its descendants. Core of `git history reword`.
+/// If the new message equals the old one, the rewritten commit hashes to the
+/// same id and the result contains no ref updates.
+pub fn history_reword(
+  db : ObjectDb,
+  fs : &@bit.FileSystem,
+  rfs : &@bit.RepoFileSystem,
+  git_dir : String,
+  target_id : @bit.ObjectId,
+  new_message : String,
+  tips : Array[HistoryRefUpdate],
+) -> HistoryFixupResult raise @bit.GitError {
+  let target = rebase_parse_commit_full(db, rfs, target_id)
+  let new_id = history_write_commit(
+    db, fs, git_dir, target.tree, target.parents, target, Some(new_message),
+  )
+  let rewrite_map : Map[String, @bit.ObjectId] = {}
+  rewrite_map[target_id.to_hex()] = new_id
+  // Trees are untouched by a reword, so descendants can never become empty
+  // during replay; Keep preserves commits that were already empty.
+  let updates = history_replay_descendants(
+    db, fs, rfs, git_dir, target_id, rewrite_map, tips,
+    HistoryEmptyAction::Keep, "reword",
+  )
+  { updates, rewritten: Some(new_id) }
+}
+
+///|
+/// Replay every descendant of `target_id` reachable from `tips` onto its
+/// rewritten parent (per `rewrite_map`, which is extended in place), and
+/// return the resulting ref updates. Chains must be linear; the caller is
+/// responsible for rejecting merges. `op` names the command in error messages.
+fn history_replay_descendants(
+  db : ObjectDb,
+  fs : &@bit.FileSystem,
+  rfs : &@bit.RepoFileSystem,
+  git_dir : String,
+  target_id : @bit.ObjectId,
+  rewrite_map : Map[String, @bit.ObjectId],
+  tips : Array[HistoryRefUpdate],
+  empty : HistoryEmptyAction,
+  op : String,
+) -> Array[HistoryRefUpdate] raise @bit.GitError {
   // Collect descendants of target reachable from the tips (linear chains only;
   // merges are rejected by the caller). Each chain is walked tip -> target.
   let descendants : Array[@bit.ObjectId] = []
@@ -230,7 +281,7 @@ pub fn history_fixup(
     )
     if !(ok) {
       raise @bit.GitError::InvalidObject(
-        "fixup would produce conflicts while replaying \{c.to_hex()}",
+        "\{op} would produce conflicts while replaying \{c.to_hex()}",
       )
     }
     let becomes_empty = replayed_tree == new_parent_tree
@@ -274,7 +325,7 @@ pub fn history_fixup(
       None => ()
     }
   }
-  { updates, rewritten: rewritten_target }
+  updates
 }
 
 ///|

--- a/modules/bit_lib/src/history_reword_wbtest.mbt
+++ b/modules/bit_lib/src/history_reword_wbtest.mbt
@@ -1,0 +1,148 @@
+///| Tests for `history reword` core (git 2.55 EXPERIMENTAL).
+/// Runs on the js target against an in-memory host, mirroring
+/// history_fixup_wbtest.mbt.
+
+///|
+fn hr_commit(host : Int, msg : String, ts : Int) -> String {
+  match js_commit(host, "/repo", msg, "T <t@e.com>", ts) {
+    Ok(id) => id
+    Err(e) => abort("commit \{msg}: \{e}")
+  }
+}
+
+///|
+fn hr_write(host : Int, path : String, content : String) -> Unit {
+  guard js_host_write_string(host, path, content) is Ok(_) else {
+    abort("write \{path}")
+  }
+}
+
+///|
+fn hr_add(host : Int, paths : Array[String]) -> Unit {
+  guard js_add_paths(host, "/repo", paths) is Ok(_) else { abort("add") }
+}
+
+///|
+/// Run history_reword on `/repo` against `target_spec`, updating only the
+/// `main` branch. Returns (result, fs, git_dir, db).
+fn hr_run(
+  host : Int,
+  target_spec : String,
+  new_message : String,
+) -> (HistoryFixupResult, LibJsHostFs, String, ObjectDb) raise @bit.GitError {
+  let fs = js_make_host_fs(host)
+  let rfs : &@bit.RepoFileSystem = fs
+  let ffs : &@bit.FileSystem = fs
+  let git_dir = js_resolve_git_dir(fs, "/repo")
+  let db = ObjectDb::load(rfs, git_dir)
+  guard rev_parse(rfs, git_dir, "HEAD") is Some(head) else { abort("rev HEAD") }
+  guard rev_parse(rfs, git_dir, target_spec) is Some(target) else {
+    abort("rev \{target_spec}")
+  }
+  let (_, branches) = list_branches(rfs, git_dir)
+  let mut main_tip = head
+  for b in branches {
+    if b.name == "main" {
+      main_tip = b.id
+    }
+  }
+  let tips : Array[HistoryRefUpdate] = [
+    { refname: "refs/heads/main", old_id: main_tip, new_id: main_tip },
+  ]
+  let result = history_reword(db, ffs, rfs, git_dir, target, new_message, tips)
+  (result, fs, git_dir, db)
+}
+
+///|
+fn hr_commit_info(
+  db : ObjectDb,
+  fs : LibJsHostFs,
+  commit : @bit.ObjectId,
+) -> RebaseCommitInfo raise @bit.GitError {
+  let rfs : &@bit.RepoFileSystem = fs
+  rebase_parse_commit_full(db, rfs, commit)
+}
+
+///|
+test "history reword: rewrite tip message, tree and identity preserved" {
+  let host = js_create_memory_host()
+  guard js_git_init(host, "/repo", "main") is Ok(_) else { abort("init") }
+  hr_write(host, "/repo/a.t", "a\n")
+  hr_add(host, ["a.t"])
+  let _c1 = hr_commit(host, "first", 1700000000)
+  hr_write(host, "/repo/b.t", "b\n")
+  hr_add(host, ["b.t"])
+  let c2 = hr_commit(host, "old message", 1700000100)
+  let (result, fs, _git_dir, db) = hr_run(host, "HEAD", "new message\n")
+  assert_eq(result.updates.length(), 1)
+  assert_eq(result.updates[0].refname, "refs/heads/main")
+  assert_eq(result.updates[0].old_id.to_hex(), c2)
+  let new_tip = result.updates[0].new_id
+  let old_info = hr_commit_info(db, fs, result.updates[0].old_id)
+  let new_info = hr_commit_info(db, fs, new_tip)
+  // Message changed; everything else preserved.
+  assert_eq(new_info.message, "new message\n")
+  assert_eq(new_info.tree, old_info.tree)
+  assert_eq(new_info.parents, old_info.parents)
+  assert_eq(new_info.author, old_info.author)
+  assert_eq(new_info.author_time, old_info.author_time)
+  assert_eq(new_info.committer, old_info.committer)
+  assert_eq(new_info.commit_time, old_info.commit_time)
+  js_destroy_host(host)
+}
+
+///|
+test "history reword: middle commit, descendant replayed with same tree" {
+  let host = js_create_memory_host()
+  guard js_git_init(host, "/repo", "main") is Ok(_) else { abort("init") }
+  hr_write(host, "/repo/a.t", "a\n")
+  hr_add(host, ["a.t"])
+  let _c1 = hr_commit(host, "first", 1700000000)
+  hr_write(host, "/repo/b.t", "b\n")
+  hr_add(host, ["b.t"])
+  let c2 = hr_commit(host, "middle old", 1700000100)
+  hr_write(host, "/repo/c.t", "c\n")
+  hr_add(host, ["c.t"])
+  let c3 = hr_commit(host, "third", 1700000200)
+  let (result, fs, _git_dir, db) = hr_run(host, "HEAD~", "middle new\n")
+  assert_eq(result.updates.length(), 1)
+  let new_tip = result.updates[0].new_id
+  // Tip is a rewritten commit: same message/tree as c3, new parent chain.
+  assert_true(new_tip.to_hex() != c3)
+  let old_tip_info = hr_commit_info(db, fs, @bit.ObjectId::from_hex(c3))
+  let new_tip_info = hr_commit_info(db, fs, new_tip)
+  assert_eq(new_tip_info.message, old_tip_info.message)
+  assert_eq(new_tip_info.tree, old_tip_info.tree)
+  // Its parent is the reworded middle commit.
+  let new_mid = new_tip_info.parents[0]
+  assert_true(new_mid.to_hex() != c2)
+  let new_mid_info = hr_commit_info(db, fs, new_mid)
+  let old_mid_info = hr_commit_info(db, fs, @bit.ObjectId::from_hex(c2))
+  assert_eq(new_mid_info.message, "middle new\n")
+  assert_eq(new_mid_info.tree, old_mid_info.tree)
+  js_destroy_host(host)
+}
+
+///|
+test "history reword: unchanged message is a no-op" {
+  let host = js_create_memory_host()
+  guard js_git_init(host, "/repo", "main") is Ok(_) else { abort("init") }
+  hr_write(host, "/repo/a.t", "a\n")
+  hr_add(host, ["a.t"])
+  let _c1 = hr_commit(host, "first", 1700000000)
+  // js_commit stores the message as given; reuse it verbatim.
+  let head_msg_probe = {
+    let fs = js_make_host_fs(host)
+    let rfs : &@bit.RepoFileSystem = fs
+    let git_dir = js_resolve_git_dir(fs, "/repo")
+    let db = ObjectDb::load(rfs, git_dir)
+    guard rev_parse(rfs, git_dir, "HEAD") is Some(head) else {
+      abort("rev HEAD")
+    }
+    rebase_parse_commit_full(db, rfs, head).message
+  }
+  let (result, _fs, _git_dir, _db) = hr_run(host, "HEAD", head_msg_probe)
+  // Identical content hashes to the identical commit: no ref updates.
+  assert_eq(result.updates.length(), 0)
+  js_destroy_host(host)
+}

--- a/modules/bit_lib/src/moon.pkg
+++ b/modules/bit_lib/src/moon.pkg
@@ -131,6 +131,7 @@ options(
     "js_api_exports.mbt": [ "js" ],
     "js_export_types.mbt": [ "js" ],
     "history_fixup_wbtest.mbt": [ "js" ],
+    "history_reword_wbtest.mbt": [ "js" ],
     "js_exports_wbtest.mbt": [ "js" ],
     "last_modified_wbtest.mbt": [ "js" ],
     "js_host_bridge.mbt": [ "js" ],


### PR DESCRIPTION
## Summary

Follow-up to #141 (`git history fixup`) and #143. Upstream git 2.55's experimental `git history` command has three subcommands — `fixup`, `reword`, `split` — and bit only implemented `fixup`. This PR implements `reword` and makes `split` fail with an explicit not-implemented error instead of "unknown subcommand". Tracked as bit issue `8f65572a`.

### Library (`modules/bit_lib/src/history_fixup.mbt`)

- Extracted the descendant-collection/replay logic of `history_fixup` into a shared `history_replay_descendants` helper (fixup behavior and error messages unchanged; the conflict message now names the invoking command).
- Added `history_reword`: rewrites the target commit with a new message while preserving tree, parents, author, and committer, then replays descendants. An unchanged message hashes to the identical commit and yields zero ref updates (no-op, matching upstream).

### CLI (`modules/bit/cmd/bit/history.mbt`)

- `git history reword <commit> [--dry-run] [--update-refs=(branches|head)]`: obtains the new message via the configured editor (GIT_EDITOR/VISUAL/EDITOR) with the original message plus comment hints as the template; strips comments; aborts on an empty result with `Aborting commit due to empty commit message.` (matching upstream). Applies ref updates with `reword: updating <spec>` reflog entries. Unlike fixup, requires no staged changes and never touches the index.
- Extracted `history_collect_tips_cmd` / `history_apply_updates_cmd` helpers shared by fixup and reword.
- `git history split` now errors with "not implemented yet (requires interactive hunk selection)"; unknown subcommands report `(supported: fixup, reword)`.

## Testing

- New `history_reword_wbtest.mbt` (js target, mirroring the fixup wbtests): tip reword preserves tree/parents/author/committer, middle-commit reword replays the descendant with an identical tree, unchanged message is a no-op — **3/3 passed**; existing fixup wbtests **4/4 passed** after the refactor.
- `moon test --target native modules/bit/cmd/bit/main_wbtest.mbt` (CI-style): **11/11 passed**.
- E2E on a built binary against a real repo: `--dry-run` prints the update without touching refs; rewording HEAD~ rewrites the descendant chain with `git diff --stat` empty vs the old tip; author/committer timestamps preserved; empty-message abort; histories containing merges rejected with `replaying merge commits is not supported yet!`; `git fsck --strict` clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6)_