### PR TITLE
Fix pack-refs deleting .git/refs and last-modified aborting on shallow clones

### DIFF
--- a/modules/bit/cmd/bit/pack_refs.mbt
+++ b/modules/bit/cmd/bit/pack_refs.mbt
@@ -91,6 +91,10 @@ fn collect_refs_to_pack(
 }
 
 ///|
+/// Remove directories left empty after pruning a loose ref, mirroring git's
+/// files backend: only directories deeper than `refs/<category>` are removed.
+/// `.git/refs` and `.git/refs/heads` / `.git/refs/tags` etc. must survive —
+/// deleting `.git/refs` makes real git no longer recognize the repository.
 fn cleanup_empty_dirs(
   fs : OsFs,
   git_dir : String,
@@ -106,8 +110,9 @@ fn cleanup_empty_dirs(
     current = current + "/" + parts[i]
     dirs.push(current)
   }
+  // dirs[0] = .git/refs, dirs[1] = .git/refs/<category>; keep both.
   let mut i = dirs.length() - 1
-  while i >= 0 {
+  while i >= 2 {
     let dir = dirs[i]
     let entries = fs.readdir(dir)
     if entries.length() == 0 {

--- a/modules/bit_lib/src/last_modified.mbt
+++ b/modules/bit_lib/src/last_modified.mbt
@@ -322,11 +322,28 @@ fn last_modified_walk(
   while stack.length() > 0 {
     let cur = stack.unsafe_pop()
     let c = commits.get(cur.to_hex()).unwrap()
+    // Parents whose objects are absent (shallow-clone boundary) are dropped,
+    // so the commit is attributed like a root instead of aborting the walk.
+    let kept : Array[@bit.ObjectId] = []
     for p in c.parents {
       let hex = p.to_hex()
-      if !(commits.contains(hex)) {
-        commits[hex] = last_modified_load_commit(db, fs, p)
-        stack.push(p)
+      if commits.contains(hex) {
+        kept.push(p)
+        continue
+      }
+      match db.get(fs, p) {
+        Some(_) => {
+          commits[hex] = last_modified_load_commit(db, fs, p)
+          stack.push(p)
+          kept.push(p)
+        }
+        None => ()
+      }
+    }
+    if kept.length() != c.parents.length() {
+      c.parents.clear()
+      for k in kept {
+        c.parents.push(k)
       }
     }
   }

--- a/modules/bit_lib/src/last_modified_wbtest.mbt
+++ b/modules/bit_lib/src/last_modified_wbtest.mbt
@@ -353,3 +353,42 @@ test "last-modified: merge attributes each path to its own branch" {
   lm_assert(got, [("main", "file"), ("side", "other")])
   js_destroy_host(host)
 }
+
+///|
+test "last-modified: shallow boundary (missing parent object) does not abort" {
+  let (host, _ids) = lm_setup_basic()
+  let fs = js_make_host_fs(host)
+  let rfs : &@bit.RepoFileSystem = fs
+  let ffs : &@bit.FileSystem = fs
+  let git_dir = js_resolve_git_dir(fs, "/repo")
+  let db = ObjectDb::load(rfs, git_dir)
+  guard rev_parse(rfs, git_dir, "HEAD") is Some(head) else { abort("rev HEAD") }
+  let head_info = rebase_parse_commit_full(db, rfs, head)
+  // Craft a commit whose sole parent object does not exist in the repository,
+  // mimicking the boundary commit of a shallow clone.
+  let missing = @bit.ObjectId::from_hex(
+    "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  )
+  let tip = @bit.Commit::new(
+    head_info.tree,
+    [missing],
+    "T <t@e.com>",
+    1700000300L,
+    "+0000",
+    "T <t@e.com>",
+    1700000300L,
+    "+0000",
+    "shallow tip\n",
+  )
+  let (tip_id, compressed) = @bit.create_commit(tip)
+  write_object_bytes(ffs, git_dir, tip_id, compressed)
+  // Must not raise; every path is attributed to the boundary commit itself.
+  let results = last_modified_compute(
+    db, rfs, tip_id, "shallow-tip", -1, false, -1, [], [],
+  )
+  assert_true(results.length() > 0)
+  for r in results {
+    assert_eq(r.oid.to_hex(), tip_id.to_hex())
+  }
+  js_destroy_host(host)
+}

--- a/t/t0006-pack-commands.sh
+++ b/t/t0006-pack-commands.sh
@@ -30,4 +30,23 @@ test_expect_success 'pack-objects file-output stdin-object mode works in standal
     test_file_exists ".git/objects/pack/test-$pack_id.idx"
 '
 
+# Regression: pruning loose refs after pack-refs must never delete .git/refs
+# itself (real git refuses to recognize the repository without it) nor the
+# refs/heads and refs/tags category directories.
+test_expect_success 'pack-refs --all keeps .git/refs and category dirs' '
+    mkdir packrefs-keep &&
+    cd packrefs-keep &&
+    git_cmd init &&
+    echo x > f.txt &&
+    git_cmd add f.txt &&
+    git_cmd commit -m one &&
+    git_cmd tag v1 &&
+    git_cmd pack-refs --all &&
+    test -d .git/refs &&
+    test -d .git/refs/heads &&
+    test -d .git/refs/tags &&
+    grep -q "refs/heads/" .git/packed-refs &&
+    cd ..
+'
+
 test_done


### PR DESCRIPTION
## Summary

Two bugs found while surveying git 2.50–2.55 feature gaps (tracked as bit issues `6cfa92f5` / `bfb9ca71`, closed with resolution comments):

1. **pack-refs deleted `.git/refs` itself (P0)** — after pruning loose refs, `cleanup_empty_dirs` walked empty parent directories all the way up, so once every ref was packed (e.g. via `bit maintenance run`'s pack-refs task) the `.git/refs` directory disappeared and real git refused to recognize the repository (`fatal: not a git repository`). Now mirrors git's files backend: only directories deeper than `refs/<category>` are pruned — `.git/refs`, `refs/heads`, and `refs/tags` always survive, while deeper empties (e.g. `refs/heads/feat/` after packing `feat/x`) are still removed.

2. **last-modified aborted on shallow clones (P1)** — the walk preloaded every ancestor and raised `bad commit <id>` on the first parent object missing past the shallow boundary. Missing parents are now dropped during preload, so boundary commits are attributed like roots — the same graceful degradation `rev-list` already has. Claude Code web session clones are shallow, so this made the command unusable there.

## Testing

- New regression test in `t/t0006-pack-commands.sh`: after `pack-refs --all`, `.git/refs`, `refs/heads`, `refs/tags` exist and the branch is packed — **5/5 passed** with the fixed binary.
- New js wbtest crafting a commit whose parent object is absent: `last_modified` wbtests **16/16 passed**.
- E2E on a real shallow clone: `bit last-modified` outputs all 39 paths with correct boundary attribution (previously died immediately); `git fsck --strict` clean and real git recognizes the repo after `bit maintenance run`.
- `moon check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6)_