### PR TITLE
refs: canonicalize every packed-refs write (sorted, deduped, git header)

### DIFF
--- a/modules/bit/cmd/bit/moon.pkg
+++ b/modules/bit/cmd/bit/moon.pkg
@@ -34,6 +34,7 @@ import {
   "mizchi/bitx_bitconfig" @bitconfig,
   "mizchi/bitx_workspace" @workspace,
   "mizchi/bit_reftable" @reftable,
+  "mizchi/bit_refs" @bitrefs,
   "mizchi/bit_runtime" @runtime,
   "mizchi/bit_utils" @string_utils,
   "mizchi/zlib",

--- a/modules/bit/cmd/bit/pack_refs.mbt
+++ b/modules/bit/cmd/bit/pack_refs.mbt
@@ -15,39 +15,20 @@ fn handle_pack_refs(args : Array[String]) -> Unit raise Error {
   let refs_dir = git_dir + "/refs"
   let packed_refs_path = git_dir + "/packed-refs"
   // Read existing packed-refs
-  let packed : Map[String, String] = {}
+  let entries : Array[@bitrefs.PackedRefEntry] = []
   if fs.is_file(packed_refs_path) {
     let content = decode_bytes(fs.read_file(packed_refs_path))
-    for line_view in content.split("\n") {
-      let line = line_view.to_owned()
-      if line.length() > 0 && !line.has_prefix("#") && !line.has_prefix("^") {
-        let parts : Array[String] = line
-          .split(" ")
-          .map(v => v.to_owned())
-          .collect()
-        if parts.length() >= 2 {
-          let sha = parts[0]
-          let ref_name = parts[1]
-          packed[ref_name] = sha
-        }
-      }
+    for e in @bitrefs.parse_packed_refs_text(content) {
+      entries.push(e)
     }
   }
-  // Collect refs to pack
+  // Collect refs to pack (loose values appended last, so they win dedupe)
   let refs_to_pack : Array[(String, String)] = []
   collect_refs_to_pack(fs, refs_dir, "refs", refs_to_pack, all)
-  // Update packed-refs
   for r in refs_to_pack {
-    packed[r.0] = r.1
+    entries.push({ refname: r.0, oid: r.1, peeled: None })
   }
-  // Write packed-refs
-  let lines : Array[String] = ["# pack-refs with: peeled fully-peeled sorted"]
-  let sorted_refs : Array[(String, String)] = packed.iter().collect()
-  sorted_refs.sort_by((a, b) => a.0.compare(b.0))
-  for entry in sorted_refs {
-    lines.push("\{entry.1} \{entry.0}")
-  }
-  fs.write_string(packed_refs_path, lines.join("\n") + "\n")
+  fs.write_string(packed_refs_path, @bitrefs.serialize_packed_refs_entries(entries))
   // Prune loose refs if requested
   if prune {
     for r in refs_to_pack {

--- a/modules/bit/cmd/bit/remote.mbt
+++ b/modules/bit/cmd/bit/remote.mbt
@@ -1653,40 +1653,17 @@ fn upsert_packed_refs(
     return
   }
   let packed_path = git_dir + "/packed-refs"
-  let packed : Map[String, String] = {}
+  let entries : Array[@bitrefs.PackedRefEntry] = []
   if fs.is_file(packed_path) {
     let content = decode_bytes(fs.read_file(packed_path))
-    for line_view in content.split("\n") {
-      let line = line_view.trim().to_owned()
-      if line.length() == 0 || line.has_prefix("#") || line.has_prefix("^") {
-        continue
-      }
-      let space = line.find(" ")
-      match space {
-        Some(i) =>
-          if i > 0 && i + 1 < line.length() {
-            let oid = String::unsafe_substring(line, start=0, end=i)
-            let refname = String::unsafe_substring(
-              line,
-              start=i + 1,
-              end=line.length(),
-            )
-            packed[refname] = oid
-          }
-        None => ()
-      }
+    for e in @bitrefs.parse_packed_refs_text(content) {
+      entries.push(e)
     }
   }
   for entry in refs {
-    packed[entry.0] = entry.1.to_hex()
+    entries.push({ refname: entry.0, oid: entry.1.to_hex(), peeled: None })
   }
-  let entries : Array[(String, String)] = packed.iter().collect()
-  entries.sort_by(fn(a, b) { a.0.compare(b.0) })
-  let lines : Array[String] = ["# pack-refs with: peeled fully-peeled sorted"]
-  for entry in entries {
-    lines.push(entry.1 + " " + entry.0)
-  }
-  fs.write_string(packed_path, lines.join("\n") + "\n")
+  fs.write_string(packed_path, @bitrefs.serialize_packed_refs_entries(entries))
 }
 
 ///|

--- a/modules/bit/cmd/bit/update_ref.mbt
+++ b/modules/bit/cmd/bit/update_ref.mbt
@@ -700,39 +700,13 @@ fn delete_packed_ref_entry(
   let content = decode_bytes(fs.read_file(packed_refs_path)) catch {
     _ => return ()
   }
-  let lines : Array[String] = []
-  let mut removed = false
-  let mut skip_peeled = false
-  for line_view in content.split("\n") {
-    let line = line_view.to_owned()
-    if skip_peeled && line.has_prefix("^") {
-      skip_peeled = false
-      removed = true
-      continue
-    }
-    skip_peeled = false
-    if line.length() > 0 && !line.has_prefix("#") && !line.has_prefix("^") {
-      let space_idx = line.find(" ")
-      match space_idx {
-        Some(i) => {
-          let packed_ref = String::unsafe_substring(
-            line,
-            start=i + 1,
-            end=line.length(),
-          )
-          if packed_ref == refname {
-            removed = true
-            skip_peeled = true
-            continue
-          }
-        }
-        None => ()
-      }
-    }
-    lines.push(line)
-  }
-  if removed {
-    fs.write_string(packed_refs_path, lines.join("\n"))
+  let entries = @bitrefs.parse_packed_refs_text(content)
+  let kept = entries.filter(e => e.refname != refname)
+  if kept.length() != entries.length() {
+    fs.write_string(
+      packed_refs_path,
+      @bitrefs.serialize_packed_refs_entries(kept),
+    )
   }
 }
 

--- a/modules/bit_lib/src/branch.mbt
+++ b/modules/bit_lib/src/branch.mbt
@@ -684,38 +684,10 @@ fn remove_from_packed_refs(
   refname : String,
 ) -> Unit raise @bit.GitError {
   let text = @utf8.decode_lossy(rfs.read_file(packed_path)[:])
-  let lines : Array[String] = []
-  let mut found = false
-  for line_view in text.split("\n") {
-    let line = line_view.to_owned()
-    if line.length() == 0 {
-      continue
-    }
-    // Check if this line is for the ref we want to remove
-    let space = line.find(" ")
-    match space {
-      None => lines.push(line)
-      Some(idx) => {
-        if idx + 1 >= line.length() {
-          lines.push(line)
-          continue
-        }
-        let name = String::unsafe_substring(
-          line,
-          start=idx + 1,
-          end=line.length(),
-        )
-        if name == refname {
-          found = true
-        } else {
-          lines.push(line)
-        }
-      }
-    }
-  }
-  if found {
-    let new_content = lines.join("\n") + "\n"
-    fs.write_string(packed_path, new_content)
+  let entries = @bitrefs.parse_packed_refs_text(text)
+  let kept = entries.filter(e => e.refname != refname)
+  if kept.length() != entries.length() {
+    fs.write_string(packed_path, @bitrefs.serialize_packed_refs_entries(kept))
   }
 }
 

--- a/modules/bit_lib/src/receive_pack.mbt
+++ b/modules/bit_lib/src/receive_pack.mbt
@@ -575,49 +575,11 @@ fn receive_delete_ref(
   }
   let data = rfs.read_file(packed)
   let text = @utf8.decode_lossy(data[:])
-  let out : Array[String] = []
-  let mut removed = false
-  let mut skip_peeled = false
-  for line_view in text.split("\n") {
-    let line = line_view.to_owned()
-    if line.length() == 0 {
-      continue
-    }
-    if skip_peeled {
-      if line.has_prefix("^") {
-        skip_peeled = false
-        continue
-      }
-      skip_peeled = false
-    }
-    if line.has_prefix("#") || line.has_prefix("^") {
-      out.push(line)
-      continue
-    }
-    match line.find(" ") {
-      None => out.push(line)
-      Some(idx) => {
-        let name = String::unsafe_substring(
-          line,
-          start=idx + 1,
-          end=line.length(),
-        )
-        if name == normalized {
-          removed = true
-          skip_peeled = true
-        } else {
-          out.push(line)
-        }
-      }
-    }
-  }
+  let entries = @bitrefs.parse_packed_refs_text(text)
+  let kept = entries.filter(e => e.refname != normalized)
+  let removed = kept.length() != entries.length()
   if removed {
-    let buf = StringBuilder::new()
-    for l in out {
-      buf.write_string(l)
-      buf.write_char('\n')
-    }
-    fs.write_string(packed, buf.to_string())
+    fs.write_string(packed, @bitrefs.serialize_packed_refs_entries(kept))
   }
   removed
 }

--- a/modules/bit_refs/src/refs_store.mbt
+++ b/modules/bit_refs/src/refs_store.mbt
@@ -177,6 +177,86 @@ pub fn list_refs_with_ids(
 }
 
 ///|
+///| A single packed-refs entry with its optional peeled (`^<oid>`) line.
+pub(all) struct PackedRefEntry {
+  refname : String
+  oid : String
+  peeled : String?
+} derive(Show, Eq)
+
+///|
+/// Parse packed-refs text into entries. Header (`#`) and blank lines are
+/// dropped; a `^` line is attached to the entry that precedes it.
+pub fn parse_packed_refs_text(text : String) -> Array[PackedRefEntry] {
+  let entries : Array[PackedRefEntry] = []
+  for line_view in text.split("\n") {
+    let line = line_view.to_owned()
+    if line.length() == 0 || line.has_prefix("#") {
+      continue
+    }
+    if line.has_prefix("^") {
+      if entries.length() > 0 {
+        let last = entries[entries.length() - 1]
+        entries[entries.length() - 1] = {
+          refname: last.refname,
+          oid: last.oid,
+          peeled: Some(
+            String::unsafe_substring(line, start=1, end=line.length()),
+          ),
+        }
+      }
+      continue
+    }
+    match line.find(" ") {
+      Some(idx) =>
+        if idx > 0 && idx + 1 < line.length() {
+          entries.push({
+            refname: String::unsafe_substring(
+              line,
+              start=idx + 1,
+              end=line.length(),
+            ),
+            oid: String::unsafe_substring(line, start=0, end=idx),
+            peeled: None,
+          })
+        }
+      None => ()
+    }
+  }
+  entries
+}
+
+///|
+/// Serialize entries into canonical packed-refs text: exactly one entry per
+/// refname (later duplicates win), sorted by refname, with git's standard
+/// header. Every packed-refs write MUST go through this (or produce the same
+/// invariants): real git trusts the `sorted` trait and binary-searches the
+/// file, so an unsorted or duplicated file breaks ref resolution in real git.
+pub fn serialize_packed_refs_entries(
+  entries : Array[PackedRefEntry],
+) -> String {
+  let dedup : Map[String, PackedRefEntry] = {}
+  for e in entries {
+    dedup[e.refname] = e
+  }
+  let unique : Array[PackedRefEntry] = dedup.iter().map(kv => kv.1).collect()
+  // NOTE: String::compare is length-first in MoonBit; git requires plain
+  // byte order (memcmp) for the `sorted` trait, which lexical_compare gives.
+  unique.sort_by((a, b) => String::lexical_compare(a.refname, b.refname))
+  let buf = StringBuilder::new()
+  // Trailing space after "sorted" matches real git's header byte-for-byte.
+  buf.write_string("# pack-refs with: peeled fully-peeled sorted \n")
+  for e in unique {
+    buf.write_string(e.oid + " " + e.refname + "\n")
+    match e.peeled {
+      Some(p) => buf.write_string("^" + p + "\n")
+      None => ()
+    }
+  }
+  buf.to_string()
+}
+
+///|
 pub fn rewrite_packed_refs(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
@@ -189,58 +269,21 @@ pub fn rewrite_packed_refs(
   }
   let data = rfs.read_file(packed_path) catch { _ => Bytes::default() }
   let text = @utf8.decode_lossy(data[:])
-  let lines : Array[String] = []
-  let mut skip_peeled = false
-  for line_view in text.split("\n") {
-    let line = line_view.to_owned()
-    if line.length() == 0 {
-      continue
-    }
-    if line.has_prefix("#") {
-      lines.push(line)
-      skip_peeled = false
-      continue
-    }
-    if line.has_prefix("^") {
-      if !skip_peeled {
-        lines.push(line)
-      }
-      continue
-    }
-    let space = line.find(" ")
-    match space {
-      None => {
-        lines.push(line)
-        skip_peeled = false
-      }
-      Some(idx) => {
-        if idx + 1 >= line.length() {
-          lines.push(line)
-          skip_peeled = false
-          continue
-        }
-        let oid = String::unsafe_substring(line, start=0, end=idx)
-        let refname = String::unsafe_substring(
-          line,
-          start=idx + 1,
-          end=line.length(),
-        )
-        match transform(refname) {
-          Some(new_ref) => {
-            lines.push(oid + " " + new_ref)
-            skip_peeled = false
-          }
-          None => skip_peeled = true
-        }
-      }
+  let entries = parse_packed_refs_text(text)
+  let kept : Array[PackedRefEntry] = []
+  for e in entries {
+    match transform(e.refname) {
+      Some(new_ref) =>
+        kept.push({ refname: new_ref, oid: e.oid, peeled: e.peeled })
+      None => ()
     }
   }
-  if lines.length() == 0 {
+  if kept.length() == 0 {
     fs.remove_file(packed_path) catch {
       _ => ()
     }
   } else {
-    fs.write_string(packed_path, lines.join("\n") + "\n")
+    fs.write_string(packed_path, serialize_packed_refs_entries(kept))
   }
 }
 

--- a/modules/bit_refs/src/refs_store_test.mbt
+++ b/modules/bit_refs/src/refs_store_test.mbt
@@ -25,3 +25,46 @@ test "refs/store: remove remote refs drops refs and logs trees" {
   assert_false(fs.is_dir("/repo/.git/refs/remotes/origin"))
   assert_false(fs.is_dir("/repo/.git/logs/refs/remotes/origin"))
 }
+
+///|
+test "refs/store: serialize_packed_refs_entries sorts, dedupes, and keeps peel lines" {
+  // Unsorted input with a duplicate refname (old value first, new value last)
+  // and a peeled tag: the canonical form must be sorted, last-wins, with
+  // git's exact header.
+  let entries = parse_packed_refs_text(
+    "# pack-refs with: peeled fully-peeled sorted \n" +
+    "1111111111111111111111111111111111111111 refs/tags/v1\n" +
+    "^2222222222222222222222222222222222222222\n" +
+    "3333333333333333333333333333333333333333 refs/notes/bit-hub\n" +
+    "4444444444444444444444444444444444444444 refs/heads/main\n" +
+    "5555555555555555555555555555555555555555 refs/notes/bit-hub\n",
+  )
+  let out = serialize_packed_refs_entries(entries)
+  @test.assert_eq(
+    out,
+    "# pack-refs with: peeled fully-peeled sorted \n" +
+    "4444444444444444444444444444444444444444 refs/heads/main\n" +
+    "5555555555555555555555555555555555555555 refs/notes/bit-hub\n" +
+    "1111111111111111111111111111111111111111 refs/tags/v1\n" +
+    "^2222222222222222222222222222222222222222\n",
+  )
+}
+
+///|
+test "refs/store: parse_packed_refs_text attaches peel lines and skips header" {
+  let entries = parse_packed_refs_text(
+    "# pack-refs with: peeled fully-peeled sorted \n" +
+    "1111111111111111111111111111111111111111 refs/tags/v1\n" +
+    "^2222222222222222222222222222222222222222\n" +
+    "4444444444444444444444444444444444444444 refs/heads/main\n",
+  )
+  @test.assert_eq(entries.length(), 2)
+  @test.assert_eq(entries[0].refname, "refs/tags/v1")
+  @test.assert_eq(
+    entries[0].peeled,
+    Some("2222222222222222222222222222222222222222"),
+  )
+  @test.assert_eq(entries[1].refname, "refs/heads/main")
+  @test.assert_eq(entries[1].peeled, None)
+}
+


### PR DESCRIPTION
## Summary

Fixes bit issue `1497d00d` (P0): bit-written `packed-refs` files could make **real git** unable to resolve refs, while bit itself kept working.

**Root cause**: MoonBit's `String::compare` is **length-first (shortlex)**, not byte order. `pack-refs` and the remote-tracking upsert sorted entries with it and then wrote git's `sorted` trait in the header — e.g. `refs/heads/main` (15 chars) sorted *before* `refs/tags/v0.43.0` (17 chars) *before* `refs/notes/bit-hub` (18 chars), which is exactly the corruption observed in the wild. Real git trusts the trait and binary-searches the file, so lookups randomly fail (`git fetch: unable to update local ref`, `git notes list` returning nothing, `push: src refspec matches more than one`). Remove-only rewrite paths additionally preserved duplicate refnames instead of cleaning them.

**Fix**: added `parse_packed_refs_text` / `serialize_packed_refs_entries` to `bit_refs` — byte-order sorting via `String::lexical_compare`, last-wins dedupe, peel-line (`^`) preservation, and git's exact header (including the trailing space). Every packed-refs writer now goes through them: `pack-refs`, remote-tracking upsert, ref deletion in `branch` / `update-ref` / `receive-pack`, and `rewrite_packed_refs`. Since writers re-serialize the whole file, **any pre-existing corruption self-heals on the next write**. Also fixes `update-ref`'s packed-refs rewrite dropping the trailing newline.

## Testing

- New unit tests in `bit_refs`: parse attaches peel lines and skips headers; serialize sorts byte-wise, dedupes last-wins, and preserves peel lines (4/4).
- E2E with branch names that expose shortlex-vs-byte ordering (`zz` vs a 20+ char name): `bit pack-refs --all` output is byte-sorted; real git resolves every ref (`rev-parse --verify` × 4), `for-each-ref` lists all, `git fsck --strict` clean.
- Self-heal E2E: a hand-corrupted unsorted file with a duplicate refname is rewritten sorted and deduped by the next `bit pack-refs`.
- `t/t0006-pack-commands.sh` 5/5 (includes the `.git/refs` preservation regression from #146); `main_wbtest.mbt` 11/11; `bit_lib` js suite 327/329 (2 known ssh-keygen environment failures); `moon check` 0 errors; `tools/check-layers.mjs` clean (cmd/bit now imports bit_refs directly).

Audited other `String::compare` sort sites: `for-each-ref` already uses its own byte-order `lexicographic_compare` for output ordering (the shortlex pre-sort in `for_each_ref_collect_refs_safe` is re-sorted downstream); remaining sites (`ai`, `hooks`, clone checkout order) don't feed git-format files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6)_