### PR TITLE
ci: run only affected tests per change; full matrix on release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,53 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
   pull_request:
   workflow_dispatch:
 
+# Test selection: PRs and main pushes only run the moon/git-compat tests
+# affected by the change (tools/select-affected-tests.mjs, driven by the
+# module -> git-test map in tools/flaker-affected-rules.mjs). Full runs are
+# the pre-release check: trigger via workflow_dispatch or a v* tag push.
+
 jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.sel.outputs.full }}
+      cmd_bit: ${{ steps.sel.outputs.cmd_bit }}
+      moon_targets: ${{ steps.sel.outputs.moon_targets }}
+      git_test_count: ${{ steps.sel.outputs.git_test_count }}
+      git_tests: ${{ steps.sel.outputs.git_tests }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Select affected tests
+        id: sel
+        run: |
+          set -euo pipefail
+          full=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then full=true; fi
+          case "${{ github.ref }}" in refs/tags/*) full=true ;; esac
+          if [ "$full" = "true" ]; then
+            echo "Full run (pre-release check trigger)"
+            node tools/select-affected-tests.mjs --full --github
+          else
+            base="${{ github.event.pull_request.base.sha || github.event.before }}"
+            if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+              base="origin/main"
+            fi
+            echo "Selecting affected tests vs base $base"
+            node tools/select-affected-tests.mjs --base "$base" --head HEAD --github
+          fi
+
   test:
     runs-on: ubuntu-latest
+    needs: select
+    if: needs.select.outputs.moon_targets != ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,36 +84,66 @@ jobs:
           git config --global protocol.file.allow always
       - name: Run JS and WASM tests
         run: |
-          moon test --target js -p mizchi/bit -p mizchi/bit_lib
-          moon test --target wasm -p mizchi/bit_runtime -f storage_runtime_wbtest.mbt
-          moon test --target wasm -p mizchi/bit_diff3
-          moon test --target wasm -p mizchi/bit_repo
-          moon test --target wasm -p mizchi/bit_grep
+          set -euo pipefail
+          full="${{ needs.select.outputs.full }}"
+          targets=" ${{ needs.select.outputs.moon_targets }} "
+          affected() { [ "$full" = "true" ] || case "$targets" in *" $1 "*) true ;; *) false ;; esac; }
+          if affected mizchi/bit/tests || affected mizchi/bit_lib; then
+            moon test --target js -p mizchi/bit -p mizchi/bit_lib
+          fi
+          if affected mizchi/bit_runtime; then
+            moon test --target wasm -p mizchi/bit_runtime -f storage_runtime_wbtest.mbt
+          fi
+          if affected mizchi/bit_diff3; then
+            moon test --target wasm -p mizchi/bit_diff3
+          fi
+          if affected mizchi/bit_repo; then
+            moon test --target wasm -p mizchi/bit_repo
+          fi
+          if affected mizchi/bit_grep; then
+            moon test --target wasm -p mizchi/bit_grep
+          fi
           # Kill any orphan moon processes and remove stale lock before native tests
           pkill -f "moon" || true
           rm -f _build/.moon-lock
       - name: Run native tests (non-cmd modules)
         timeout-minutes: 30
         run: |
-          # Test extracted bit_* and bitx_* modules + mizchi/bit (without cmd).
-          # cmd/bit native tests run in the separate cmd-native-test job because
-          # they dominate runtime (~50 min for the linker pass).
-          modules=$(awk '/members = \[/,/\]/' moon.work | grep -oE '"[^"]+"' | tr -d '"' | sed 's|^\./||')
-          for m in $modules; do
-            case "$m" in
-              modules/bit) continue ;; # cmd lives here — handled separately
-            esac
-            mod_name="mizchi/$(basename "$m")"
-            echo "::group::moon test --target native -p $mod_name"
-            moon test --target native -p "$mod_name"
-            echo "::endgroup::"
-          done
-          # Test mizchi/bit's non-cmd packages (tests + fuzz_tests).
-          moon test --target native -p mizchi/bit/tests
-          moon test --target native -p mizchi/bit/fuzz_tests || true
+          set -euo pipefail
+          full="${{ needs.select.outputs.full }}"
+          if [ "$full" = "true" ]; then
+            # Test every extracted bit_* / bitx_* module + mizchi/bit (without cmd).
+            # cmd/bit native tests run in the separate cmd-native-test job because
+            # they dominate runtime (~50 min for the linker pass).
+            modules=$(awk '/members = \[/,/\]/' moon.work | grep -oE '"[^"]+"' | tr -d '"' | sed 's|^\./||')
+            for m in $modules; do
+              case "$m" in
+                modules/bit) continue ;; # cmd lives here — handled separately
+              esac
+              mod_name="mizchi/$(basename "$m")"
+              echo "::group::moon test --target native -p $mod_name"
+              moon test --target native -p "$mod_name"
+              echo "::endgroup::"
+            done
+            moon test --target native -p mizchi/bit/tests
+            moon test --target native -p mizchi/bit/fuzz_tests || true
+          else
+            for t in ${{ needs.select.outputs.moon_targets }}; do
+              echo "::group::moon test --target native -p $t"
+              if [ "$t" = "mizchi/bit/tests" ]; then
+                moon test --target native -p mizchi/bit/tests
+                moon test --target native -p mizchi/bit/fuzz_tests || true
+              else
+                moon test --target native -p "$t"
+              fi
+              echo "::endgroup::"
+            done
+          fi
 
   cmd-native-test:
     runs-on: ubuntu-latest
+    needs: select
+    if: needs.select.outputs.cmd_bit == 'true'
     # The bundled `tcc` backend hangs compiling cmd/bit's large test binary, so
     # override the native C compiler with gcc (MOON_CC). gcc at -O0 (the debug
     # default) compiles it quickly and never hangs, unlike tcc; using gcc -O
@@ -154,6 +225,11 @@ jobs:
 
   distributed-test:
     runs-on: ubuntu-latest
+    needs: select
+    if: >-
+      needs.select.outputs.full == 'true' ||
+      contains(needs.select.outputs.moon_targets, 'bitx_hub') ||
+      contains(needs.select.outputs.moon_targets, 'bitx_kv')
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -173,6 +249,8 @@ jobs:
 
   nix-build:
     runs-on: ubuntu-latest
+    needs: select
+    if: needs.select.outputs.moon_targets != ''
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -188,6 +266,8 @@ jobs:
 
   git-compat:
     runs-on: ubuntu-latest
+    needs: select
+    if: needs.select.outputs.git_test_count != '0'
     strategy:
       fail-fast: false
       matrix:
@@ -199,28 +279,49 @@ jobs:
           submodules: true
           fetch-depth: 0
 
+      - name: Compute shard test list
+        id: shardtests
+        run: |
+          set -euo pipefail
+          printf '%s\n' "${{ needs.select.outputs.git_tests }}" > /tmp/selected-git-tests.txt
+          tests=$(tools/select-git-tests.sh "${{ matrix.shard }}" 10 /tmp/selected-git-tests.txt)
+          count=$(echo "$tests" | wc -w | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          {
+            echo "tests<<SHARD_TESTS_EOF"
+            echo "$tests"
+            echo "SHARD_TESTS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Shard ${{ matrix.shard }}: $count of ${{ needs.select.outputs.git_test_count }} selected tests"
+
       - name: Apply git test patches
+        if: steps.shardtests.outputs.count != '0'
         run: tools/apply-git-test-patches.sh
 
       - name: Install dependencies
+        if: steps.shardtests.outputs.count != '0'
         run: |
           sudo apt-get update
           sudo apt-get install -y gettext libcurl4-openssl-dev libexpat1-dev
 
       - name: Build git from source
+        if: steps.shardtests.outputs.count != '0'
         run: |
           cd third_party/git
           make -j$(nproc)
 
       - name: Install MoonBit CLI
+        if: steps.shardtests.outputs.count != '0'
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Moon update
+        if: steps.shardtests.outputs.count != '0'
         run: moon update
 
       - name: Build bit
+        if: steps.shardtests.outputs.count != '0'
         run: |
           set -euo pipefail
           moon --version
@@ -236,13 +337,14 @@ jobs:
           chmod +x tools/git-shim/moon
 
       - name: Run git compatibility tests
+        if: steps.shardtests.outputs.count != '0'
         run: |
           real_git="$(pwd)/third_party/git/git"
           exec_path="$(pwd)/third_party/git"
           shim_dir="$(pwd)/tools/git-shim/bin"
           echo "$real_git" > tools/git-shim/real-git-path
 
-          tests=$(tools/select-git-tests.sh "${{ matrix.shard }}" 10 tools/git-test-allowlist.txt)
+          tests="${{ steps.shardtests.outputs.tests }}"
           echo "Shard ${{ matrix.shard }}: $(echo "$tests" | wc -w | tr -d ' ') tests"
 
           export SHIM_REAL_GIT="$real_git" SHIM_EXEC_PATH="$exec_path" \
@@ -297,30 +399,33 @@ jobs:
           if [ -n "$failed_tests" ]; then
             echo "Failed tests:$failed_tests"
           fi
-          # Regression check: fail only if pass count drops below baseline.
+          # Regression check (full runs only — the absolute baseline is
+          # meaningless for a selected subset).
           # Baseline: 191 passes across 10 shards (~19 per shard).
           # Per-shard minimum: 12 (allows natural variance across shards).
-          shard_min=12
-          if [ "$passed" -lt "$shard_min" ]; then
-            echo "REGRESSION: only $passed tests passed (minimum: $shard_min)"
-            exit 1
+          if [ "${{ needs.select.outputs.full }}" = "true" ]; then
+            shard_min=12
+            if [ "$passed" -lt "$shard_min" ]; then
+              echo "REGRESSION: only $passed tests passed (minimum: $shard_min)"
+              exit 1
+            fi
           fi
 
       - name: Upload test timing
-        if: always()
+        if: always() && steps.shardtests.outputs.count != '0'
         uses: actions/upload-artifact@v4
         with:
           name: test-timing-shard-${{ matrix.shard }}
           path: test-timing-shard-${{ matrix.shard }}.tsv
 
       - name: Generate compat table
-        if: always()
+        if: always() && steps.shardtests.outputs.count != '0'
         run: |
           bash tools/generate-compat-table.sh > "compat-results-shard-${{ matrix.shard }}.md"
           cat "compat-results-shard-${{ matrix.shard }}.md"
 
       - name: Upload compat results
-        if: always()
+        if: always() && steps.shardtests.outputs.count != '0'
         uses: actions/upload-artifact@v4
         with:
           name: compat-results-shard-${{ matrix.shard }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       git_tests: ${{ steps.sel.outputs.git_tests }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Select affected tests
@@ -53,7 +53,7 @@ jobs:
     if: needs.select.outputs.moon_targets != ''
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install pkfire + pkspec
@@ -169,7 +169,7 @@ jobs:
     name: cmd-native-test (${{ matrix.name }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install pkfire + pkspec
@@ -232,7 +232,7 @@ jobs:
       contains(needs.select.outputs.moon_targets, 'bitx_kv')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install MoonBit CLI
@@ -254,7 +254,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: ./.github/actions/setup-nix
       - name: Build
         run: >
@@ -274,7 +274,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0
@@ -413,10 +413,14 @@ jobs:
 
       - name: Upload test timing
         if: always() && steps.shardtests.outputs.count != '0'
-        uses: actions/upload-artifact@v4
+        # Informational artifact: a flaky artifact-service 403 must not fail
+        # the shard after its tests already passed.
+        continue-on-error: true
+        uses: actions/upload-artifact@v5
         with:
           name: test-timing-shard-${{ matrix.shard }}
           path: test-timing-shard-${{ matrix.shard }}.tsv
+          overwrite: true
 
       - name: Generate compat table
         if: always() && steps.shardtests.outputs.count != '0'
@@ -426,7 +430,11 @@ jobs:
 
       - name: Upload compat results
         if: always() && steps.shardtests.outputs.count != '0'
-        uses: actions/upload-artifact@v4
+        # Informational artifact: a flaky artifact-service 403 must not fail
+        # the shard after its tests already passed.
+        continue-on-error: true
+        uses: actions/upload-artifact@v5
         with:
           name: compat-results-shard-${{ matrix.shard }}
           path: compat-results-shard-${{ matrix.shard }}.md
+          overwrite: true

--- a/.github/workflows/git-compat-random.yml
+++ b/.github/workflows/git-compat-random.yml
@@ -35,7 +35,7 @@ jobs:
         shard: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
       - name: Upload compat results
         if: >-
           ${{ steps.shard_guard.outputs.should_run == 'true' && (success() || failure()) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: compat-random-run-${{ github.run_id }}-shard-${{ matrix.shard }}
           path: compat-random-results
@@ -118,10 +118,10 @@ jobs:
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all compat artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: "compat-random-run-${{ github.run_id }}-*"
           path: compat-random-results
@@ -133,7 +133,7 @@ jobs:
           bash tools/aggregate-git-compat-random.sh compat-random-results | tee compat-random-summary.md
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload summary
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: compat-random-summary-${{ github.run_id }}
           path: compat-random-summary.md

--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 

--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -35,7 +35,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -43,7 +43,7 @@ jobs:
           version: 10
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -70,7 +70,7 @@ jobs:
           Copy-Item $binPath "${{ matrix.asset }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.asset }}
           path: ${{ matrix.asset }}
@@ -80,12 +80,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: artifacts
 

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -300,7 +300,7 @@ local testUpdate: Task = new {
 local testJsBuild: Task = new {
   name = "test-js-build"
   description = "Node-side smoke tests for the published JS lib + npm wrapper"
-  cmd = "node --test tools/js-build.test.mjs tools/npm-lib.test.mjs tools/npm-cli.test.mjs tools/demo-relay.test.mjs tools/demo-editor-link.test.mjs tools/playground-commands.test.mjs tools/playground-view.test.mjs"
+  cmd = "node --test tools/js-build.test.mjs tools/npm-lib.test.mjs tools/npm-cli.test.mjs tools/demo-relay.test.mjs tools/demo-editor-link.test.mjs tools/playground-commands.test.mjs tools/playground-view.test.mjs tools/flaker-affected-rules.test.mjs tools/select-affected-tests.test.mjs"
   deps {
     syncNpmLibRaw
     syncNpmBitCjs
@@ -370,6 +370,14 @@ local compatRandomRun: Task = new {
 //   tools/compare-real-git.sh [REPO_URL=...]
 //   tools/bench-save.sh <name>
 //   tools/bench-compare.sh <args>
+
+// -- affected-test selection ----------------------------------------------
+
+local testAffected: Task = new {
+  name = "test:affected"
+  description = "Show moon targets + git-compat suites affected vs origin/main (CI uses the same selector)"
+  cmd = "node tools/select-affected-tests.mjs --base origin/main"
+}
 
 // -- upstream Git test suite ---------------------------------------------
 
@@ -658,6 +666,7 @@ tasks {
   bundleJsLibGitOps
 
   test
+  testAffected
   testUpdate
   testJsBuild
   testJsLib

--- a/docs/ci-test-selection.md
+++ b/docs/ci-test-selection.md
@@ -1,0 +1,83 @@
+# CI test selection (affected-only runs)
+
+CI runtime was dominated by running everything on every PR: all 43 workspace
+modules' native tests, 7 cmd-shard jobs, and 10 git-compat shards that each
+build real git from source and run the full ~900-test allowlist. Since v0.45.0
+CI only runs what a change can affect; the full matrix is reserved for the
+pre-release check.
+
+## How selection works
+
+`tools/select-affected-tests.mjs` computes the test set for a diff:
+
+1. **Changed files** come from `git diff --name-only <base>...HEAD`
+   (PRs: the PR base; main pushes: the previous tip).
+2. **Moon targets** — the changed files' modules are expanded through the
+   reverse dependency closure of the workspace graph (parsed from `moon.work`
+   + each module's `moon.mod`), so a change to `bit_diff_core` also re-tests
+   `bit_diff` and the CLI. `modules/bit` in the closure enables the cmd-shard
+   jobs.
+3. **git-compat suites** — changed paths map to suites through
+   `tools/flaker-affected-rules.mjs`:
+   - module-level rules (`modules/bit_pack/** → t53*` etc.); foundational
+     modules (bit_core, bit_object, IO, …) map to the full suite;
+   - file-level rules carve command areas out of the two kitchen-sink
+     packages (`modules/bit/cmd/bit/*.mbt`, `modules/bit_lib/src/*.mbt`);
+   - `bitx_*` modules map to no git suites (bit-specific features).
+4. **Safety nets** — infrastructure changes (`moon.work`, `Taskfile.pkl`,
+   `.github/**`, `third_party/**`, the selector itself, …) and any
+   `modules/**` file that no rule knows about escalate to a **full run**.
+   An incomplete map over-tests; it never under-tests.
+
+The map is additive: a file selects the union of every rule it matches.
+`tools/flaker-affected-rules.toml` (used by flaker) is generated from the
+`.mjs` — regenerate with:
+
+```bash
+node tools/flaker-affected-rules.mjs > tools/flaker-affected-rules.toml
+```
+
+## In CI
+
+`.github/workflows/ci.yml` starts with a `select` job; the other jobs consume
+its outputs:
+
+| Job | Gate |
+|---|---|
+| `test` (module native + js/wasm) | affected moon targets only; js/wasm steps keyed by module |
+| `cmd-native-test` (7 shards) | only when `modules/bit` is in the closure |
+| `distributed-test` | only for `bitx_hub` / `bitx_kv` changes |
+| `nix-build` | any module change |
+| `git-compat` (10 shards) | selected suites only; shards with no tests skip before building git |
+
+The per-shard pass-count regression floor only applies to full runs — an
+absolute baseline is meaningless for a subset.
+
+## Full runs (pre-release check)
+
+The full matrix runs when:
+
+- **`workflow_dispatch`** — trigger CI manually from the Actions tab before
+  cutting a release; or
+- a **`v*` tag** is pushed (backstop so a release never ships untested).
+
+Release procedure: run the dispatch full check on main, confirm green, then
+tag.
+
+## Local usage
+
+```bash
+pkf run test:affected               # show what CI would run for your branch
+node tools/select-affected-tests.mjs --changed modules/bit_diff/src/myers.mbt
+node tools/select-affected-tests.mjs --base origin/main --json
+```
+
+## Maintaining the map
+
+- New module → add a rule in `tools/flaker-affected-rules.mjs` (or accept
+  that its changes trigger full runs via the safety net), regenerate the
+  toml, and extend `tools/select-affected-tests.test.mjs`.
+- New `cmd/bit` or `bit_lib` file → covered by existing globs where the name
+  matches (`merge*.mbt`, …); otherwise the safety net escalates to full until
+  a rule is added.
+- Rules tests: `node --test tools/flaker-affected-rules.test.mjs tools/select-affected-tests.test.mjs`.

--- a/tools/flaker-affected-rules.mjs
+++ b/tools/flaker-affected-rules.mjs
@@ -1,11 +1,36 @@
 import { pathToFileURL } from "node:url";
 
+// Mapping from changed paths to the git-compat suites they can affect.
+//
+// Two layers of rules:
+//   1. Module-level rules (`modules/<name>/**`) — every workspace module maps
+//      to the git test areas its subsystem implements. Foundational modules
+//      (object store, IO, core types) map to the full suite.
+//   2. File-level rules for the two kitchen-sink packages
+//      (`modules/bit/cmd/bit/*.mbt`, `modules/bit_lib/src/*.mbt`) — these
+//      carve command areas out of packages that would otherwise select
+//      everything.
+//
+// Matching is additive: a changed file selects the union of all rules it
+// matches. Changed files under `modules/**` that match NO rule are treated by
+// the selector (tools/select-affected-tests.mjs) as "run the full suite" — a
+// safety net for new modules and unmapped files, so an incomplete map fails
+// towards over-testing, never under-testing.
+//
+// tools/flaker-affected-rules.toml is generated from this file:
+//   node tools/flaker-affected-rules.mjs > tools/flaker-affected-rules.toml
+
+const FULL_SUITE = ["third_party/git/t/*.sh"];
+
 export const GIT_COMPAT_AFFECTED_RULES = [
+  // ---- infrastructure: anything here invalidates every suite -------------
   {
     reason: "infrastructure",
     changed: [
-      "modules/bit/moon.mod.json",
+      "modules/bit/moon.mod",
+      "modules/bit/moon.pkg",
       "modules/bit/top.mbt",
+      "modules/bit/main.mbt",
       "modules/bit/cmd/bit/main*.mbt",
       "modules/bit/cmd/bit/helpers*.mbt",
       "modules/bit/cmd/bit/fallback*.mbt",
@@ -15,8 +40,167 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "tools/select-git-tests.sh",
       "tools/flaker-run-git-compat-tests.mjs",
     ],
-    select: ["third_party/git/t/*.sh"],
+    select: FULL_SUITE,
   },
+  {
+    reason: "module:foundation",
+    changed: [
+      "modules/bit_core/**",
+      "modules/bit_types/**",
+      "modules/bit_object/**",
+      "modules/bit_hash/**",
+      "modules/bit_io/**",
+      "modules/bit_io_native/**",
+      "modules/bit_osfs/**",
+      "modules/bit_vfs/**",
+      "modules/bit_runtime/**",
+      "modules/bit_utils/**",
+      "modules/bit_bootstrap/**",
+    ],
+    select: FULL_SUITE,
+  },
+
+  // ---- module-level areas -------------------------------------------------
+  {
+    reason: "module:config",
+    changed: ["modules/bit_config/**", "modules/bitx_bitconfig/**"],
+    select: ["third_party/git/t/t13*.sh", "third_party/git/t/t0007-git-var.sh"],
+  },
+  {
+    reason: "module:refs",
+    changed: ["modules/bit_refs/**", "modules/bit_reftable/**"],
+    select: [
+      "third_party/git/t/t14*.sh",
+      "third_party/git/t/t32*.sh",
+      "third_party/git/t/t63*.sh",
+      "third_party/git/t/t1401-symbolic-ref.sh",
+      "third_party/git/t/t1403-show-ref.sh",
+    ],
+  },
+  {
+    reason: "module:repo",
+    changed: ["modules/bit_repo/**", "modules/bit_repo_ops/**"],
+    select: [
+      "third_party/git/t/t15*.sh",
+      "third_party/git/t/t60*.sh",
+      "third_party/git/t/t61*.sh",
+    ],
+  },
+  {
+    reason: "module:diff",
+    changed: [
+      "modules/bit_diff/**",
+      "modules/bit_diff_core/**",
+      "modules/bit_diff3/**",
+    ],
+    select: [
+      "third_party/git/t/t40*.sh",
+      "third_party/git/t/t6427-diff3-conflict-markers.sh",
+    ],
+  },
+  {
+    reason: "module:apply",
+    changed: ["modules/bit_apply/**"],
+    select: [
+      "third_party/git/t/t41*.sh",
+      "third_party/git/t/t3400-rebase.sh",
+      "third_party/git/t/t4254-am-corrupt.sh",
+    ],
+  },
+  {
+    reason: "module:pack",
+    changed: [
+      "modules/bit_pack/**",
+      "modules/bit_pack_ops/**",
+      "modules/bit_fingerprint/**",
+    ],
+    select: [
+      "third_party/git/t/t53*.sh",
+      "third_party/git/t/t6113-rev-list-bitmap-filters.sh",
+      "third_party/git/t/t6114-keep-packs.sh",
+      "third_party/git/t/t7700-repack.sh",
+    ],
+  },
+  {
+    reason: "module:transport",
+    changed: [
+      "modules/bit_protocol/**",
+      "modules/bit_remote/**",
+      "modules/bit_fast_import/**",
+    ],
+    select: [
+      "third_party/git/t/t55*.sh",
+      "third_party/git/t/t57*.sh",
+      "third_party/git/t/t93*.sh",
+    ],
+  },
+  {
+    reason: "module:worktree",
+    changed: ["modules/bit_worktree/**"],
+    select: ["third_party/git/t/t24*.sh", "third_party/git/t/t74*.sh"],
+  },
+  {
+    reason: "module:grep",
+    changed: ["modules/bit_grep/**"],
+    select: ["third_party/git/t/t781*.sh"],
+  },
+  {
+    reason: "module:ignore",
+    changed: ["modules/bit_ignore/**"],
+    select: [
+      "third_party/git/t/t0008-ignores.sh",
+      "third_party/git/t/t7011-skip-worktree-reading.sh",
+      "third_party/git/t/t7012-skip-worktree-writing.sh",
+      "third_party/git/t/t7061-wtstatus-ignore.sh",
+    ],
+  },
+  {
+    reason: "module:archive",
+    changed: ["modules/bit_archive/**"],
+    select: ["third_party/git/t/t500*.sh"],
+  },
+  {
+    reason: "module:trailers",
+    changed: ["modules/bit_trailers/**"],
+    select: ["third_party/git/t/t7513-interpret-trailers.sh"],
+  },
+  {
+    reason: "module:date",
+    changed: ["modules/bit_date/**"],
+    select: ["third_party/git/t/t0006-date.sh"],
+  },
+  {
+    reason: "module:signing",
+    changed: ["modules/bitx_openpgp/**"],
+    select: [
+      "third_party/git/t/t7004-tag.sh",
+      "third_party/git/t/t7030-verify-tag.sh",
+      "third_party/git/t/t7031-verify-tag-signed-ssh.sh",
+      "third_party/git/t/t7510-signed-commit.sh",
+      "third_party/git/t/t7528-signed-commit-ssh.sh",
+    ],
+  },
+  {
+    reason: "module:bit-only",
+    // bit-specific extension modules and non-git-compat test trees: no
+    // git-compat impact. An explicit empty selection keeps the selector's
+    // safety net from escalating these to a full run.
+    changed: [
+      "modules/bitx_hub/**",
+      "modules/bitx_kv/**",
+      "modules/bitx_workspace/**",
+      "modules/bitx_doc/**",
+      "modules/bitx_hq/**",
+      "modules/bitx_subdir/**",
+      "modules/bitx_rebase_ai/**",
+      "modules/bit/cmd/git-bit/**",
+      "modules/bit/tests/**",
+      "modules/bit/fuzz_tests/**",
+    ],
+    select: [],
+  },
+
+  // ---- file-level rules: modules/bit/cmd/bit + modules/bit_lib -----------
   {
     reason: "command:setup",
     changed: [
@@ -28,10 +212,6 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/rev_parse*.mbt",
       "modules/bit/cmd/bit/hash_object*.mbt",
       "modules/bit/cmd/bit/cat_file*.mbt",
-      "modules/bit/src/object/**",
-      "modules/bit/src/hash/**",
-      "modules/bit/src/refs/**",
-      "modules/bit/src/repo_ops/revparse_ops.mbt",
     ],
     select: [
       "third_party/git/t/t0000-basic.sh",
@@ -47,15 +227,29 @@ export const GIT_COMPAT_AFFECTED_RULES = [
     ],
   },
   {
+    reason: "command:refs",
+    changed: [
+      "modules/bit/cmd/bit/update_ref.mbt",
+      "modules/bit/cmd/bit/pack_refs.mbt",
+      "modules/bit/cmd/bit/reflog*.mbt",
+      "modules/bit/cmd/bit/for_each_ref.mbt",
+      "modules/bit/cmd/bit/check_ref_format.mbt",
+    ],
+    select: [
+      "third_party/git/t/t14*.sh",
+      "third_party/git/t/t63*.sh",
+      "third_party/git/t/t32*.sh",
+    ],
+  },
+  {
     reason: "command:checkout",
     changed: [
       "modules/bit/cmd/bit/checkout*.mbt",
       "modules/bit/cmd/bit/switch*.mbt",
       "modules/bit/cmd/bit/restore*.mbt",
       "modules/bit/cmd/bit/checkout_index.mbt",
-      "modules/bit/src/lib/checkout*.mbt",
-      "modules/bit/src/lib/path.mbt",
-      "modules/bit/src/worktree/**",
+      "modules/bit_lib/src/checkout*.mbt",
+      "modules/bit_lib/src/path.mbt",
     ],
     select: [
       "third_party/git/t/t2006-checkout-index-basic.sh",
@@ -73,10 +267,10 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/update_index*.mbt",
       "modules/bit/cmd/bit/sparse_checkout*.mbt",
       "modules/bit/cmd/bit/check_attr.mbt",
-      "modules/bit/cmd/bit/check_ignore.mbt",
-      "modules/bit/src/lib/gitattributes.mbt",
-      "modules/bit/src/lib/tree_ops.mbt",
-      "modules/bit/src/worktree/**",
+      "modules/bit/cmd/bit/check_ignore*.mbt",
+      "modules/bit_lib/src/gitattributes.mbt",
+      "modules/bit_lib/src/tree_ops.mbt",
+      "modules/bit_lib/src/index*.mbt",
     ],
     select: [
       "third_party/git/t/t300*.sh",
@@ -90,15 +284,12 @@ export const GIT_COMPAT_AFFECTED_RULES = [
     reason: "command:branch",
     changed: [
       "modules/bit/cmd/bit/branch*.mbt",
-      "modules/bit/cmd/bit/check_ref_format.mbt",
       "modules/bit/cmd/bit/show_branches.mbt",
-      "modules/bit/cmd/bit/for_each_ref.mbt",
-      "modules/bit/cmd/bit/show_ref.mbt",
-      "modules/bit/src/refs/**",
+      "modules/bit_lib/src/branch*.mbt",
     ],
     select: [
-      "third_party/git/t/t320*.sh",
-      "third_party/git/t/t630*.sh",
+      "third_party/git/t/t32*.sh",
+      "third_party/git/t/t63*.sh",
       "third_party/git/t/t7419-submodule-set-branch.sh",
     ],
   },
@@ -107,11 +298,9 @@ export const GIT_COMPAT_AFFECTED_RULES = [
     changed: [
       "modules/bit/cmd/bit/diff*.mbt",
       "modules/bit/cmd/bit/difftool.mbt",
-      "modules/bit/src/diff/**",
-      "modules/bit/src/diff_core/**",
     ],
     select: [
-      "third_party/git/t/t400*.sh",
+      "third_party/git/t/t40*.sh",
       "third_party/git/t/t6427-diff3-conflict-markers.sh",
     ],
   },
@@ -126,16 +315,19 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/bisect*.mbt",
       "modules/bit/cmd/bit/bundle.mbt",
       "modules/bit/cmd/bit/fmt_merge_msg.mbt",
-      "modules/bit/src/lib/merge_base.mbt",
-      "modules/bit/src/repo/**",
-      "modules/bit/src/repo_ops/**",
+      "modules/bit/cmd/bit/last_modified.mbt",
+      "modules/bit_lib/src/merge_base.mbt",
+      "modules/bit_lib/src/last_modified.mbt",
+      "modules/bit_lib/src/log*.mbt",
+      "modules/bit_lib/src/revwalk*.mbt",
     ],
     select: [
       "third_party/git/t/t60*.sh",
-      "third_party/git/t/t610*.sh",
-      "third_party/git/t/t611*.sh",
+      "third_party/git/t/t61*.sh",
+      "third_party/git/t/t42*.sh",
       "third_party/git/t/t6120-describe.sh",
       "third_party/git/t/t6200-fmt-merge-msg.sh",
+      "third_party/git/t/t8020-last-modified.sh",
     ],
   },
   {
@@ -145,18 +337,17 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/cherry_pick*.mbt",
       "modules/bit/cmd/bit/rebase*.mbt",
       "modules/bit/cmd/bit/revert.mbt",
-      "modules/bit/src/lib/cherry_pick.mbt",
-      "modules/bit/src/lib/rebase.mbt",
-      "modules/bit/src/lib/merge*.mbt",
+      "modules/bit/cmd/bit/history.mbt",
+      "modules/bit_lib/src/cherry_pick.mbt",
+      "modules/bit_lib/src/rebase*.mbt",
+      "modules/bit_lib/src/merge*.mbt",
+      "modules/bit_lib/src/history_*.mbt",
     ],
     select: [
-      "third_party/git/t/t640*.sh",
-      "third_party/git/t/t641*.sh",
-      "third_party/git/t/t642*.sh",
-      "third_party/git/t/t643*.sh",
+      "third_party/git/t/t34*.sh",
+      "third_party/git/t/t64*.sh",
+      "third_party/git/t/t76*.sh",
       "third_party/git/t/t7402-submodule-rebase.sh",
-      "third_party/git/t/t760*.sh",
-      "third_party/git/t/t761*.sh",
     ],
   },
   {
@@ -168,17 +359,18 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/verify_pack.mbt",
       "modules/bit/cmd/bit/multi_pack_index*.mbt",
       "modules/bit/cmd/bit/commit_graph*.mbt",
-      "modules/bit/src/pack/**",
-      "modules/bit/src/pack_ops/**",
+      "modules/bit/cmd/bit/repack*.mbt",
+      "modules/bit/cmd/bit/gc.mbt",
+      "modules/bit/cmd/bit/maintenance.mbt",
+      "modules/bit/cmd/bit/prune*.mbt",
+      "modules/bit/cmd/bit/fsck*.mbt",
     ],
     select: [
-      "third_party/git/t/t530*.sh",
-      "third_party/git/t/t531*.sh",
-      "third_party/git/t/t532*.sh",
-      "third_party/git/t/t533*.sh",
-      "third_party/git/t/t5351-unpack-large-objects.sh",
+      "third_party/git/t/t53*.sh",
+      "third_party/git/t/t1450-fsck.sh",
       "third_party/git/t/t6113-rev-list-bitmap-filters.sh",
       "third_party/git/t/t6114-keep-packs.sh",
+      "third_party/git/t/t7700-repack.sh",
     ],
   },
   {
@@ -196,22 +388,16 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/http_fetch.mbt",
       "modules/bit/cmd/bit/http_serve_*.mbt",
       "modules/bit/cmd/bit/fetch_serve_*.mbt",
-      "modules/bit/src/lib/remote*.mbt",
-      "modules/bit/src/protocol/**",
-      "modules/bit/src/io/http_client.mbt",
-      "modules/bit/src/io/native/http_client_native.mbt",
-      "modules/bit/src/io/native/upload_pack*.mbt",
-      "modules/bit/src/io/native/remote.mbt",
-      "modules/bit/src/remote/**",
+      "modules/bit/cmd/bit/ls_remote.mbt",
+      "modules/bit/cmd/bit/serve.mbt",
+      "modules/bit_lib/src/remote*.mbt",
+      "modules/bit_lib/src/upload_pack*.mbt",
+      "modules/bit_lib/src/receive_pack*.mbt",
+      "modules/bit_lib/src/smart_http*.mbt",
     ],
     select: [
-      "third_party/git/t/t550*.sh",
-      "third_party/git/t/t551*.sh",
-      "third_party/git/t/t552*.sh",
-      "third_party/git/t/t553*.sh",
-      "third_party/git/t/t570*.sh",
-      "third_party/git/t/t5710-promisor-remote-capability.sh",
-      "third_party/git/t/t573*.sh",
+      "third_party/git/t/t55*.sh",
+      "third_party/git/t/t57*.sh",
       "third_party/git/t/t5750-bundle-uri-parse.sh",
     ],
   },
@@ -227,9 +413,14 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/mv.mbt",
       "modules/bit/cmd/bit/stash.mbt",
       "modules/bit/cmd/bit/clean.mbt",
-      "modules/bit/src/lib/reset.mbt",
+      "modules/bit_lib/src/reset.mbt",
+      "modules/bit_lib/src/stash*.mbt",
+      "modules/bit_lib/src/status*.mbt",
+      "modules/bit_lib/src/add*.mbt",
+      "modules/bit_lib/src/commit*.mbt",
     ],
     select: [
+      "third_party/git/t/t39*.sh",
       "third_party/git/t/t7001-mv.sh",
       "third_party/git/t/t7002-mv-sparse-checkout.sh",
       "third_party/git/t/t7007-show.sh",
@@ -248,6 +439,7 @@ export const GIT_COMPAT_AFFECTED_RULES = [
       "modules/bit/cmd/bit/mktag_cmd.mbt",
       "modules/bit/cmd/bit/tag*.mbt",
       "modules/bit/cmd/bit/verify_tag.mbt",
+      "modules/bit_lib/src/tag*.mbt",
     ],
     select: [
       "third_party/git/t/t7004-tag.sh",
@@ -260,17 +452,52 @@ export const GIT_COMPAT_AFFECTED_RULES = [
     changed: [
       "modules/bit/cmd/bit/submodule*.mbt",
       "modules/bit/cmd/bit/worktree*.mbt",
-      "modules/bit/cmd/bit/sparse_checkout*.mbt",
-      "modules/bitx_subdir/src/**",
+      "modules/bit_lib/src/worktree*.mbt",
+      "modules/bit_lib/src/submodule*.mbt",
     ],
     select: [
+      "third_party/git/t/t24*.sh",
+      "third_party/git/t/t74*.sh",
       "third_party/git/t/t6437-submodule-merge.sh",
       "third_party/git/t/t6438-submodule-directory-file-conflicts.sh",
-      "third_party/git/t/t740*.sh",
-      "third_party/git/t/t741*.sh",
-      "third_party/git/t/t742*.sh",
-      "third_party/git/t/t7450-bad-git-dotfiles.sh",
     ],
+  },
+  {
+    reason: "command:blame",
+    changed: [
+      "modules/bit/cmd/bit/blame.mbt",
+      "modules/bit/cmd/bit/annotate.mbt",
+      "modules/bit/cmd/bit/shortlog.mbt",
+    ],
+    select: ["third_party/git/t/t80*.sh"],
+  },
+  {
+    reason: "command:patch",
+    changed: [
+      "modules/bit/cmd/bit/format_patch.mbt",
+      "modules/bit/cmd/bit/am.mbt",
+      "modules/bit/cmd/bit/apply.mbt",
+      "modules/bit/cmd/bit/mailsplit.mbt",
+      "modules/bit/cmd/bit/mailinfo.mbt",
+      "modules/bit/cmd/bit/quiltimport.mbt",
+      "modules/bit/cmd/bit/patch_id.mbt",
+      "modules/bit/cmd/bit/range_diff.mbt",
+    ],
+    select: [
+      "third_party/git/t/t41*.sh",
+      "third_party/git/t/t51*.sh",
+      "third_party/git/t/t3206-range-diff.sh",
+    ],
+  },
+  {
+    reason: "command:grep",
+    changed: ["modules/bit/cmd/bit/grep.mbt"],
+    select: ["third_party/git/t/t781*.sh"],
+  },
+  {
+    reason: "command:notes",
+    changed: ["modules/bit/cmd/bit/notes.mbt"],
+    select: ["third_party/git/t/t33*.sh"],
   },
 ];
 
@@ -278,14 +505,26 @@ function escapeRegex(value) {
   return value.replace(/[.+^${}()|[\]\\]/g, "\\$&");
 }
 
+// Escape character-by-character so glob tokens are substituted before any
+// regex escaping can mangle them. (The previous implementation escaped the
+// expansion of `**` into `\\.*` -- "zero or more dots" -- which silently
+// broke every `**` rule.)
 function compileGlob(glob) {
-  const escaped = glob
-    .replaceAll("\\", "/")
-    .replaceAll("**", "\u0000")
-    .replaceAll("*", "[^/]*")
-    .replaceAll("?", "[^/]")
-    .replaceAll("\u0000", ".*");
-  return new RegExp(`^${escapeRegex(escaped).replace(/\\\[\\\^\/\\\]\\\*/g, "[^/]*").replace(/\\\[\\\^\/\\\]/g, "[^/]")}$`);
+  const normalized = glob.replaceAll("\\", "/");
+  let out = "";
+  for (let i = 0; i < normalized.length; i++) {
+    if (normalized.startsWith("**", i)) {
+      out += ".*";
+      i += 1;
+    } else if (normalized[i] === "*") {
+      out += "[^/]*";
+    } else if (normalized[i] === "?") {
+      out += "[^/]";
+    } else {
+      out += escapeRegex(normalized[i]);
+    }
+  }
+  return new RegExp(`^${out}$`);
 }
 
 function compileRule(rule) {
@@ -334,6 +573,14 @@ export function selectSuitesForChanges(changedFiles, suites, rules) {
   }
 
   return suites.filter((suite) => selected.has(suite));
+}
+
+/// True when `file` matches at least one rule's `changed` globs.
+export function fileHasRule(file, rules) {
+  const normalized = file.replaceAll("\\", "/");
+  return rules.some((rule) =>
+    rule.changed.some((glob) => compileGlob(glob).test(normalized)),
+  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/tools/flaker-affected-rules.test.mjs
+++ b/tools/flaker-affected-rules.test.mjs
@@ -32,7 +32,7 @@ test("merge-related changes select merge-focused git compat suites", () => {
 
 test("fetch and protocol changes include transport suites", () => {
   const selected = selectSuitesForChanges(
-    ["modules/bit/cmd/bit/fetch.mbt", "modules/bit/src/protocol/transport.mbt"],
+    ["modules/bit/cmd/bit/fetch.mbt", "modules/bit_protocol/src/transport.mbt"],
     [
       "third_party/git/t/t5500-fetch-pack.sh",
       "third_party/git/t/t5700-protocol-v1.sh",
@@ -60,7 +60,6 @@ test("refname validation changes include branch-oriented suites", () => {
 
   assert.deepEqual(selected, [
     "third_party/git/t/t3204-branch-name-interpretation.sh",
-    "third_party/git/t/t7419-submodule-set-branch.sh",
   ]);
 });
 
@@ -81,4 +80,42 @@ test("tag verification changes include tag suites", () => {
     "third_party/git/t/t7030-verify-tag.sh",
     "third_party/git/t/t7031-verify-tag-signed-ssh.sh",
   ]);
+});
+
+test("module-level rule: bit_diff maps to diff suites without full run", () => {
+  const selected = selectSuitesForChanges(
+    ["modules/bit_diff/src/myers.mbt"],
+    [
+      "third_party/git/t/t4000-diff-format.sh",
+      "third_party/git/t/t6427-diff3-conflict-markers.sh",
+      "third_party/git/t/t7600-merge.sh",
+    ],
+    GIT_COMPAT_AFFECTED_RULES,
+  );
+  assert.deepEqual(selected, [
+    "third_party/git/t/t4000-diff-format.sh",
+    "third_party/git/t/t6427-diff3-conflict-markers.sh",
+  ]);
+});
+
+test("foundation module changes select every suite", () => {
+  const suites = [
+    "third_party/git/t/t0000-basic.sh",
+    "third_party/git/t/t9999-anything.sh",
+  ];
+  const selected = selectSuitesForChanges(
+    ["modules/bit_object/src/object.mbt"],
+    suites,
+    GIT_COMPAT_AFFECTED_RULES,
+  );
+  assert.deepEqual(selected, suites);
+});
+
+test("bit-only modules select no git suites", () => {
+  const selected = selectSuitesForChanges(
+    ["modules/bitx_hub/src/issue.mbt", "modules/bitx_kv/src/store.mbt"],
+    ["third_party/git/t/t0000-basic.sh"],
+    GIT_COMPAT_AFFECTED_RULES,
+  );
+  assert.deepEqual(selected, []);
 });

--- a/tools/flaker-affected-rules.toml
+++ b/tools/flaker-affected-rules.toml
@@ -1,64 +1,169 @@
 [[rules]]
-changed = ["modules/bit/moon.mod.json", "modules/bit/top.mbt", "modules/bit/cmd/bit/main*.mbt", "modules/bit/cmd/bit/helpers*.mbt", "modules/bit/cmd/bit/fallback*.mbt", "tools/git-shim/**", "tools/run-git-test.sh", "tools/apply-git-test-patches.sh", "tools/select-git-tests.sh", "tools/flaker-run-git-compat-tests.mjs"]
+changed = ["modules/bit/moon.mod", "modules/bit/moon.pkg", "modules/bit/top.mbt", "modules/bit/main.mbt", "modules/bit/cmd/bit/main*.mbt", "modules/bit/cmd/bit/helpers*.mbt", "modules/bit/cmd/bit/fallback*.mbt", "tools/git-shim/**", "tools/run-git-test.sh", "tools/apply-git-test-patches.sh", "tools/select-git-tests.sh", "tools/flaker-run-git-compat-tests.mjs"]
 select = ["third_party/git/t/*.sh"]
 reason = "infrastructure"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/init*.mbt", "modules/bit/cmd/bit/config*.mbt", "modules/bit/cmd/bit/gitconfig*.mbt", "modules/bit/cmd/bit/show_ref.mbt", "modules/bit/cmd/bit/symbolic_ref.mbt", "modules/bit/cmd/bit/rev_parse*.mbt", "modules/bit/cmd/bit/hash_object*.mbt", "modules/bit/cmd/bit/cat_file*.mbt", "modules/bit/src/object/**", "modules/bit/src/hash/**", "modules/bit/src/refs/**", "modules/bit/src/repo_ops/revparse_ops.mbt"]
+changed = ["modules/bit_core/**", "modules/bit_types/**", "modules/bit_object/**", "modules/bit_hash/**", "modules/bit_io/**", "modules/bit_io_native/**", "modules/bit_osfs/**", "modules/bit_vfs/**", "modules/bit_runtime/**", "modules/bit_utils/**", "modules/bit_bootstrap/**"]
+select = ["third_party/git/t/*.sh"]
+reason = "module:foundation"
+
+[[rules]]
+changed = ["modules/bit_config/**", "modules/bitx_bitconfig/**"]
+select = ["third_party/git/t/t13*.sh", "third_party/git/t/t0007-git-var.sh"]
+reason = "module:config"
+
+[[rules]]
+changed = ["modules/bit_refs/**", "modules/bit_reftable/**"]
+select = ["third_party/git/t/t14*.sh", "third_party/git/t/t32*.sh", "third_party/git/t/t63*.sh", "third_party/git/t/t1401-symbolic-ref.sh", "third_party/git/t/t1403-show-ref.sh"]
+reason = "module:refs"
+
+[[rules]]
+changed = ["modules/bit_repo/**", "modules/bit_repo_ops/**"]
+select = ["third_party/git/t/t15*.sh", "third_party/git/t/t60*.sh", "third_party/git/t/t61*.sh"]
+reason = "module:repo"
+
+[[rules]]
+changed = ["modules/bit_diff/**", "modules/bit_diff_core/**", "modules/bit_diff3/**"]
+select = ["third_party/git/t/t40*.sh", "third_party/git/t/t6427-diff3-conflict-markers.sh"]
+reason = "module:diff"
+
+[[rules]]
+changed = ["modules/bit_apply/**"]
+select = ["third_party/git/t/t41*.sh", "third_party/git/t/t3400-rebase.sh", "third_party/git/t/t4254-am-corrupt.sh"]
+reason = "module:apply"
+
+[[rules]]
+changed = ["modules/bit_pack/**", "modules/bit_pack_ops/**", "modules/bit_fingerprint/**"]
+select = ["third_party/git/t/t53*.sh", "third_party/git/t/t6113-rev-list-bitmap-filters.sh", "third_party/git/t/t6114-keep-packs.sh", "third_party/git/t/t7700-repack.sh"]
+reason = "module:pack"
+
+[[rules]]
+changed = ["modules/bit_protocol/**", "modules/bit_remote/**", "modules/bit_fast_import/**"]
+select = ["third_party/git/t/t55*.sh", "third_party/git/t/t57*.sh", "third_party/git/t/t93*.sh"]
+reason = "module:transport"
+
+[[rules]]
+changed = ["modules/bit_worktree/**"]
+select = ["third_party/git/t/t24*.sh", "third_party/git/t/t74*.sh"]
+reason = "module:worktree"
+
+[[rules]]
+changed = ["modules/bit_grep/**"]
+select = ["third_party/git/t/t781*.sh"]
+reason = "module:grep"
+
+[[rules]]
+changed = ["modules/bit_ignore/**"]
+select = ["third_party/git/t/t0008-ignores.sh", "third_party/git/t/t7011-skip-worktree-reading.sh", "third_party/git/t/t7012-skip-worktree-writing.sh", "third_party/git/t/t7061-wtstatus-ignore.sh"]
+reason = "module:ignore"
+
+[[rules]]
+changed = ["modules/bit_archive/**"]
+select = ["third_party/git/t/t500*.sh"]
+reason = "module:archive"
+
+[[rules]]
+changed = ["modules/bit_trailers/**"]
+select = ["third_party/git/t/t7513-interpret-trailers.sh"]
+reason = "module:trailers"
+
+[[rules]]
+changed = ["modules/bit_date/**"]
+select = ["third_party/git/t/t0006-date.sh"]
+reason = "module:date"
+
+[[rules]]
+changed = ["modules/bitx_openpgp/**"]
+select = ["third_party/git/t/t7004-tag.sh", "third_party/git/t/t7030-verify-tag.sh", "third_party/git/t/t7031-verify-tag-signed-ssh.sh", "third_party/git/t/t7510-signed-commit.sh", "third_party/git/t/t7528-signed-commit-ssh.sh"]
+reason = "module:signing"
+
+[[rules]]
+changed = ["modules/bitx_hub/**", "modules/bitx_kv/**", "modules/bitx_workspace/**", "modules/bitx_doc/**", "modules/bitx_hq/**", "modules/bitx_subdir/**", "modules/bitx_rebase_ai/**", "modules/bit/cmd/git-bit/**", "modules/bit/tests/**", "modules/bit/fuzz_tests/**"]
+select = []
+reason = "module:bit-only"
+
+[[rules]]
+changed = ["modules/bit/cmd/bit/init*.mbt", "modules/bit/cmd/bit/config*.mbt", "modules/bit/cmd/bit/gitconfig*.mbt", "modules/bit/cmd/bit/show_ref.mbt", "modules/bit/cmd/bit/symbolic_ref.mbt", "modules/bit/cmd/bit/rev_parse*.mbt", "modules/bit/cmd/bit/hash_object*.mbt", "modules/bit/cmd/bit/cat_file*.mbt"]
 select = ["third_party/git/t/t0000-basic.sh", "third_party/git/t/t0001-init.sh", "third_party/git/t/t0012-help.sh", "third_party/git/t/t0450-txt-doc-vs-help.sh", "third_party/git/t/t1006-cat-file.sh", "third_party/git/t/t1007-hash-object.sh", "third_party/git/t/t1300-config.sh", "third_party/git/t/t1401-symbolic-ref.sh", "third_party/git/t/t1403-show-ref.sh", "third_party/git/t/t1500-rev-parse.sh"]
 reason = "command:setup"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/checkout*.mbt", "modules/bit/cmd/bit/switch*.mbt", "modules/bit/cmd/bit/restore*.mbt", "modules/bit/cmd/bit/checkout_index.mbt", "modules/bit/src/lib/checkout*.mbt", "modules/bit/src/lib/path.mbt", "modules/bit/src/worktree/**"]
+changed = ["modules/bit/cmd/bit/update_ref.mbt", "modules/bit/cmd/bit/pack_refs.mbt", "modules/bit/cmd/bit/reflog*.mbt", "modules/bit/cmd/bit/for_each_ref.mbt", "modules/bit/cmd/bit/check_ref_format.mbt"]
+select = ["third_party/git/t/t14*.sh", "third_party/git/t/t63*.sh", "third_party/git/t/t32*.sh"]
+reason = "command:refs"
+
+[[rules]]
+changed = ["modules/bit/cmd/bit/checkout*.mbt", "modules/bit/cmd/bit/switch*.mbt", "modules/bit/cmd/bit/restore*.mbt", "modules/bit/cmd/bit/checkout_index.mbt", "modules/bit_lib/src/checkout*.mbt", "modules/bit_lib/src/path.mbt"]
 select = ["third_party/git/t/t2006-checkout-index-basic.sh", "third_party/git/t/t2014-checkout-switch.sh", "third_party/git/t/t2060-switch.sh", "third_party/git/t/t7201-co.sh"]
 reason = "command:checkout"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/ls_files*.mbt", "modules/bit/cmd/bit/ls_tree.mbt", "modules/bit/cmd/bit/read_tree.mbt", "modules/bit/cmd/bit/update_index*.mbt", "modules/bit/cmd/bit/sparse_checkout*.mbt", "modules/bit/cmd/bit/check_attr.mbt", "modules/bit/cmd/bit/check_ignore.mbt", "modules/bit/src/lib/gitattributes.mbt", "modules/bit/src/lib/tree_ops.mbt", "modules/bit/src/worktree/**"]
+changed = ["modules/bit/cmd/bit/ls_files*.mbt", "modules/bit/cmd/bit/ls_tree.mbt", "modules/bit/cmd/bit/read_tree.mbt", "modules/bit/cmd/bit/update_index*.mbt", "modules/bit/cmd/bit/sparse_checkout*.mbt", "modules/bit/cmd/bit/check_attr.mbt", "modules/bit/cmd/bit/check_ignore*.mbt", "modules/bit_lib/src/gitattributes.mbt", "modules/bit_lib/src/tree_ops.mbt", "modules/bit_lib/src/index*.mbt"]
 select = ["third_party/git/t/t300*.sh", "third_party/git/t/t310*.sh", "third_party/git/t/t613*.sh", "third_party/git/t/t7011-skip-worktree-reading.sh", "third_party/git/t/t7012-skip-worktree-writing.sh"]
 reason = "command:index"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/branch*.mbt", "modules/bit/cmd/bit/check_ref_format.mbt", "modules/bit/cmd/bit/show_branches.mbt", "modules/bit/cmd/bit/for_each_ref.mbt", "modules/bit/cmd/bit/show_ref.mbt", "modules/bit/src/refs/**"]
-select = ["third_party/git/t/t320*.sh", "third_party/git/t/t630*.sh", "third_party/git/t/t7419-submodule-set-branch.sh"]
+changed = ["modules/bit/cmd/bit/branch*.mbt", "modules/bit/cmd/bit/show_branches.mbt", "modules/bit_lib/src/branch*.mbt"]
+select = ["third_party/git/t/t32*.sh", "third_party/git/t/t63*.sh", "third_party/git/t/t7419-submodule-set-branch.sh"]
 reason = "command:branch"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/diff*.mbt", "modules/bit/cmd/bit/difftool.mbt", "modules/bit/src/diff/**", "modules/bit/src/diff_core/**"]
-select = ["third_party/git/t/t400*.sh", "third_party/git/t/t6427-diff3-conflict-markers.sh"]
+changed = ["modules/bit/cmd/bit/diff*.mbt", "modules/bit/cmd/bit/difftool.mbt"]
+select = ["third_party/git/t/t40*.sh", "third_party/git/t/t6427-diff3-conflict-markers.sh"]
 reason = "command:diff"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/log*.mbt", "modules/bit/cmd/bit/rev_list*.mbt", "modules/bit/cmd/bit/merge_base.mbt", "modules/bit/cmd/bit/name_rev.mbt", "modules/bit/cmd/bit/describe.mbt", "modules/bit/cmd/bit/bisect*.mbt", "modules/bit/cmd/bit/bundle.mbt", "modules/bit/cmd/bit/fmt_merge_msg.mbt", "modules/bit/src/lib/merge_base.mbt", "modules/bit/src/repo/**", "modules/bit/src/repo_ops/**"]
-select = ["third_party/git/t/t60*.sh", "third_party/git/t/t610*.sh", "third_party/git/t/t611*.sh", "third_party/git/t/t6120-describe.sh", "third_party/git/t/t6200-fmt-merge-msg.sh"]
+changed = ["modules/bit/cmd/bit/log*.mbt", "modules/bit/cmd/bit/rev_list*.mbt", "modules/bit/cmd/bit/merge_base.mbt", "modules/bit/cmd/bit/name_rev.mbt", "modules/bit/cmd/bit/describe.mbt", "modules/bit/cmd/bit/bisect*.mbt", "modules/bit/cmd/bit/bundle.mbt", "modules/bit/cmd/bit/fmt_merge_msg.mbt", "modules/bit/cmd/bit/last_modified.mbt", "modules/bit_lib/src/merge_base.mbt", "modules/bit_lib/src/last_modified.mbt", "modules/bit_lib/src/log*.mbt", "modules/bit_lib/src/revwalk*.mbt"]
+select = ["third_party/git/t/t60*.sh", "third_party/git/t/t61*.sh", "third_party/git/t/t42*.sh", "third_party/git/t/t6120-describe.sh", "third_party/git/t/t6200-fmt-merge-msg.sh", "third_party/git/t/t8020-last-modified.sh"]
 reason = "command:history"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/merge*.mbt", "modules/bit/cmd/bit/cherry_pick*.mbt", "modules/bit/cmd/bit/rebase*.mbt", "modules/bit/cmd/bit/revert.mbt", "modules/bit/src/lib/cherry_pick.mbt", "modules/bit/src/lib/rebase.mbt", "modules/bit/src/lib/merge*.mbt"]
-select = ["third_party/git/t/t640*.sh", "third_party/git/t/t641*.sh", "third_party/git/t/t642*.sh", "third_party/git/t/t643*.sh", "third_party/git/t/t7402-submodule-rebase.sh", "third_party/git/t/t760*.sh", "third_party/git/t/t761*.sh"]
+changed = ["modules/bit/cmd/bit/merge*.mbt", "modules/bit/cmd/bit/cherry_pick*.mbt", "modules/bit/cmd/bit/rebase*.mbt", "modules/bit/cmd/bit/revert.mbt", "modules/bit/cmd/bit/history.mbt", "modules/bit_lib/src/cherry_pick.mbt", "modules/bit_lib/src/rebase*.mbt", "modules/bit_lib/src/merge*.mbt", "modules/bit_lib/src/history_*.mbt"]
+select = ["third_party/git/t/t34*.sh", "third_party/git/t/t64*.sh", "third_party/git/t/t76*.sh", "third_party/git/t/t7402-submodule-rebase.sh"]
 reason = "command:merge"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/pack*.mbt", "modules/bit/cmd/bit/index_pack.mbt", "modules/bit/cmd/bit/unpack_objects.mbt", "modules/bit/cmd/bit/verify_pack.mbt", "modules/bit/cmd/bit/multi_pack_index*.mbt", "modules/bit/cmd/bit/commit_graph*.mbt", "modules/bit/src/pack/**", "modules/bit/src/pack_ops/**"]
-select = ["third_party/git/t/t530*.sh", "third_party/git/t/t531*.sh", "third_party/git/t/t532*.sh", "third_party/git/t/t533*.sh", "third_party/git/t/t5351-unpack-large-objects.sh", "third_party/git/t/t6113-rev-list-bitmap-filters.sh", "third_party/git/t/t6114-keep-packs.sh"]
+changed = ["modules/bit/cmd/bit/pack*.mbt", "modules/bit/cmd/bit/index_pack.mbt", "modules/bit/cmd/bit/unpack_objects.mbt", "modules/bit/cmd/bit/verify_pack.mbt", "modules/bit/cmd/bit/multi_pack_index*.mbt", "modules/bit/cmd/bit/commit_graph*.mbt", "modules/bit/cmd/bit/repack*.mbt", "modules/bit/cmd/bit/gc.mbt", "modules/bit/cmd/bit/maintenance.mbt", "modules/bit/cmd/bit/prune*.mbt", "modules/bit/cmd/bit/fsck*.mbt"]
+select = ["third_party/git/t/t53*.sh", "third_party/git/t/t1450-fsck.sh", "third_party/git/t/t6113-rev-list-bitmap-filters.sh", "third_party/git/t/t6114-keep-packs.sh", "third_party/git/t/t7700-repack.sh"]
 reason = "command:pack"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/fetch*.mbt", "modules/bit/cmd/bit/pull.mbt", "modules/bit/cmd/bit/push.mbt", "modules/bit/cmd/bit/clone*.mbt", "modules/bit/cmd/bit/remote*.mbt", "modules/bit/cmd/bit/receive_pack.mbt", "modules/bit/cmd/bit/upload_pack.mbt", "modules/bit/cmd/bit/fetch_pack.mbt", "modules/bit/cmd/bit/send_pack.mbt", "modules/bit/cmd/bit/http_fetch.mbt", "modules/bit/cmd/bit/http_serve_*.mbt", "modules/bit/cmd/bit/fetch_serve_*.mbt", "modules/bit/src/lib/remote*.mbt", "modules/bit/src/protocol/**", "modules/bit/src/io/http_client.mbt", "modules/bit/src/io/native/http_client_native.mbt", "modules/bit/src/io/native/upload_pack*.mbt", "modules/bit/src/io/native/remote.mbt", "modules/bit/src/remote/**"]
-select = ["third_party/git/t/t550*.sh", "third_party/git/t/t551*.sh", "third_party/git/t/t552*.sh", "third_party/git/t/t553*.sh", "third_party/git/t/t570*.sh", "third_party/git/t/t5710-promisor-remote-capability.sh", "third_party/git/t/t573*.sh", "third_party/git/t/t5750-bundle-uri-parse.sh"]
+changed = ["modules/bit/cmd/bit/fetch*.mbt", "modules/bit/cmd/bit/pull.mbt", "modules/bit/cmd/bit/push.mbt", "modules/bit/cmd/bit/clone*.mbt", "modules/bit/cmd/bit/remote*.mbt", "modules/bit/cmd/bit/receive_pack.mbt", "modules/bit/cmd/bit/upload_pack.mbt", "modules/bit/cmd/bit/fetch_pack.mbt", "modules/bit/cmd/bit/send_pack.mbt", "modules/bit/cmd/bit/http_fetch.mbt", "modules/bit/cmd/bit/http_serve_*.mbt", "modules/bit/cmd/bit/fetch_serve_*.mbt", "modules/bit/cmd/bit/ls_remote.mbt", "modules/bit/cmd/bit/serve.mbt", "modules/bit_lib/src/remote*.mbt", "modules/bit_lib/src/upload_pack*.mbt", "modules/bit_lib/src/receive_pack*.mbt", "modules/bit_lib/src/smart_http*.mbt"]
+select = ["third_party/git/t/t55*.sh", "third_party/git/t/t57*.sh", "third_party/git/t/t5750-bundle-uri-parse.sh"]
 reason = "command:transport"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/add*.mbt", "modules/bit/cmd/bit/commit*.mbt", "modules/bit/cmd/bit/reset*.mbt", "modules/bit/cmd/bit/status*.mbt", "modules/bit/cmd/bit/show*.mbt", "modules/bit/cmd/bit/rm*.mbt", "modules/bit/cmd/bit/mv.mbt", "modules/bit/cmd/bit/stash.mbt", "modules/bit/cmd/bit/clean.mbt", "modules/bit/src/lib/reset.mbt"]
-select = ["third_party/git/t/t7001-mv.sh", "third_party/git/t/t7002-mv-sparse-checkout.sh", "third_party/git/t/t7007-show.sh", "third_party/git/t/t706*.sh", "third_party/git/t/t710*.sh", "third_party/git/t/t711*.sh", "third_party/git/t/t730*.sh", "third_party/git/t/t750*.sh", "third_party/git/t/t751*.sh", "third_party/git/t/t752*.sh"]
+changed = ["modules/bit/cmd/bit/add*.mbt", "modules/bit/cmd/bit/commit*.mbt", "modules/bit/cmd/bit/reset*.mbt", "modules/bit/cmd/bit/status*.mbt", "modules/bit/cmd/bit/show*.mbt", "modules/bit/cmd/bit/rm*.mbt", "modules/bit/cmd/bit/mv.mbt", "modules/bit/cmd/bit/stash.mbt", "modules/bit/cmd/bit/clean.mbt", "modules/bit_lib/src/reset.mbt", "modules/bit_lib/src/stash*.mbt", "modules/bit_lib/src/status*.mbt", "modules/bit_lib/src/add*.mbt", "modules/bit_lib/src/commit*.mbt"]
+select = ["third_party/git/t/t39*.sh", "third_party/git/t/t7001-mv.sh", "third_party/git/t/t7002-mv-sparse-checkout.sh", "third_party/git/t/t7007-show.sh", "third_party/git/t/t706*.sh", "third_party/git/t/t710*.sh", "third_party/git/t/t711*.sh", "third_party/git/t/t730*.sh", "third_party/git/t/t750*.sh", "third_party/git/t/t751*.sh", "third_party/git/t/t752*.sh"]
 reason = "command:porcelain"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/mktag_cmd.mbt", "modules/bit/cmd/bit/tag*.mbt", "modules/bit/cmd/bit/verify_tag.mbt"]
+changed = ["modules/bit/cmd/bit/mktag_cmd.mbt", "modules/bit/cmd/bit/tag*.mbt", "modules/bit/cmd/bit/verify_tag.mbt", "modules/bit_lib/src/tag*.mbt"]
 select = ["third_party/git/t/t7004-tag.sh", "third_party/git/t/t7030-verify-tag.sh", "third_party/git/t/t7031-verify-tag-signed-ssh.sh"]
 reason = "command:tag"
 
 [[rules]]
-changed = ["modules/bit/cmd/bit/submodule*.mbt", "modules/bit/cmd/bit/worktree*.mbt", "modules/bit/cmd/bit/sparse_checkout*.mbt", "modules/bitx_subdir/src/**"]
-select = ["third_party/git/t/t6437-submodule-merge.sh", "third_party/git/t/t6438-submodule-directory-file-conflicts.sh", "third_party/git/t/t740*.sh", "third_party/git/t/t741*.sh", "third_party/git/t/t742*.sh", "third_party/git/t/t7450-bad-git-dotfiles.sh"]
+changed = ["modules/bit/cmd/bit/submodule*.mbt", "modules/bit/cmd/bit/worktree*.mbt", "modules/bit_lib/src/worktree*.mbt", "modules/bit_lib/src/submodule*.mbt"]
+select = ["third_party/git/t/t24*.sh", "third_party/git/t/t74*.sh", "third_party/git/t/t6437-submodule-merge.sh", "third_party/git/t/t6438-submodule-directory-file-conflicts.sh"]
 reason = "command:submodule"
+
+[[rules]]
+changed = ["modules/bit/cmd/bit/blame.mbt", "modules/bit/cmd/bit/annotate.mbt", "modules/bit/cmd/bit/shortlog.mbt"]
+select = ["third_party/git/t/t80*.sh"]
+reason = "command:blame"
+
+[[rules]]
+changed = ["modules/bit/cmd/bit/format_patch.mbt", "modules/bit/cmd/bit/am.mbt", "modules/bit/cmd/bit/apply.mbt", "modules/bit/cmd/bit/mailsplit.mbt", "modules/bit/cmd/bit/mailinfo.mbt", "modules/bit/cmd/bit/quiltimport.mbt", "modules/bit/cmd/bit/patch_id.mbt", "modules/bit/cmd/bit/range_diff.mbt"]
+select = ["third_party/git/t/t41*.sh", "third_party/git/t/t51*.sh", "third_party/git/t/t3206-range-diff.sh"]
+reason = "command:patch"
+
+[[rules]]
+changed = ["modules/bit/cmd/bit/grep.mbt"]
+select = ["third_party/git/t/t781*.sh"]
+reason = "command:grep"
+
+[[rules]]
+changed = ["modules/bit/cmd/bit/notes.mbt"]
+select = ["third_party/git/t/t33*.sh"]
+reason = "command:notes"

--- a/tools/select-affected-tests.mjs
+++ b/tools/select-affected-tests.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+// Select the moon test targets and git-compat suites affected by a change.
+//
+// Sources of truth:
+//   - moon.work + modules/*/moon.mod        → module graph (reverse-dep closure)
+//   - tools/flaker-affected-rules.mjs       → changed path → git-compat suites
+//   - tools/git-test-allowlist.txt          → the universe of git-compat suites
+//
+// Usage:
+//   node tools/select-affected-tests.mjs --base origin/main [--head HEAD]
+//   node tools/select-affected-tests.mjs --changed a.mbt --changed b.mbt
+//   ... [--json | --github]      (--json is the default output format)
+//
+// Output (JSON):
+//   {
+//     full: bool,            // run everything (infra change or unmapped file)
+//     reasons: [...],        // why full was triggered, if it was
+//     modules: [...],        // affected module dirs (dependency closure)
+//     moon_targets: [...],   // moon test -p targets for native module tests
+//     cmd_bit: bool,         // whether cmd/bit native shards must run
+//     git_tests: [...],      // git-compat suites (relative to third_party/git/t)
+//   }
+//
+// `--github` additionally appends step outputs to $GITHUB_OUTPUT.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync, existsSync, appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import {
+  GIT_COMPAT_AFFECTED_RULES,
+  selectSuitesForChanges,
+  fileHasRule,
+} from "./flaker-affected-rules.mjs";
+
+// Changes to these paths cannot be mapped to a subset — run everything.
+const FULL_TRIGGERS = [
+  /^moon\.work$/,
+  /^Taskfile\.pkl$/,
+  /^\.github\//,
+  /^third_party\//,
+  /^tools\/git-patches\//,
+  /^tools\/git-test-allowlist\.txt$/,
+  /^tools\/git-test-runtime-seconds\.tsv$/,
+  /^tools\/select-affected-tests\.mjs$/,
+  /^tools\/flaker-affected-rules\.mjs$/,
+  /^flake\.(nix|lock)$/,
+  /^package\.nix$/,
+  /^nix\//,
+];
+
+// Changes to these paths affect no tests at all (docs, editor config, ...).
+const NO_TEST_PATHS = [
+  /^docs\//,
+  /^\.claude\//,
+  /\.md$/,
+  /^AGENTS\.md$/,
+  /^LICENSE$/,
+  /^t\//, // bit's own e2e harness runs in its own job, not selected here
+  /^e2e\//,
+  /^npm\//,
+  /^playground\//,
+  /^fixtures\//,
+  /^pkspec\//,
+  /^component\//,
+  /^dir$/,
+  /^file\.txt$/,
+];
+
+export function parseWorkspaceModules(root) {
+  const work = readFileSync(`${root}/moon.work`, "utf8");
+  const members = [...work.matchAll(/"\.\/([^"]+)"/g)].map((m) => m[1]);
+  return members;
+}
+
+export function parseModuleGraph(root, members) {
+  // moduleName (mizchi/<x>) -> { dir, deps: [moduleName] }
+  const byName = new Map();
+  for (const dir of members) {
+    const modFile = `${root}/${dir}/moon.mod`;
+    if (!existsSync(modFile)) continue;
+    const text = readFileSync(modFile, "utf8");
+    const name = text.match(/name = "([^"]+)"/)?.[1];
+    if (!name) continue;
+    const deps = [...text.matchAll(/"(mizchi\/[a-z0-9_]+)@/g)]
+      .map((m) => m[1]);
+    byName.set(name, { dir, deps });
+  }
+  return byName;
+}
+
+export function reverseClosure(graph, seedNames) {
+  // dependents: name -> [names that import it]
+  const dependents = new Map();
+  for (const [name, { deps }] of graph) {
+    for (const dep of deps) {
+      if (!graph.has(dep)) continue; // external mooncakes dep
+      if (!dependents.has(dep)) dependents.set(dep, []);
+      dependents.get(dep).push(name);
+    }
+  }
+  const affected = new Set(seedNames);
+  const queue = [...seedNames];
+  while (queue.length > 0) {
+    const cur = queue.pop();
+    for (const dependent of dependents.get(cur) ?? []) {
+      if (!affected.has(dependent)) {
+        affected.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+  return affected;
+}
+
+export function moduleForPath(members, file) {
+  // Longest matching member dir wins (modules/bit vs modules/bit_lib).
+  let best = null;
+  for (const dir of members) {
+    if (file.startsWith(`${dir}/`) && (!best || dir.length > best.length)) {
+      best = dir;
+    }
+  }
+  return best;
+}
+
+export function loadSuites(root) {
+  const text = readFileSync(`${root}/tools/git-test-allowlist.txt`, "utf8");
+  return text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith("#"))
+    .map((l) => (l.startsWith("third_party/") ? l : `third_party/git/t/${l}`));
+}
+
+export function selectAffected(root, changedFiles) {
+  const reasons = [];
+  let full = false;
+
+  const changed = changedFiles
+    .map((f) => f.replaceAll("\\", "/"))
+    .filter((f) => f.length > 0);
+
+  for (const f of changed) {
+    if (FULL_TRIGGERS.some((re) => re.test(f))) {
+      full = true;
+      reasons.push(`infra: ${f}`);
+    }
+  }
+
+  const members = parseWorkspaceModules(root);
+  const graph = parseModuleGraph(root, members);
+  const dirToName = new Map(
+    [...graph.entries()].map(([name, { dir }]) => [dir, name]),
+  );
+
+  const seedNames = new Set();
+  const relevant = [];
+  for (const f of changed) {
+    if (NO_TEST_PATHS.some((re) => re.test(f))) continue;
+    const dir = moduleForPath(members, f);
+    if (dir) {
+      relevant.push(f);
+      const name = dirToName.get(dir);
+      if (name) seedNames.add(name);
+      // Safety net: a module file no git-test rule knows about → full run.
+      if (!fileHasRule(f, GIT_COMPAT_AFFECTED_RULES)) {
+        full = true;
+        reasons.push(`unmapped: ${f}`);
+      }
+    } else if (f.startsWith("tools/")) {
+      // Unlisted tools scripts don't affect bit itself.
+      continue;
+    } else if (!FULL_TRIGGERS.some((re) => re.test(f))) {
+      // Unknown top-level file: be safe.
+      full = true;
+      reasons.push(`unknown: ${f}`);
+    }
+  }
+
+  const affectedNames = reverseClosure(graph, [...seedNames]);
+  const modules = [...affectedNames]
+    .map((n) => graph.get(n)?.dir)
+    .filter(Boolean)
+    .sort();
+
+  const cmdBit = full || affectedNames.has("mizchi/bit");
+  const moonTargets = [];
+  for (const name of [...affectedNames].sort()) {
+    if (name === "mizchi/bit") {
+      moonTargets.push("mizchi/bit/tests");
+    } else {
+      moonTargets.push(name);
+    }
+  }
+
+  const suites = loadSuites(root);
+  const gitTests = full
+    ? suites
+    : selectSuitesForChanges(relevant, suites, GIT_COMPAT_AFFECTED_RULES);
+
+  return {
+    full,
+    reasons,
+    modules,
+    moon_targets: full ? ["ALL"] : moonTargets,
+    cmd_bit: cmdBit,
+    git_tests: gitTests,
+  };
+}
+
+function gitChangedFiles(root, base, head) {
+  const out = execFileSync(
+    "git",
+    ["diff", "--name-only", `${base}...${head}`],
+    { cwd: root, encoding: "utf8" },
+  );
+  return out.split("\n").filter(Boolean);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const root = process.cwd();
+  let base = null;
+  let head = "HEAD";
+  const changed = [];
+  let github = false;
+  let forceFull = false;
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--base":
+        base = args[++i];
+        break;
+      case "--head":
+        head = args[++i];
+        break;
+      case "--changed":
+        changed.push(args[++i]);
+        break;
+      case "--github":
+        github = true;
+        break;
+      case "--full":
+        forceFull = true;
+        break;
+      case "--json":
+        break;
+      default:
+        console.error(`unknown argument: ${args[i]}`);
+        process.exit(2);
+    }
+  }
+
+  const files = base ? gitChangedFiles(root, base, head) : changed;
+  let result = selectAffected(root, files);
+  if (forceFull) {
+    const suites = loadSuites(root);
+    result = {
+      ...result,
+      full: true,
+      reasons: ["forced"],
+      moon_targets: ["ALL"],
+      cmd_bit: true,
+      git_tests: suites,
+    };
+  }
+
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+
+  if (github && process.env.GITHUB_OUTPUT) {
+    // git_tests entries use the allowlist's bare-basename format so the list
+    // can be fed straight back into tools/select-git-tests.sh for sharding.
+    const bare = result.git_tests.map((t) =>
+      t.replace(/^third_party\/git\/t\//, ""),
+    );
+    const lines = [
+      `full=${result.full}`,
+      `cmd_bit=${result.cmd_bit}`,
+      `moon_targets=${result.moon_targets.join(" ")}`,
+      `git_test_count=${result.git_tests.length}`,
+      "git_tests<<GIT_TESTS_EOF",
+      ...bare,
+      "GIT_TESTS_EOF",
+    ];
+    appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join("\n")}\n`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tools/select-affected-tests.test.mjs
+++ b/tools/select-affected-tests.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseWorkspaceModules,
+  parseModuleGraph,
+  reverseClosure,
+  moduleForPath,
+  selectAffected,
+} from "./select-affected-tests.mjs";
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+test("workspace modules parse from moon.work", () => {
+  const members = parseWorkspaceModules(ROOT);
+  assert.ok(members.includes("modules/bit"));
+  assert.ok(members.includes("modules/bit_lib"));
+  assert.ok(members.length > 30);
+});
+
+test("module graph has reverse-dependency closure to mizchi/bit", () => {
+  const members = parseWorkspaceModules(ROOT);
+  const graph = parseModuleGraph(ROOT, members);
+  const affected = reverseClosure(graph, ["mizchi/bit_diff_core"]);
+  // bit_diff imports bit_diff_core; the CLI imports bit_diff.
+  assert.ok(affected.has("mizchi/bit_diff_core"));
+  assert.ok(affected.has("mizchi/bit_diff"));
+  assert.ok(affected.has("mizchi/bit"));
+});
+
+test("moduleForPath picks the longest member match", () => {
+  const members = ["modules/bit", "modules/bit_lib"];
+  assert.equal(
+    moduleForPath(members, "modules/bit_lib/src/merge.mbt"),
+    "modules/bit_lib",
+  );
+  assert.equal(
+    moduleForPath(members, "modules/bit/cmd/bit/merge.mbt"),
+    "modules/bit",
+  );
+});
+
+test("docs-only changes select nothing", () => {
+  const result = selectAffected(ROOT, ["docs/introduce-bit.md", "README.md"]);
+  assert.equal(result.full, false);
+  assert.deepEqual(result.moon_targets, []);
+  assert.deepEqual(result.git_tests, []);
+});
+
+test("bitx_hub changes run moon tests but no git-compat suites", () => {
+  const result = selectAffected(ROOT, ["modules/bitx_hub/src/issue.mbt"]);
+  assert.equal(result.full, false);
+  assert.ok(result.moon_targets.includes("mizchi/bitx_hub"));
+  assert.equal(result.git_tests.length, 0);
+  // The CLI depends on bitx_hub, so cmd shards must still run.
+  assert.equal(result.cmd_bit, true);
+});
+
+test("bit_diff changes select the diff suites, not the world", () => {
+  const result = selectAffected(ROOT, ["modules/bit_diff/src/myers.mbt"]);
+  assert.equal(result.full, false);
+  assert.ok(result.git_tests.length > 0);
+  assert.ok(
+    result.git_tests.every(
+      (t) =>
+        /\/t40[0-9]+/.test(t) || t.includes("t6427-diff3-conflict-markers"),
+    ),
+    `unexpected suites: ${result.git_tests.slice(0, 5)}`,
+  );
+});
+
+test("workflow changes force a full run", () => {
+  const result = selectAffected(ROOT, [".github/workflows/ci.yml"]);
+  assert.equal(result.full, true);
+});
+
+test("unmapped module files force a full run (safety net)", () => {
+  const result = selectAffected(ROOT, [
+    "modules/bit_lib/src/some_brand_new_area.mbt",
+  ]);
+  assert.equal(result.full, true);
+  assert.ok(result.reasons.some((r) => r.startsWith("unmapped:")));
+});


