### PR TITLE
Optimize status and native tests

### DIFF
--- a/modules/bit/cmd/bit/pack_helpers_wbtest.mbt
+++ b/modules/bit/cmd/bit/pack_helpers_wbtest.mbt
@@ -64,3 +64,19 @@ test "pack helpers: scan_ref_delta_bases supports sha256 ids" {
   assert_eq(bases.length(), 1)
   assert_eq(bases[0], base_hex)
 }
+
+///|
+test "pack helpers: object_hex uses the cached object id" {
+  let cached_id = @bitcore.hash_object_content(
+    @bitcore.ObjectType::Blob,
+    b"cached identity",
+  )
+  let obj = @bitcore.PackObject::with_metadata(
+    @bitcore.ObjectType::Blob,
+    b"different payload",
+    cached_id,
+    -1,
+    0U,
+  )
+  assert_eq(object_hex(obj), cached_id.to_hex())
+}

--- a/modules/bit/cmd/bit/pack_objects.mbt
+++ b/modules/bit/cmd/bit/pack_objects.mbt
@@ -1249,11 +1249,8 @@ fn read_pack_objects(
 }
 
 ///|
-fn object_hex(
-  obj : @bitcore.PackObject,
-  algo? : @bitobject.HashAlgorithm = Sha1,
-) -> String {
-  @bitobject.hash_object_content_with_algo(algo, obj.obj_type, obj.data).to_hex()
+fn object_hex(obj : @bitcore.PackObject) -> String {
+  obj.id.to_hex()
 }
 
 ///|

--- a/modules/bit_lib/src/gc_test.mbt
+++ b/modules/bit_lib/src/gc_test.mbt
@@ -407,7 +407,10 @@ test "gc tolerates symref files under refs" {
   let git_dir = root + "/.git"
   let (commit_id, _, _) = build_simple_repo(fs, root)
   fs.mkdir_p(git_dir + "/refs/remotes/origin")
-  fs.write_string(git_dir + "/refs/remotes/origin/HEAD", "ref: refs/heads/main\n")
+  fs.write_string(
+    git_dir + "/refs/remotes/origin/HEAD",
+    "ref: refs/heads/main\n",
+  )
   // Must not raise, and reachable objects stay reachable.
   let result = gc_repo(fs, fs, root)
   for id in result.dangling {

--- a/modules/bit_lib/src/index.mbt
+++ b/modules/bit_lib/src/index.mbt
@@ -120,7 +120,13 @@ pub fn read_index_entries(
   fs : &@bit.RepoFileSystem,
   git_dir : String,
 ) -> Array[IndexEntry] raise @bit.GitError {
-  let staged_entries = read_index_stage_entries(fs, git_dir)
+  index_entries_from_stage_entries(read_index_stage_entries(fs, git_dir))
+}
+
+///|
+fn index_entries_from_stage_entries(
+  staged_entries : Array[IndexStageEntry],
+) -> Array[IndexEntry] {
   let mut has_conflicts = false
   for item in staged_entries {
     if item.stage != 0 {
@@ -154,6 +160,31 @@ pub fn read_index_entries(
     }
     entries
   }
+}
+
+///|
+/// Read the index entries and optional TREE extension from one index snapshot.
+/// A missing or malformed extension falls back to the ordinary staged-tree walk.
+fn read_index_entries_with_cache_tree(
+  fs : &@bit.RepoFileSystem,
+  git_dir : String,
+) -> (Array[IndexEntry], IndexCacheTree?) raise @bit.GitError {
+  let path = join_path(git_dir, "index")
+  if !fs.is_file(path) {
+    return ([], None)
+  }
+  let data = fs.read_file(path)
+  let hash_size = index_repo_hash_size(fs, git_dir)
+  let staged_entries = index_read_stage_entries_from_bytes(data, hash_size~)
+  let index_entries = index_entries_from_stage_entries(staged_entries)
+  let cache_tree = if staged_entries.any(fn(item) { item.stage != 0 }) {
+    None
+  } else {
+    index_read_cache_tree_from_bytes(data, hash_size~) catch {
+      _ => None
+    }
+  }
+  (index_entries, cache_tree)
 }
 
 ///|

--- a/modules/bit_lib/src/js_api_exports.mbt
+++ b/modules/bit_lib/src/js_api_exports.mbt
@@ -1203,7 +1203,7 @@ pub fn js_status(host_id : Int, root : String) -> Result[Status, String] {
   let fs = js_make_host_fs(host_id)
   js_wrap_error(() => {
     let git_dir = js_resolve_git_dir(fs, root)
-    let entries = read_index_entries(fs, git_dir)
+    let (entries, cache_tree) = read_index_entries_with_cache_tree(fs, git_dir)
     let index_map : Map[String, IndexEntry] = Map([])
     for entry in entries {
       index_map[entry.path] = entry
@@ -1247,7 +1247,8 @@ pub fn js_status(host_id : Int, root : String) -> Result[Status, String] {
     let staged_deleted : Array[String] = []
     let skip_worktree_paths : Map[String, Bool] = Map([])
     collect_staged_changes_from_head(
-      fs, git_dir, staged_index_map, skip_worktree_paths, staged_modified, staged_deleted,
+      fs, git_dir, cache_tree, staged_index_map, skip_worktree_paths, staged_modified,
+      staged_deleted,
     )
     let staged_added = staged_index_map.keys().to_array()
     staged_added.sort()

--- a/modules/bit_lib/src/upload_pack.mbt
+++ b/modules/bit_lib/src/upload_pack.mbt
@@ -422,13 +422,11 @@ pub fn upload_pack(
     let have_set : Map[String, Bool] = Map([])
     let have_objects = collect_reachable_objects_from_commits(db, fs, req.haves)
     for obj in have_objects {
-      let id = @bit.hash_object_content(obj.obj_type, obj.data)
-      have_set[id.to_hex()] = true
+      have_set[obj.id.to_hex()] = true
     }
     let filtered : Array[@bit.PackObject] = []
     for obj in objects {
-      let id = @bit.hash_object_content(obj.obj_type, obj.data)
-      if !have_set.contains(id.to_hex()) {
+      if !have_set.contains(obj.id.to_hex()) {
         filtered.push(obj)
       }
     }
@@ -779,13 +777,11 @@ pub fn upload_pack_v2(
     let have_set : Map[String, Bool] = Map([])
     let have_objects = collect_reachable_objects_from_commits(db, fs, req.haves)
     for obj in have_objects {
-      let id = @bit.hash_object_content(obj.obj_type, obj.data)
-      have_set[id.to_hex()] = true
+      have_set[obj.id.to_hex()] = true
     }
     let filtered : Array[@bit.PackObject] = []
     for obj in objects {
-      let id = @bit.hash_object_content(obj.obj_type, obj.data)
-      if !have_set.contains(id.to_hex()) {
+      if !have_set.contains(obj.id.to_hex()) {
         filtered.push(obj)
       }
     }

--- a/modules/bit_lib/src/worktree.mbt
+++ b/modules/bit_lib/src/worktree.mbt
@@ -28,7 +28,9 @@ pub async fn status(
   let autocrlf = read_autocrlf_setting(fs, actual_git_dir)
   let skip_worktree_paths = read_skip_worktree_paths(fs, actual_git_dir)
   let racy_git = racy_git_enabled()
-  let index_entries = read_index_entries(fs, actual_git_dir)
+  let (index_entries, cache_tree) = read_index_entries_with_cache_tree(
+    fs, actual_git_dir,
+  )
   t0 = profile_lap(profile, "status read_index_entries", t0)
   let (unstaged_modified, unstaged_deleted, untracked) = index_guided_status_walk(
     fs,
@@ -53,7 +55,8 @@ pub async fn status(
   let staged_modified : Array[String] = []
   let staged_deleted : Array[String] = []
   collect_staged_changes_from_head(
-    fs, actual_git_dir, index_map, skip_worktree_paths, staged_modified, staged_deleted,
+    fs, actual_git_dir, cache_tree, index_map, skip_worktree_paths, staged_modified,
+    staged_deleted,
   )
   t0 = profile_lap(profile, "status read_head_entries", t0)
   for path in index_map.keys() {
@@ -1499,6 +1502,7 @@ fn resolve_worktree_common_git_dir(
 fn collect_staged_changes_from_head(
   fs : &@bit.RepoFileSystem,
   git_dir : String,
+  cache_tree : IndexCacheTree?,
   index_map : Map[String, IndexEntry],
   skip_worktree_paths : Map[String, Bool],
   staged_modified : Array[String],
@@ -1527,6 +1531,7 @@ fn collect_staged_changes_from_head(
             fs,
             info.tree,
             "",
+            cache_tree,
             index_map,
             skip_worktree_paths,
             staged_modified,
@@ -1544,11 +1549,19 @@ fn collect_staged_changes_db(
   fs : &@bit.RepoFileSystem,
   tree_id : @bit.ObjectId,
   prefix : String,
+  cache_tree : IndexCacheTree?,
   index_map : Map[String, IndexEntry],
   skip_worktree_paths : Map[String, Bool],
   staged_modified : Array[String],
   staged_deleted : Array[String],
 ) -> Unit raise @bit.GitError {
+  match cache_tree {
+    Some(tree) if index_cache_tree_matches_tree(tree, tree_id) => {
+      index_map_remove_tree_paths(index_map, prefix)
+      return
+    }
+    _ => ()
+  }
   let tree_obj = db.get(fs, tree_id)
   match tree_obj {
     None => raise @bit.GitError::InvalidObject("Missing tree object")
@@ -1572,6 +1585,7 @@ fn collect_staged_changes_db(
             fs,
             entry.id,
             path,
+            index_cache_tree_child(cache_tree, entry.name),
             index_map,
             skip_worktree_paths,
             staged_modified,
@@ -1591,6 +1605,52 @@ fn collect_staged_changes_db(
         }
       }
     }
+  }
+}
+
+///|
+fn index_cache_tree_matches_tree(
+  cache_tree : IndexCacheTree,
+  tree_id : @bit.ObjectId,
+) -> Bool {
+  match cache_tree.oid {
+    Some(cache_tree_id) =>
+      cache_tree.entry_count >= 0 && cache_tree_id == tree_id
+    None => false
+  }
+}
+
+///|
+fn index_cache_tree_child(
+  cache_tree : IndexCacheTree?,
+  name : String,
+) -> IndexCacheTree? {
+  match cache_tree {
+    None => None
+    Some(tree) => {
+      for subtree in tree.subtrees {
+        if subtree.name == name {
+          return Some(subtree)
+        }
+      }
+      None
+    }
+  }
+}
+
+///|
+fn index_map_remove_tree_paths(
+  index_map : Map[String, IndexEntry],
+  prefix : String,
+) -> Unit {
+  let paths : Array[String] = []
+  for path in index_map.keys() {
+    if prefix.length() == 0 || path.has_prefix(prefix + "/") {
+      paths.push(path)
+    }
+  }
+  for path in paths {
+    index_map.remove(path)
   }
 }
 

--- a/modules/bit_lib/src/worktree_test.mbt
+++ b/modules/bit_lib/src/worktree_test.mbt
@@ -110,6 +110,64 @@ async test "worktree: add_paths writes cache-tree extension" {
 }
 
 ///|
+async test "worktree: status skips a matching HEAD cache-tree root" {
+  let fs = setup_repo()
+  fs.write_string("/repo/tracked.txt", "tracked\n")
+  add_paths(fs, fs, "/repo", ["tracked.txt"])
+  let commit_id = commit(
+    fs, fs, "/repo", "initial\n", "Test <test@example.com>", 1700000000L,
+  )
+  let db = ObjectDb::load(fs, "/repo/.git")
+  let commit_obj = db.get(fs, commit_id).unwrap()
+  let tree_id = @bit.parse_commit(commit_obj.data).tree
+
+  // A clean index has the same root OID in its TREE extension as HEAD. If
+  // status consults it first, it need not load this tree object at all.
+  fs.remove_file(worktree_test_object_path("/repo/.git", tree_id))
+
+  let st = status(fs, "/repo")
+  assert_true(st.staged_added.length() == 0)
+  assert_true(st.staged_modified.length() == 0)
+  assert_true(st.staged_deleted.length() == 0)
+}
+
+///|
+async test "worktree: status skips unchanged cache-tree subtrees" {
+  let fs = setup_repo()
+  fs.mkdir_p("/repo/clean")
+  fs.mkdir_p("/repo/changed")
+  fs.write_string("/repo/clean/file.txt", "clean\n")
+  fs.write_string("/repo/changed/file.txt", "before\n")
+  add_paths(fs, fs, "/repo", ["clean/file.txt", "changed/file.txt"])
+  let commit_id = commit(
+    fs, fs, "/repo", "initial\n", "Test <test@example.com>", 1700000000L,
+  )
+  let db = ObjectDb::load(fs, "/repo/.git")
+  let commit_obj = db.get(fs, commit_id).unwrap()
+  let root_tree = db.get(fs, @bit.parse_commit(commit_obj.data).tree).unwrap()
+  let mut clean_tree_id = None
+  for entry in @bit.parse_tree(root_tree.data) {
+    if entry.name == "clean" {
+      clean_tree_id = Some(entry.id)
+    }
+  }
+  guard clean_tree_id is Some(clean_tree_id) else {
+    fail("expected clean subtree in HEAD")
+  }
+
+  // Updating the sibling invalidates the root and only that sibling in the
+  // index TREE extension. The clean subtree remains reusable.
+  fs.write_string("/repo/changed/file.txt", "after\n")
+  add_paths(fs, fs, "/repo", ["changed/file.txt"])
+  fs.remove_file(worktree_test_object_path("/repo/.git", clean_tree_id))
+
+  let st = status(fs, "/repo")
+  assert_true(st.staged_modified.contains("changed/file.txt"))
+  assert_true(st.staged_added.length() == 0)
+  assert_true(st.staged_deleted.length() == 0)
+}
+
+///|
 async test "worktree: commit writes HEAD and branch reflogs" {
   let fs = setup_repo()
   fs.write_string("/repo/a.txt", "hello\n")

--- a/tools/taskfile.test.mjs
+++ b/tools/taskfile.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const taskInfo = () => {
@@ -24,4 +25,14 @@ test("pkf test task tracks its test specifications and runners", () => {
   ]) {
     assert.ok(inputs.includes(input), `missing test input: ${input}`);
   }
+});
+
+test("Darwin native runner executes the cmd/bit suite in release mode", () => {
+  const script = readFileSync("tools/test-native.sh", "utf8");
+
+  assert.match(
+    script,
+    /moon test --target native --release -p mizchi\/bit\/cmd\/bit/,
+  );
+  assert.doesNotMatch(script, /skipping cmd\/bit whitebox shards/);
 });

--- a/tools/test-native.sh
+++ b/tools/test-native.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# cmd/bit's full whitebox suite exceeds the new backend's layout limit. Use
-# the classic backend with the system C compiler, matching the sharded CI job.
-unset MOONBIT_NEW_NATIVE
+# cmd/bit's debug native whitebox driver exceeds moonc's layout table limit on
+# arm64 macOS. Release-mode native tests use the C backend and avoid that link.
 if [[ "$(uname -s)" == "Darwin" ]]; then
   # Keep the linker target aligned with the SDK used to compile MoonBit C stubs.
   export MACOSX_DEPLOYMENT_TARGET="$(xcrun --sdk macosx --show-sdk-platform-version)"
@@ -39,10 +38,8 @@ moon test --target native -p mizchi/bit/fuzz_tests || true
 moon test --target native -p mizchi/bit/cmd/git-bit
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  # moonc currently ICEs while linking cmd/bit's native whitebox driver on
-  # arm64 macOS. The six shards run in Linux CI; the native release build and
-  # all non-CLI native package tests above still run locally.
-  echo "[native] skipping cmd/bit whitebox shards on Darwin (moonc layout ICE)"
+  echo "[native] cmd/bit release suite on Darwin (avoid debug layout ICE)"
+  moon test --target native --release -p mizchi/bit/cmd/bit
 else
   for shard in 0 1 2 3 4 5; do
     # shellcheck disable=SC2012


### PR DESCRIPTION
## Summary

- Reuse index cache-tree entries during status collection to avoid loading unchanged HEAD trees.
- Reuse cached PackObject IDs in pack-objects and upload-pack instead of hashing object content again.
- Run the Darwin cmd/bit native suite in release mode, avoiding the debug native layout-table ICE while retaining native coverage.

## Validation

- moon test -p mizchi/bit_lib --target js -f "*upload*"
- moon check --target native modules/bit/cmd/bit
- pkf run check
- moon build --target native --release modules/bit
- node --test tools/taskfile.test.mjs
- bash -n tools/test-native.sh
- moon test --target native --release -p mizchi/bit/cmd/bit -f "pack helpers: pack_hash_hex supports sha256 trailer"