### PR DESCRIPTION
## Summary

CI currently runs everything on every PR: all 43 modules' native tests, 7 cmd-shard jobs, and 10 git-compat shards that each build real git and sweep the ~900-suite allowlist. This PR makes PR/main CI run only what the change can affect, and reserves the full matrix for the pre-release check. Tracked as bit issue `afc65338`.

### Selection (`tools/select-affected-tests.mjs`, new)

- **Moon targets**: changed files → owning modules → reverse-dependency closure over the workspace graph (`moon.work` + each `moon.mod`), so a `bit_diff_core` change also re-tests `bit_diff` and the CLI. `modules/bit` in the closure enables the cmd shards.
- **git-compat suites**: changed paths → suites via `tools/flaker-affected-rules.mjs`.
- **Safety nets**: infra changes (`moon.work`, `Taskfile.pkl`, `.github/**`, `third_party/**`, the selector itself) and any `modules/**` file no rule knows about escalate to a full run — an incomplete map over-tests, never under-tests.

### Module → git-test map (`tools/flaker-affected-rules.mjs`, rewritten)

The existing flaker rules referenced the pre-split `modules/bit/src/**` layout and were dormant. Now: module-level rules for every workspace module (foundation modules → full suite; `bitx_*` → no git suites), plus file-level rules carving command areas out of `cmd/bit` and `bit_lib`. Also fixes a latent glob-compiler bug: the `**` expansion got regex-escaped into `\.*` ("zero or more dots"), silently breaking every `**` rule. `flaker-affected-rules.toml` regenerated.

### CI wiring (`.github/workflows/ci.yml`)

A `select` job feeds the rest: module native tests iterate only affected targets; js/wasm steps key off their modules; `cmd-native-test` runs only when `modules/bit` is affected; `distributed-test` gates on `bitx_hub`/`bitx_kv`; `nix-build` on any module change; `git-compat` shards consume the selected list and **skip before building git** when their shard is empty. The per-shard pass-count regression floor now applies to full runs only (an absolute baseline is meaningless for a subset).

**Full matrix triggers**: `workflow_dispatch` (the pre-release check — run it on main, confirm green, then tag) and `v*` tag pushes as a backstop.

### Examples

| Change | Moon targets | git-compat suites |
|---|---|---|
| `modules/bit_grep/src/pattern.mbt` | 2 | 8 (t781x) |
| `modules/bit_diff/src/myers.mbt` | 2 | 74 (t40xx + diff3) |
| `modules/bitx_hub/src/issue.mbt` | 2 | 0 (+cmd shards) |
| `modules/bit_core/**` | 24 (closure) | full 911 |
| docs-only | 0 | 0 (jobs skip) |

## Testing

- `node --test tools/flaker-affected-rules.test.mjs tools/select-affected-tests.test.mjs`: **16/16** (rules↔toml sync, closure, per-area selection, empty-selection for `bitx_*`, full-run escalations, safety net).
- `tools/select-git-tests.sh` verified against selected subsets and the empty list (weighted sharding intact).
- `GITHUB_OUTPUT` emission verified locally; ci.yml parses as valid YAML.
- Local helper: `pkf run test:affected`; docs in `docs/ci-test-selection.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7hxWopNKWR1xzCkHpe7y6)_