### PR TITLE
Optimize clone and pack traversal

### DIFF
--- a/modules/bit/cmd/bit/bundle.mbt
+++ b/modules/bit/cmd/bit/bundle.mbt
@@ -94,10 +94,11 @@ async fn handle_bundle_create(args : Array[String]) -> Unit raise Error {
       None => ()
     }
   }
+  let db = @bitlib.ObjectDb::load(fs, git_dir)
   let exclude_ids : Map[String, Bool] = Map([])
   for spec in excludes {
     match @bitrepo.rev_parse(fs, git_dir, spec) {
-      Some(id) => walk_commits_to_map(fs, git_dir, id, exclude_ids)
+      Some(id) => walk_commits_to_map(db, fs, id, exclude_ids)
       None => ()
     }
   }
@@ -120,7 +121,7 @@ async fn handle_bundle_create(args : Array[String]) -> Unit raise Error {
   let header = lines.join("\n")
   let header_bytes = @utf8.encode(header[:])
   // Collect all reachable objects
-  let objects = collect_bundle_objects(fs, git_dir, start_ids, exclude_ids)
+  let objects = collect_bundle_objects(db, fs, start_ids, exclude_ids)
   // Create packfile
   let pack_data = @pack.create_packfile(objects)
   // Write bundle
@@ -140,12 +141,11 @@ async fn handle_bundle_create(args : Array[String]) -> Unit raise Error {
 
 ///|
 fn collect_bundle_objects(
+  db : @bitlib.ObjectDb,
   fs : OsFs,
-  git_dir : String,
   start_ids : Array[@bitcore.ObjectId],
   exclude_ids : Map[String, Bool],
 ) -> Array[@bitcore.PackObject] raise Error {
-  let db = @bitlib.ObjectDb::load(fs, git_dir)
   let visited : Map[String, Bool] = Map([])
   let objects : Array[@bitcore.PackObject] = []
   let queue : Array[@bitcore.ObjectId] = []

--- a/modules/bit/cmd/bit/format_patch.mbt
+++ b/modules/bit/cmd/bit/format_patch.mbt
@@ -457,8 +457,10 @@ fn collect_commits_in_range(
   base : @bitcore.ObjectId,
   end : @bitcore.ObjectId,
 ) -> Array[@bitcore.ObjectId] raise Error {
+  let db = @bitlib.ObjectDb::load(rfs, git_dir)
   let excluded : Map[String, Bool] = Map([])
   let base_entries = log_walk_commits(
+    db,
     rfs,
     git_dir,
     [base],
@@ -472,6 +474,7 @@ fn collect_commits_in_range(
     excluded[entry.id.to_hex()] = true
   }
   let entries = log_walk_commits(
+    db,
     rfs,
     git_dir,
     [end],

--- a/modules/bit/cmd/bit/helpers_wbtest.mbt
+++ b/modules/bit/cmd/bit/helpers_wbtest.mbt
@@ -364,10 +364,12 @@ test "helpers: get_work_root finds repo root from PWD when shim pwd is absent" {
   fs.mkdir_p(root + "/.git")
   fs.mkdir_p(subdir)
   let prev_shim_pwd = @sys.get_env_var("GIT_SHIM_PWD")
+  let prev_shim_cwd = @sys.get_env_var("GIT_SHIM_CWD")
   let prev_pwd = @sys.get_env_var("PWD")
   let prev_git_dir = @sys.get_env_var("GIT_DIR")
   let prev_work_tree = @sys.get_env_var("GIT_WORK_TREE")
   @sys.unset_env_var("GIT_SHIM_PWD")
+  @sys.unset_env_var("GIT_SHIM_CWD")
   @sys.set_env_var("PWD", subdir)
   @sys.unset_env_var("GIT_DIR")
   @sys.unset_env_var("GIT_WORK_TREE")
@@ -375,6 +377,10 @@ test "helpers: get_work_root finds repo root from PWD when shim pwd is absent" {
   match prev_shim_pwd {
     Some(value) => @sys.set_env_var("GIT_SHIM_PWD", value)
     None => @sys.unset_env_var("GIT_SHIM_PWD")
+  }
+  match prev_shim_cwd {
+    Some(value) => @sys.set_env_var("GIT_SHIM_CWD", value)
+    None => @sys.unset_env_var("GIT_SHIM_CWD")
   }
   match prev_pwd {
     Some(value) => @sys.set_env_var("PWD", value)

--- a/modules/bit/cmd/bit/log.mbt
+++ b/modules/bit/cmd/bit/log.mbt
@@ -1110,13 +1110,13 @@ fn log_assign_left_right_marker(
 
 ///|
 fn log_build_left_right_markers(
+  db : @bitlib.ObjectDb,
   fs : OsFs,
   rfs : &@bitcore.RepoFileSystem,
   git_dir : String,
   symmetric_ranges : Array[(String, String)],
   ignore_missing : Bool,
 ) -> Map[String, String] raise Error {
-  let db = @bitlib.ObjectDb::load(rfs, log_resolve_common_git_dir(rfs, git_dir))
   let markers : Map[String, String] = Map([])
   for pair in symmetric_ranges {
     let left_spec = pair.0
@@ -1138,11 +1138,10 @@ fn log_build_left_right_markers(
         let left_seen : Map[String, Bool] = Map([])
         let right_seen : Map[String, Bool] = Map([])
         let merge_base_seen : Map[String, Bool] = Map([])
-        walk_commits_to_map(fs, git_dir, left_commit, left_seen)
-        walk_commits_to_map(fs, git_dir, right_commit, right_seen)
-        match log_find_merge_base(rfs, git_dir, left_commit, right_commit) {
-          Some(base_id) =>
-            walk_commits_to_map(fs, git_dir, base_id, merge_base_seen)
+        walk_commits_to_map(db, fs, left_commit, left_seen)
+        walk_commits_to_map(db, fs, right_commit, right_seen)
+        match log_find_merge_base(db, rfs, left_commit, right_commit) {
+          Some(base_id) => walk_commits_to_map(db, fs, base_id, merge_base_seen)
           None => ()
         }
         let left_entries : Array[(String, Bool)] = left_seen.iter().collect()
@@ -1217,6 +1216,7 @@ fn log_add_resolved_ancestry_root(
 
 ///|
 fn log_resolve_ancestry_roots(
+  db : @bitlib.ObjectDb,
   rfs : &@bitcore.RepoFileSystem,
   git_dir : String,
   ancestry_path : Bool,
@@ -1230,7 +1230,6 @@ fn log_resolve_ancestry_roots(
     return roots
   }
   let seen : Map[String, Bool] = Map([])
-  let db = @bitlib.ObjectDb::load(rfs, log_resolve_common_git_dir(rfs, git_dir))
   if ancestry_path_specs.length() > 0 {
     for spec in ancestry_path_specs {
       log_add_resolved_ancestry_root(
@@ -1260,7 +1259,7 @@ fn log_resolve_ancestry_roots(
             Some(id) => id
             None => right_id
           }
-          match log_find_merge_base(rfs, git_dir, left_commit, right_commit) {
+          match log_find_merge_base(db, rfs, left_commit, right_commit) {
             Some(base_id) => {
               let hex = base_id.to_hex()
               if !seen.contains(hex) {
@@ -1289,8 +1288,8 @@ fn log_resolve_ancestry_roots(
 
 ///|
 fn log_commit_has_ancestor(
+  db : @bitlib.ObjectDb,
   rfs : &@bitcore.RepoFileSystem,
-  git_dir : String,
   commit_id : @bitcore.ObjectId,
   ancestor_ids : Array[@bitcore.ObjectId],
   first_parent? : Bool = false,
@@ -1302,7 +1301,6 @@ fn log_commit_has_ancestor(
   for id in ancestor_ids {
     ancestors[id.to_hex()] = true
   }
-  let db = @bitlib.ObjectDb::load(rfs, log_resolve_common_git_dir(rfs, git_dir))
   let seen : Map[String, Bool] = Map([])
   let queue : Array[@bitcore.ObjectId] = [commit_id]
   while queue.length() > 0 {
@@ -2203,11 +2201,10 @@ fn log_collect_reflog_targets(
 
 ///|
 fn log_sort_targets_by_time(
+  db : @bitlib.ObjectDb,
   rfs : &@bitcore.RepoFileSystem,
-  git_dir : String,
   targets : Array[(String, @bitcore.ObjectId)],
-) -> Array[(String, @bitcore.ObjectId)] raise Error {
-  let db = @bitlib.ObjectDb::load(rfs, git_dir)
+) -> Array[(String, @bitcore.ObjectId)] {
   let ordered : Array[(Int64, Int, (String, @bitcore.ObjectId))] = []
   for i in 0..<targets.length() {
     let target = targets[i]
@@ -2230,12 +2227,11 @@ fn log_sort_targets_by_time(
 
 ///|
 fn log_find_merge_base(
+  db : @bitlib.ObjectDb,
   rfs : &@bitcore.RepoFileSystem,
-  git_dir : String,
   left : @bitcore.ObjectId,
   right : @bitcore.ObjectId,
 ) -> @bitcore.ObjectId? raise Error {
-  let db = @bitlib.ObjectDb::load(rfs, git_dir)
   let left_ancestors : Map[String, Bool] = Map([])
   let left_queue : Array[@bitcore.ObjectId] = [left]
   while left_queue.length() > 0 {
@@ -4770,13 +4766,13 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
     )
     let left_right_markers = if left_right && symmetric_ranges.length() > 0 {
       log_build_left_right_markers(
-        fs, rfs, git_dir, symmetric_ranges, ignore_missing,
+        db, fs, rfs, git_dir, symmetric_ranges, ignore_missing,
       )
     } else {
       Map([])
     }
     let ancestry_roots = log_resolve_ancestry_roots(
-      rfs, git_dir, ancestry_path, ancestry_path_specs, range_excludes, symmetric_ranges,
+      db, rfs, git_dir, ancestry_path, ancestry_path_specs, range_excludes, symmetric_ranges,
       ignore_missing,
     )
     let seen : Map[String, Bool] = Map([])
@@ -4794,7 +4790,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
       let targets = if no_walk_unsorted {
         resolved_targets
       } else {
-        log_sort_targets_by_time(rfs, git_dir, resolved_targets)
+        log_sort_targets_by_time(db, rfs, resolved_targets)
       }
       for target in targets {
         if formatted_lines.length() >= max_count {
@@ -4806,13 +4802,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
           continue
         }
         if ancestry_roots.length() > 0 &&
-          !log_commit_has_ancestor(
-            rfs,
-            git_dir,
-            id,
-            ancestry_roots,
-            first_parent~,
-          ) {
+          !log_commit_has_ancestor(db, rfs, id, ancestry_roots, first_parent~) {
           continue
         }
         if !log_commit_matches_text_filters(
@@ -4908,8 +4898,8 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         match @bitrepo.rev_parse(rfs, git_dir, spec) {
           Some(id) =>
             walk_commits_to_map(
+              db,
               fs,
-              git_dir,
               id,
               exclude_ids,
               first_parent=exclude_first_parent_only,
@@ -4928,11 +4918,11 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
             @bitrepo.rev_parse(rfs, git_dir, right_spec),
           ) {
           (Some(left_id), Some(right_id)) =>
-            match log_find_merge_base(rfs, git_dir, left_id, right_id) {
+            match log_find_merge_base(db, rfs, left_id, right_id) {
               Some(base_id) =>
                 walk_commits_to_map(
+                  db,
                   fs,
-                  git_dir,
                   base_id,
                   exclude_ids,
                   first_parent=exclude_first_parent_only,
@@ -4947,6 +4937,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         }
       }
       let entries = log_walk_commits(
+        db,
         rfs,
         git_dir,
         start_ids,
@@ -4986,8 +4977,8 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         }
         if ancestry_roots.length() > 0 &&
           !log_commit_has_ancestor(
+            db,
             rfs,
-            git_dir,
             entry.id,
             ancestry_roots,
             first_parent~,
@@ -5157,10 +5148,11 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
       default_head=!saw_revision_input,
       ignore_missing~,
     )
+    let db = @bitlib.ObjectDb::load(rfs, git_dir)
     let targets = if no_walk_unsorted {
       resolved_targets
     } else {
-      log_sort_targets_by_time(rfs, git_dir, resolved_targets)
+      log_sort_targets_by_time(db, rfs, resolved_targets)
     }
     let selection_ref_names = if show_decorations || simplify_by_decoration {
       log_build_ref_names(rfs, git_dir, decoration_options)
@@ -5168,9 +5160,8 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
       Map([])
     }
     let ref_names = if show_decorations { selection_ref_names } else { Map([]) }
-    let db = @bitlib.ObjectDb::load(rfs, git_dir)
     let ancestry_roots = log_resolve_ancestry_roots(
-      rfs, git_dir, ancestry_path, ancestry_path_specs, range_excludes, symmetric_ranges,
+      db, rfs, git_dir, ancestry_path, ancestry_path_specs, range_excludes, symmetric_ranges,
       ignore_missing,
     )
     let seen : Map[String, Bool] = Map([])
@@ -5186,13 +5177,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
           continue
         }
         if ancestry_roots.length() > 0 &&
-          !log_commit_has_ancestor(
-            rfs,
-            git_dir,
-            id,
-            ancestry_roots,
-            first_parent~,
-          ) {
+          !log_commit_has_ancestor(db, rfs, id, ancestry_roots, first_parent~) {
           continue
         }
         if !log_commit_matches_text_filters(
@@ -5259,13 +5244,7 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
           continue
         }
         if ancestry_roots.length() > 0 &&
-          !log_commit_has_ancestor(
-            rfs,
-            git_dir,
-            id,
-            ancestry_roots,
-            first_parent~,
-          ) {
+          !log_commit_has_ancestor(db, rfs, id, ancestry_roots, first_parent~) {
           continue
         }
         if !log_commit_matches_text_filters(
@@ -5466,14 +5445,18 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
     for target in start_targets {
       start_ids.push(target.1)
     }
+    let walk_db = @bitlib.ObjectDb::load(
+      rfs,
+      log_resolve_common_git_dir(rfs, git_dir),
+    )
     // Build exclude_ids from range_excludes
     let exclude_ids : Map[String, Bool] = Map([])
     for spec in range_excludes {
       match @bitrepo.rev_parse(rfs, git_dir, spec) {
         Some(id) =>
           walk_commits_to_map(
+            walk_db,
             fs,
-            git_dir,
             id,
             exclude_ids,
             first_parent=exclude_first_parent_only,
@@ -5492,11 +5475,11 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
           @bitrepo.rev_parse(rfs, git_dir, right_spec),
         ) {
         (Some(left_id), Some(right_id)) =>
-          match log_find_merge_base(rfs, git_dir, left_id, right_id) {
+          match log_find_merge_base(walk_db, rfs, left_id, right_id) {
             Some(base_id) =>
               walk_commits_to_map(
+                walk_db,
                 fs,
-                git_dir,
                 base_id,
                 exclude_ids,
                 first_parent=exclude_first_parent_only,
@@ -5534,22 +5517,19 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
     } else {
       Map([])
     }
-    let walk_db = @bitlib.ObjectDb::load(
-      rfs,
-      log_resolve_common_git_dir(rfs, git_dir),
-    )
     let left_right_markers = if left_right && symmetric_ranges.length() > 0 {
       log_build_left_right_markers(
-        fs, rfs, git_dir, symmetric_ranges, ignore_missing,
+        walk_db, fs, rfs, git_dir, symmetric_ranges, ignore_missing,
       )
     } else {
       Map([])
     }
     let ancestry_roots = log_resolve_ancestry_roots(
-      rfs, git_dir, ancestry_path, ancestry_path_specs, range_excludes, symmetric_ranges,
-      ignore_missing,
+      walk_db, rfs, git_dir, ancestry_path, ancestry_path_specs, range_excludes,
+      symmetric_ranges, ignore_missing,
     )
     let entries = log_walk_commits(
+      walk_db,
       rfs,
       git_dir,
       start_ids,
@@ -5593,8 +5573,8 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         }
         if ancestry_roots.length() > 0 &&
           !log_commit_has_ancestor(
+            walk_db,
             rfs,
-            git_dir,
             entry.id,
             ancestry_roots,
             first_parent~,
@@ -5680,8 +5660,8 @@ async fn handle_log(args : Array[String]) -> Unit raise Error {
         }
         if ancestry_roots.length() > 0 &&
           !log_commit_has_ancestor(
+            walk_db,
             rfs,
-            git_dir,
             entry.id,
             ancestry_roots,
             first_parent~,
@@ -5979,9 +5959,79 @@ fn log_entry_marker_prefix(
 }
 
 ///|
+fn log_get_cached_commit(
+  cache : Map[String, @bitcore.PackObject],
+  id : @bitcore.ObjectId,
+  loader : (@bitcore.ObjectId) -> @bitcore.PackObject?,
+) -> @bitcore.PackObject? {
+  let hex = id.to_hex()
+  match cache.get(hex) {
+    Some(object) => Some(object)
+    None =>
+      match loader(id) {
+        Some(object) => {
+          cache[hex] = object
+          Some(object)
+        }
+        None => None
+      }
+  }
+}
+
+///|
+fn log_load_walk_commit(
+  db : @bitlib.ObjectDb,
+  rfs : &@bitcore.RepoFileSystem,
+  cache : Map[String, @bitcore.PackObject],
+  id : @bitcore.ObjectId,
+) -> @bitcore.PackObject? {
+  log_get_cached_commit(cache, id, fn(id) {
+    db.get(rfs, id) catch {
+      _ => None
+    }
+  })
+}
+
+///|
+fn log_get_walk_commit_timestamp(
+  db : @bitlib.ObjectDb,
+  rfs : &@bitcore.RepoFileSystem,
+  cache : Map[String, @bitcore.PackObject],
+  id : @bitcore.ObjectId,
+) -> Int64 {
+  match log_load_walk_commit(db, rfs, cache, id) {
+    Some(object) => log_extract_committer_timestamp(object.data)
+    None => 0L
+  }
+}
+
+///|
+fn log_get_walk_commit_tree(
+  db : @bitlib.ObjectDb,
+  rfs : &@bitcore.RepoFileSystem,
+  cache : Map[String, @bitcore.PackObject],
+  id : @bitcore.ObjectId,
+) -> @bitcore.ObjectId? {
+  match db.get_commit_graph_commit(id) {
+    Some(info) => Some(info.tree)
+    None =>
+      match log_load_walk_commit(db, rfs, cache, id) {
+        Some(object) if object.obj_type == @bitcore.ObjectType::Commit => {
+          let info = @bitcore.parse_commit(object.data) catch {
+            _ => return None
+          }
+          Some(info.tree)
+        }
+        _ => None
+      }
+  }
+}
+
+///|
 /// BFS walk from start_ids, excluding exclude_ids, with timestamp filtering.
 /// Returns entries sorted by timestamp descending (or topologically if topo_order).
 fn log_walk_commits(
+  db : @bitlib.ObjectDb,
   rfs : &@bitcore.RepoFileSystem,
   git_dir : String,
   start_ids : Array[@bitcore.ObjectId],
@@ -5994,22 +6044,25 @@ fn log_walk_commits(
   topo_order? : Bool = false,
   show_boundary? : Bool = false,
 ) -> Array[LogWalkEntry] raise Error {
-  let db = @bitlib.ObjectDb::load(rfs, log_resolve_common_git_dir(rfs, git_dir))
+  db.set_skip_verify(true)
+  let commit_cache : Map[String, @bitcore.PackObject] = Map([])
   let result : Array[LogWalkEntry] = []
   let visited : Map[String, Bool] = Map([])
   let boundary_seen : Map[String, Bool] = Map([])
   let boundary_ids : Array[@bitcore.ObjectId] = []
-  // Priority queue: (timestamp, id) sorted desc by timestamp
-  // Use insertion-sorted array
-  let queue : Array[(Int64, @bitcore.ObjectId)] = []
+  // Max heap: (committer timestamp, insertion order, id). The insertion
+  // order preserves the old queue's stable behaviour for equal timestamps.
+  let queue : Array[(Int64, Int, @bitcore.ObjectId)] = []
+  let mut queue_sequence = 0
   // For topo_order: DFS stack follows first-parent chains
   let topo_stack : Array[@bitcore.ObjectId] = []
   for id in start_ids {
     let hex = id.to_hex()
     if !visited.contains(hex) && !exclude_ids.contains(hex) {
       // Get timestamp for sorting
-      let ts = log_get_commit_timestamp(db, rfs, id)
-      log_queue_insert(queue, (ts, id))
+      let ts = log_get_walk_commit_timestamp(db, rfs, commit_cache, id)
+      log_queue_push(queue, (ts, queue_sequence, id))
+      queue_sequence += 1
       visited[hex] = true
     }
   }
@@ -6019,18 +6072,7 @@ fn log_walk_commits(
     let id = if topo_order && topo_stack.length() > 0 {
       topo_stack.unsafe_pop()
     } else if queue.length() > 0 {
-      let (_, qid) = queue[0]
-      // Remove front
-      let new_q : Array[(Int64, @bitcore.ObjectId)] = []
-      for i in 1..<queue.length() {
-        new_q.push(queue[i])
-      }
-      while queue.length() > 0 {
-        ignore(queue.unsafe_pop())
-      }
-      for item in new_q {
-        queue.push(item)
-      }
+      let (_, _, qid) = log_queue_pop(queue).unwrap()
       qid
     } else {
       break
@@ -6040,7 +6082,7 @@ fn log_walk_commits(
       continue
     }
     // Get commit data
-    let obj = db.get(rfs, id)
+    let obj = log_load_walk_commit(db, rfs, commit_cache, id)
     guard obj is Some(o) else { continue }
     let info = @bitcore.parse_commit(o.data)
     let parents = log_resolve_parents(rfs, git_dir, id, info.parents)
@@ -6066,8 +6108,11 @@ fn log_walk_commits(
           if idx == 0 {
             topo_stack.push(parent)
           } else {
-            let pts = log_get_commit_timestamp(db, rfs, parent)
-            log_queue_insert(queue, (pts, parent))
+            let pts = log_get_walk_commit_timestamp(
+              db, rfs, commit_cache, parent,
+            )
+            log_queue_push(queue, (pts, queue_sequence, parent))
+            queue_sequence += 1
           }
         }
       }
@@ -6083,8 +6128,9 @@ fn log_walk_commits(
         }
         if !visited.contains(phex) {
           visited[phex] = true
-          let pts = log_get_commit_timestamp(db, rfs, parent)
-          log_queue_insert(queue, (pts, parent))
+          let pts = log_get_walk_commit_timestamp(db, rfs, commit_cache, parent)
+          log_queue_push(queue, (pts, queue_sequence, parent))
+          queue_sequence += 1
         }
       }
     }
@@ -6099,7 +6145,7 @@ fn log_walk_commits(
     }
     let parent_tree : @bitcore.ObjectId? = if include_parent_tree &&
       parents.length() > 0 {
-      log_get_commit_tree(db, rfs, parents[0])
+      log_get_walk_commit_tree(db, rfs, commit_cache, parents[0])
     } else {
       None
     }
@@ -6108,7 +6154,7 @@ fn log_walk_commits(
   }
   if show_boundary {
     for boundary_id in boundary_ids {
-      let obj = db.get(rfs, boundary_id)
+      let obj = log_load_walk_commit(db, rfs, commit_cache, boundary_id)
       guard obj is Some(o) else { continue }
       if o.obj_type != @bitcore.ObjectType::Commit {
         continue
@@ -6124,7 +6170,7 @@ fn log_walk_commits(
       )
       let parent_tree : @bitcore.ObjectId? = if include_parent_tree &&
         parents.length() > 0 {
-        log_get_commit_tree(db, rfs, parents[0])
+        log_get_walk_commit_tree(db, rfs, commit_cache, parents[0])
       } else {
         None
       }
@@ -6135,28 +6181,67 @@ fn log_walk_commits(
 }
 
 ///|
-/// Insert into timestamp-descending sorted array.
-fn log_queue_insert(
-  queue : Array[(Int64, @bitcore.ObjectId)],
-  item : (Int64, @bitcore.ObjectId),
+
+///|
+/// Higher timestamps win; equal timestamps keep insertion order.
+fn log_queue_higher_priority(
+  left : (Int64, Int, @bitcore.ObjectId),
+  right : (Int64, Int, @bitcore.ObjectId),
+) -> Bool {
+  left.0 > right.0 || (left.0 == right.0 && left.1 < right.1)
+}
+
+///|
+/// Insert an item into a max heap in O(log N).
+fn log_queue_push(
+  queue : Array[(Int64, Int, @bitcore.ObjectId)],
+  item : (Int64, Int, @bitcore.ObjectId),
 ) -> Unit {
-  let ts = item.0
-  let mut pos = queue.length()
-  // Find insertion point (descending order)
-  for i in 0..<queue.length() {
-    if ts > queue[i].0 {
-      pos = i
+  queue.push(item)
+  let mut child = queue.length() - 1
+  while child > 0 {
+    let parent = (child - 1) / 2
+    if !log_queue_higher_priority(queue[child], queue[parent]) {
       break
     }
+    let temp = queue[parent]
+    queue[parent] = queue[child]
+    queue[child] = temp
+    child = parent
   }
-  queue.push(item) // push to end first
-  // Shift elements right
-  let mut j = queue.length() - 1
-  while j > pos {
-    queue[j] = queue[j - 1]
-    j -= 1
+}
+
+///|
+/// Remove the highest-priority item from a max heap in O(log N).
+fn log_queue_pop(
+  queue : Array[(Int64, Int, @bitcore.ObjectId)],
+) -> (Int64, Int, @bitcore.ObjectId)? {
+  if queue.length() == 0 {
+    return None
   }
-  queue[pos] = item
+  let first = queue[0]
+  let last = queue.unsafe_pop()
+  if queue.length() == 0 {
+    return Some(first)
+  }
+  queue[0] = last
+  let mut parent = 0
+  let mut child = 1
+  while child < queue.length() {
+    if child + 1 < queue.length() &&
+      log_queue_higher_priority(queue[child + 1], queue[child]) {
+      child += 1
+    }
+    if !log_queue_higher_priority(queue[child], queue[parent]) {
+      break
+    }
+    let temp = queue[parent]
+    queue[parent] = queue[child]
+    queue[child] = temp
+    parent = child
+    child = parent * 2 + 1
+  }
+  Some(first)
 }
 
 ///|
@@ -6455,7 +6540,7 @@ async fn log_with_graph(
   let exclude_ids : Map[String, Bool] = Map([])
   for spec in range_excludes {
     match @bitrepo.rev_parse(rfs, git_dir, spec) {
-      Some(id) => walk_commits_to_map(OsFs::new(), git_dir, id, exclude_ids)
+      Some(id) => walk_commits_to_map(db, OsFs::new(), id, exclude_ids)
       None =>
         raise @bitcore.GitError::InvalidObject("Unknown revision: " + spec)
     }
@@ -6469,6 +6554,7 @@ async fn log_with_graph(
   // gathers the full reachable history and we truncate the sorted result. (A
   // walk-then-truncate would topo-sort the wrong subset near the cutoff.)
   let walked = log_walk_commits(
+    db,
     rfs,
     git_dir,
     starts,

--- a/modules/bit/cmd/bit/log_wbtest.mbt
+++ b/modules/bit/cmd/bit/log_wbtest.mbt
@@ -90,6 +90,31 @@ test "log: log_find_tripledot parses A...B ranges" {
 }
 
 ///|
+test "log: commit cache avoids loading an object twice" {
+  let id = @bitcore.hash_object_content(
+    @bitcore.ObjectType::Commit,
+    b"tree 0000000000000000000000000000000000000000\n\nmessage\n",
+  )
+  let object = @bitcore.PackObject::new(
+    @bitcore.ObjectType::Commit,
+    b"tree 0000000000000000000000000000000000000000\n\nmessage\n",
+  )
+  let cache : Map[String, @bitcore.PackObject] = Map([])
+  let loads = [0]
+  let loader = fn(_ : @bitcore.ObjectId) -> @bitcore.PackObject? {
+    loads[0] += 1
+    Some(object)
+  }
+
+  let first = log_get_cached_commit(cache, id, loader)
+  let second = log_get_cached_commit(cache, id, loader)
+
+  assert_true(first is Some(_))
+  assert_true(second is Some(_))
+  @test.assert_eq(loads[0], 1)
+}
+
+///|
 test "log: revision input handles caret and not-mode excludes" {
   let revs : Array[String] = []
   let excludes : Array[String] = []
@@ -370,7 +395,9 @@ test "log: ancestry path keeps commits descended from bottom commits" {
   let exclude_ids : Map[String, Bool] = Map([])
   exclude_ids[root.to_hex()] = true
   exclude_ids[bottom.to_hex()] = true
+  let db = @bitlib.ObjectDb::load(fs, git_dir)
   let entries = log_walk_commits(
+    db,
     fs,
     git_dir,
     [merge],
@@ -381,12 +408,12 @@ test "log: ancestry path keeps commits descended from bottom commits" {
     false,
   )
   @test.assert_eq(entries.length(), 2)
-  assert_true(log_commit_has_ancestor(fs, git_dir, merge, [bottom]))
-  assert_false(log_commit_has_ancestor(fs, git_dir, side, [bottom]))
+  assert_true(log_commit_has_ancestor(db, fs, merge, [bottom]))
+  assert_false(log_commit_has_ancestor(db, fs, side, [bottom]))
 
   let ancestry_entries : Array[LogWalkEntry] = []
   for entry in entries {
-    if log_commit_has_ancestor(fs, git_dir, entry.id, [bottom]) {
+    if log_commit_has_ancestor(db, fs, entry.id, [bottom]) {
       ancestry_entries.push(entry)
     }
   }
@@ -422,7 +449,9 @@ test "log: boundary walk appends excluded parent with marker flag" {
   let exclude_ids : Map[String, Bool] = Map([])
   exclude_ids[first.to_hex()] = true
   exclude_ids[second.to_hex()] = true
+  let db = @bitlib.ObjectDb::load(fs, "/repo/.git")
   let entries = log_walk_commits(
+    db,
     fs,
     "/repo/.git",
     [third],
@@ -967,8 +996,8 @@ test "log: is_short_count_flag" {
 }
 
 ///|
-test "log: log_queue_insert maintains descending order" {
-  let queue : Array[(Int64, @bitcore.ObjectId)] = []
+test "log: priority queue pops latest timestamps first and keeps equal timestamps stable" {
+  let queue : Array[(Int64, Int, @bitcore.ObjectId)] = []
   let id1 = @bitcore.ObjectId::from_hex(
     "1111111111111111111111111111111111111111",
   )
@@ -978,12 +1007,16 @@ test "log: log_queue_insert maintains descending order" {
   let id3 = @bitcore.ObjectId::from_hex(
     "3333333333333333333333333333333333333333",
   )
-  log_queue_insert(queue, (100L, id1))
-  log_queue_insert(queue, (300L, id3))
-  log_queue_insert(queue, (200L, id2))
-  @test.assert_eq(queue[0].0, 300L)
-  @test.assert_eq(queue[1].0, 200L)
-  @test.assert_eq(queue[2].0, 100L)
+  log_queue_push(queue, (100L, 0, id1))
+  log_queue_push(queue, (300L, 1, id3))
+  log_queue_push(queue, (200L, 2, id2))
+  log_queue_push(queue, (200L, 3, id1))
+
+  @test.assert_eq(log_queue_pop(queue).unwrap().2, id3)
+  @test.assert_eq(log_queue_pop(queue).unwrap().2, id2)
+  @test.assert_eq(log_queue_pop(queue).unwrap().2, id1)
+  @test.assert_eq(log_queue_pop(queue).unwrap().2, id1)
+  @test.assert_eq(log_queue_pop(queue), None)
 }
 
 ///|

--- a/modules/bit/cmd/bit/pack_objects.mbt
+++ b/modules/bit/cmd/bit/pack_objects.mbt
@@ -2567,7 +2567,8 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
           }
         }
         // Create cruft pack(s) — may split if --max-cruft-size
-        let cruft_pack_list : Array[Bytes] = match cruft_size_limit {
+        let cruft_pack_list : Array[(Bytes, Array[@bitcore.PackObject])] = match
+          cruft_size_limit {
           Some(limit) if limit > 0L => {
             let effective_limit = if limit < 1048576L {
               @stdio.stderr.write("warning: minimum pack size limit is 1 MiB\n")
@@ -2575,7 +2576,7 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
             } else {
               limit
             }
-            let (packs, _dc) = @pack.create_packfiles_with_size_limit(
+            let (packs, _dc) = @pack.create_packfiles_with_size_limit_and_metadata(
               cruft_objects,
               cfg.delta_mode,
               pack_compression,
@@ -2590,7 +2591,7 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
           _ =>
             if cruft_objects.length() == 0 {
               // Create an empty pack
-              let (pack, _dc) = @pack.create_packfile_with_delta_stats_compression_reuse(
+              let (pack, _dc, idx_objects) = @pack.create_packfile_with_delta_stats_compression_reuse_and_metadata(
                 [],
                 cfg.delta_mode,
                 pack_compression,
@@ -2599,9 +2600,9 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
                 cfg.window,
                 hash_size~,
               )
-              [pack]
+              [(pack, idx_objects)]
             } else {
-              let (pack, _dc) = @pack.create_packfile_with_delta_stats_compression_reuse(
+              let (pack, _dc, idx_objects) = @pack.create_packfile_with_delta_stats_compression_reuse_and_metadata(
                 cruft_objects,
                 cfg.delta_mode,
                 pack_compression,
@@ -2610,15 +2611,16 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
                 cfg.window,
                 hash_size~,
               )
-              [pack]
+              [(pack, idx_objects)]
             }
         }
-        for pack in cruft_pack_list {
+        for entry in cruft_pack_list {
+          let pack = entry.0
+          let idx_objects = entry.1
           let hash_hex = pack_hash_hex(pack, hash_size~)
           let pack_path = base_name + "-" + hash_hex + ".pack"
           let idx_path = base_name + "-" + hash_hex + ".idx"
           fs.write_file(pack_path, pack)
-          let idx_objects = @pack.parse_packfile(pack, hash_size~)
           @pack.write_pack_index_from_objects_versioned(
             fs,
             idx_path,
@@ -2640,13 +2642,7 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
             // Collect IDs for objects in this specific pack
             let ids : Array[String] = []
             for obj in idx_objects {
-              ids.push(
-                @bitobject.hash_object_content_with_algo(
-                  hash_algo,
-                  obj.obj_type,
-                  obj.data,
-                ).to_hex(),
-              )
+              ids.push(obj.id.to_hex())
             }
             ids.sort_by(fn(a, b) { a.compare(b) })
             ids
@@ -3126,10 +3122,11 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
         }
       }
       let mut total_delta_count = 0
-      let pack_list : Array[Bytes] = match effective_limit {
+      let pack_list : Array[(Bytes, Array[@bitcore.PackObject])] = match
+        effective_limit {
         Some(limit) =>
           if limit > 0L {
-            let (packs, dc) = @pack.create_packfiles_with_size_limit(
+            let (packs, dc) = @pack.create_packfiles_with_size_limit_and_metadata(
               objects,
               cfg.delta_mode,
               pack_compression,
@@ -3142,7 +3139,7 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
             total_delta_count += dc
             packs
           } else {
-            let (pack, dc) = @pack.create_packfile_with_delta_stats_compression_reuse(
+            let (pack, dc, idx_objects) = @pack.create_packfile_with_delta_stats_compression_reuse_and_metadata(
               objects,
               cfg.delta_mode,
               pack_compression,
@@ -3152,10 +3149,10 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
               hash_size~,
             )
             total_delta_count += dc
-            [pack]
+            [(pack, idx_objects)]
           }
         _ => {
-          let (pack, dc) = @pack.create_packfile_with_delta_stats_compression_reuse(
+          let (pack, dc, idx_objects) = @pack.create_packfile_with_delta_stats_compression_reuse_and_metadata(
             objects,
             cfg.delta_mode,
             pack_compression,
@@ -3165,10 +3162,12 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
             hash_size~,
           )
           total_delta_count += dc
-          [pack]
+          [(pack, idx_objects)]
         }
       }
-      for pack in pack_list {
+      for entry in pack_list {
+        let pack = entry.0
+        let idx_objects = entry.1
         if cfg.stdout {
           @stdio.stdout.write(pack)
         } else {
@@ -3185,9 +3184,6 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
           let pack_path = base_name + "-" + hash_hex + ".pack"
           let idx_path = base_name + "-" + hash_hex + ".idx"
           fs.write_file(pack_path, pack)
-          // Always re-parse the newly created pack to compute correct
-          // offsets and CRC32 values for the index.
-          let idx_objects = @pack.parse_packfile(pack, hash_size~)
           @pack.write_pack_index_from_objects_versioned(
             fs,
             idx_path,
@@ -3214,7 +3210,7 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
       if cfg.filter_to is Some(filter_to_prefix) {
         if filtered_out_objects.length() > 0 {
           let deduped = dedup_objects(filtered_out_objects)
-          let (ft_pack, _dc) = @pack.create_packfile_with_delta_stats_compression_reuse(
+          let (ft_pack, _dc, ft_idx_objects) = @pack.create_packfile_with_delta_stats_compression_reuse_and_metadata(
             deduped,
             cfg.delta_mode,
             pack_compression,
@@ -3228,7 +3224,6 @@ async fn handle_pack_objects(args : Array[String]) -> Unit raise Error {
           let ft_pack_path = ft_prefix + "-" + ft_hash + ".pack"
           let ft_idx_path = ft_prefix + "-" + ft_hash + ".idx"
           fs.write_file(ft_pack_path, ft_pack)
-          let ft_idx_objects = @pack.parse_packfile(ft_pack, hash_size~)
           @pack.write_pack_index_from_objects_versioned(
             fs,
             ft_idx_path,

--- a/modules/bit/cmd/bit/rev_list.mbt
+++ b/modules/bit/cmd/bit/rev_list.mbt
@@ -561,16 +561,16 @@ async fn handle_rev_list(args : Array[String]) -> Unit raise Error {
     }
   }
   // Resolve exclude commits
+  let db = @bitlib.ObjectDb::load(fs, git_dir)
   let exclude_ids : Map[String, Bool] = Map([])
   for spec in excludes {
     match @bitrepo.rev_parse(fs, git_dir, spec) {
       Some(id) =>
         // Walk the exclude commit and all its ancestors
-        walk_commits_to_map(fs, git_dir, id, exclude_ids)
+        walk_commits_to_map(db, fs, id, exclude_ids)
       None => ()
     }
   }
-  let db = @bitlib.ObjectDb::load(fs, git_dir)
   for pair in symmetric_ranges {
     match
       (
@@ -586,7 +586,7 @@ async fn handle_rev_list(args : Array[String]) -> Unit raise Error {
         )
         let bases = @bitlib.merge_base_all(db, fs, left_commit, right_commit)
         for base in bases {
-          walk_commits_to_map(fs, git_dir, base, exclude_ids)
+          walk_commits_to_map(db, fs, base, exclude_ids)
         }
       }
       _ => ()
@@ -1087,11 +1087,11 @@ fn rev_list_build_left_right_markers(
         let left_seen : Map[String, Bool] = Map([])
         let right_seen : Map[String, Bool] = Map([])
         let merge_base_seen : Map[String, Bool] = Map([])
-        walk_commits_to_map(fs, git_dir, left_commit, left_seen)
-        walk_commits_to_map(fs, git_dir, right_commit, right_seen)
+        walk_commits_to_map(db, fs, left_commit, left_seen)
+        walk_commits_to_map(db, fs, right_commit, right_seen)
         let bases = @bitlib.merge_base_all(db, fs, left_commit, right_commit)
         for base in bases {
-          walk_commits_to_map(fs, git_dir, base, merge_base_seen)
+          walk_commits_to_map(db, fs, base, merge_base_seen)
         }
         for hex in left_seen.keys() {
           if merge_base_seen.contains(hex) {
@@ -1287,13 +1287,12 @@ fn rev_list_window(
 
 ///|
 fn walk_commits_to_map(
+  db : @bitlib.ObjectDb,
   fs : OsFs,
-  git_dir : String,
   start : @bitcore.ObjectId,
   out : Map[String, Bool],
   first_parent? : Bool = false,
 ) -> Unit {
-  let db = @bitlib.ObjectDb::load(fs, git_dir) catch { _ => return () }
   let queue : Array[@bitcore.ObjectId] = [start]
   while queue.length() > 0 {
     let id = queue.unsafe_pop()

--- a/modules/bit/cmd/bit/show.mbt
+++ b/modules/bit/cmd/bit/show.mbt
@@ -933,7 +933,7 @@ async fn handle_show(args : Array[String]) -> Unit raise Error {
     )
     for target in exclude_targets {
       let (_, exclude_id) = target
-      walk_commits_to_map(fs, git_dir, exclude_id, exclude_ids)
+      walk_commits_to_map(db, fs, exclude_id, exclude_ids)
     }
     let max_count = if options.max_count > 0 {
       options.max_count
@@ -943,8 +943,8 @@ async fn handle_show(args : Array[String]) -> Unit raise Error {
     let blocks : Array[String] = []
     for
       entry in log_walk_commits(
-        fs, git_dir, start_ids, exclude_ids, max_count, -9223372036854775807L, 9223372036854775807L,
-        false,
+        db, fs, git_dir, start_ids, exclude_ids, max_count, -9223372036854775807L,
+        9223372036854775807L, false,
       ) {
       let obj = db.get(fs, entry.id)
       guard obj is Some(o) else { continue }

--- a/modules/bit_hash/src/pkg.generated.mbti
+++ b/modules/bit_hash/src/pkg.generated.mbti
@@ -20,6 +20,8 @@ pub fn sha1_bytes(Bytes) -> Bytes
 
 pub fn sha1_prefix_raw(Bytes, Int) -> FixedArray[Byte]
 
+pub fn sha1_prefixed_raw(Bytes, Bytes) -> FixedArray[Byte]
+
 pub fn sha1_raw(Bytes) -> FixedArray[Byte]
 
 pub fn sha256_array_prefix_raw(Array[Byte], Int) -> FixedArray[Byte]

--- a/modules/bit_hash/src/sha1_ni.c
+++ b/modules/bit_hash/src/sha1_ni.c
@@ -12,6 +12,18 @@
 #include <string.h>
 
 /*
+ * Apple Silicon ships a hardware-backed SHA-1 implementation through
+ * CommonCrypto. Keep this native-only path behind the C target check; other
+ * platforms continue through the portable/SHA-NI dispatch below.
+ */
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+#  include <CommonCrypto/CommonDigest.h>
+#  define USE_APPLE_ARM_SHA1 1
+#else
+#  define USE_APPLE_ARM_SHA1 0
+#endif
+
+/*
  * Function-level target attributes allow SHA-NI intrinsics with clang/gcc
  * even without -msha on the command line.
  * TCC doesn't support __attribute__((target(...))), so we fall back there.
@@ -286,6 +298,13 @@ static void sha1_scalar_blocks(uint32_t h[5], const uint8_t* data, size_t num_bl
   }
 }
 
+#if USE_SHA_NI
+#  define SHA1_DISPATCH(st, d, n) \
+     (sha1_ni_ok() ? sha1_ni_blocks((st),(d),(n)) : sha1_scalar_blocks((st),(d),(n)))
+#else
+#  define SHA1_DISPATCH(st, d, n) sha1_scalar_blocks((st),(d),(n))
+#endif
+
 /* ── MoonBit-callable entry points ────────────────────────────────────── */
 
 /*
@@ -305,13 +324,6 @@ void sha1_compute(const uint8_t* data, int32_t len, uint8_t* out) {
   /* Process all full blocks from the input directly. */
   int32_t full_blocks = len / 64;
   int32_t remainder   = len % 64;
-
-#if USE_SHA_NI
-#  define SHA1_DISPATCH(st, d, n) \
-     (sha1_ni_ok() ? sha1_ni_blocks((st),(d),(n)) : sha1_scalar_blocks((st),(d),(n)))
-#else
-#  define SHA1_DISPATCH(st, d, n) sha1_scalar_blocks((st),(d),(n))
-#endif
 
   if (full_blocks > 0) {
     SHA1_DISPATCH(state, data, (size_t)full_blocks);
@@ -353,6 +365,86 @@ void sha1_compute(const uint8_t* data, int32_t len, uint8_t* out) {
     out[i*4 + 2] = (uint8_t)(state[i] >>  8);
     out[i*4 + 3] = (uint8_t)(state[i]      );
   }
+}
+
+static void sha1_update_part(uint32_t state[5], uint8_t block[64],
+                             size_t *block_len, const uint8_t *data,
+                             size_t len) {
+  if (*block_len > 0) {
+    size_t take = 64 - *block_len;
+    if (take > len) take = len;
+    memcpy(block + *block_len, data, take);
+    *block_len += take;
+    data += take;
+    len -= take;
+    if (*block_len == 64) {
+      SHA1_DISPATCH(state, block, 1);
+      *block_len = 0;
+    }
+  }
+  size_t full_blocks = len / 64;
+  if (full_blocks > 0) {
+    SHA1_DISPATCH(state, data, full_blocks);
+    data += full_blocks * 64;
+    len -= full_blocks * 64;
+  }
+  if (len > 0) {
+    memcpy(block, data, len);
+    *block_len = len;
+  }
+}
+
+/*
+ * Hash two consecutive byte slices without a temporary concatenation. This is
+ * the shape used by Git object IDs: "<type> <size>\\0" followed by content.
+ */
+void sha1_compute_prefixed(const uint8_t* prefix, int32_t prefix_len,
+                           const uint8_t* data, int32_t data_len,
+                           uint8_t* out) {
+#if USE_APPLE_ARM_SHA1
+  CC_SHA1_CTX ctx;
+  CC_SHA1_Init(&ctx);
+  if (prefix_len > 0)
+    CC_SHA1_Update(&ctx, prefix, (CC_LONG)prefix_len);
+  if (data_len > 0)
+    CC_SHA1_Update(&ctx, data, (CC_LONG)data_len);
+  CC_SHA1_Final(out, &ctx);
+#else
+  uint32_t state[5] = {
+    0x67452301u, 0xefcdab89u, 0x98badcfeu, 0x10325476u, 0xc3d2e1f0u
+  };
+  uint8_t block[64];
+  size_t block_len = 0;
+  uint64_t total_len = (uint64_t)(uint32_t)prefix_len +
+                       (uint64_t)(uint32_t)data_len;
+  sha1_update_part(state, block, &block_len, prefix, (size_t)prefix_len);
+  sha1_update_part(state, block, &block_len, data, (size_t)data_len);
+
+  block[block_len++] = 0x80;
+  if (block_len > 56) {
+    memset(block + block_len, 0, 64 - block_len);
+    SHA1_DISPATCH(state, block, 1);
+    block_len = 0;
+  }
+  memset(block + block_len, 0, 56 - block_len);
+  uint64_t bit_len = total_len * 8;
+  block[56] = (uint8_t)(bit_len >> 56);
+  block[57] = (uint8_t)(bit_len >> 48);
+  block[58] = (uint8_t)(bit_len >> 40);
+  block[59] = (uint8_t)(bit_len >> 32);
+  block[60] = (uint8_t)(bit_len >> 24);
+  block[61] = (uint8_t)(bit_len >> 16);
+  block[62] = (uint8_t)(bit_len >> 8);
+  block[63] = (uint8_t)bit_len;
+  SHA1_DISPATCH(state, block, 1);
+
+  for (int i = 0; i < 5; i++) {
+    out[i * 4] = (uint8_t)(state[i] >> 24);
+    out[i * 4 + 1] = (uint8_t)(state[i] >> 16);
+    out[i * 4 + 2] = (uint8_t)(state[i] >> 8);
+    out[i * 4 + 3] = (uint8_t)state[i];
+  }
+#endif
 }
 
 /*

--- a/modules/bit_hash/src/sha1_prefixed.mbt
+++ b/modules/bit_hash/src/sha1_prefixed.mbt
@@ -1,0 +1,32 @@
+///| Hash two consecutive byte slices as one SHA-1 stream.
+
+///|
+/// The native implementation dispatches to the platform SHA-1 backend without
+/// copying `prefix` and `data` into one temporary buffer. Other targets retain
+/// the portable MoonBit implementation.
+#cfg(target="native")
+#borrow(prefix, data, out)
+extern "C" fn sha1_compute_prefixed_ffi(
+  prefix : Bytes,
+  prefix_len : Int,
+  data : Bytes,
+  data_len : Int,
+  out : FixedArray[Byte],
+) -> Unit = "sha1_compute_prefixed"
+
+///|
+#cfg(target="native")
+pub fn sha1_prefixed_raw(prefix : Bytes, data : Bytes) -> FixedArray[Byte] {
+  let out : FixedArray[Byte] = FixedArray::make(20, b'\x00')
+  sha1_compute_prefixed_ffi(prefix, prefix.length(), data, data.length(), out)
+  out
+}
+
+///|
+#cfg(not(target="native"))
+pub fn sha1_prefixed_raw(prefix : Bytes, data : Bytes) -> FixedArray[Byte] {
+  let state = Sha1State::new()
+  state.update(prefix)
+  state.update(data)
+  state.finish_raw()
+}

--- a/modules/bit_hash/src/sha1_test.mbt
+++ b/modules/bit_hash/src/sha1_test.mbt
@@ -23,6 +23,14 @@ test "sha1_raw abc" {
 }
 
 ///|
+test "sha1_prefixed_raw: git blob object" {
+  let prefix = Bytes::from_array([b'b', b'l', b'o', b'b', b' ', b'3', b'\x00'])
+  let content = Bytes::from_array([b'a', b'b', b'c'])
+  let got = sha1_prefixed_raw(prefix, content) |> raw_to_hex
+  inspect(got, content="f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f")
+}
+
+///|
 test "Sha1State: abc" {
   let state = Sha1State::new()
   state.update(Bytes::from_array([b'a', b'b', b'c']))

--- a/modules/bit_lib/src/object_db.mbt
+++ b/modules/bit_lib/src/object_db.mbt
@@ -246,6 +246,10 @@ pub struct ObjectDb {
   pack_cache : Map[String, Bytes]
   pack_cache_order : Array[String]
   pack_cache_limit : Int
+  decoded_cache : Map[String, @bit.PackObject]
+  decoded_cache_order : Array[String]
+  mut decoded_cache_bytes : Int
+  decoded_cache_limit : Int
   mut prefer_packed : Bool
   mut saw_corrupt_pack : Bool
   mut skip_verify : Bool
@@ -262,6 +266,22 @@ fn pack_cache_limit_from_env() -> Int {
         n => if n < 0 { 0 } else { n }
       }
     None => 2
+  }
+}
+
+///|
+/// Limit decoded packed-object cache memory. The cache is bounded by decoded
+/// object bytes rather than entry count because a single large blob should not
+/// crowd out many small delta bases.
+fn decoded_cache_limit_from_env() -> Int {
+  match @bitio.env_get("BIT_DECODED_OBJECT_CACHE_LIMIT") {
+    Some(v) =>
+      try object_db_parse_int(v) catch {
+        _ => 4 * 1024 * 1024
+      } noraise {
+        n => if n < 0 { 0 } else { n }
+      }
+    None => 4 * 1024 * 1024
   }
 }
 
@@ -299,6 +319,79 @@ fn evict_pack_cache(db : ObjectDb) -> Unit {
     let evict = db.pack_cache_order.remove(0)
     db.pack_cache.remove(evict)
   }
+}
+
+///|
+/// Key an object by its immutable pack location, rather than object ID. This
+/// lets OFS_DELTA bases be shared directly by all children that reference them.
+fn decoded_cache_key(pack_path : String, offset : Int64) -> String {
+  pack_path + "\u0000" + offset.to_string()
+}
+
+///|
+fn decoded_cache_entry_size(obj : @bit.PackObject) -> Int {
+  obj.data.length() + 128
+}
+
+///|
+fn touch_decoded_cache(db : ObjectDb, key : String) -> Unit {
+  if db.decoded_cache_order.search(key) is Some(idx) {
+    ignore(db.decoded_cache_order.remove(idx))
+  }
+  db.decoded_cache_order.push(key)
+}
+
+///|
+fn evict_decoded_cache(db : ObjectDb) -> Unit {
+  while db.decoded_cache_bytes > db.decoded_cache_limit &&
+        db.decoded_cache_order.length() > 0 {
+    let evict = db.decoded_cache_order.remove(0)
+    match db.decoded_cache.get(evict) {
+      Some(obj) => {
+        db.decoded_cache_bytes -= decoded_cache_entry_size(obj)
+        db.decoded_cache.remove(evict)
+      }
+      None => ()
+    }
+  }
+}
+
+///|
+fn get_decoded_cache(
+  db : ObjectDb,
+  pack_path : String,
+  offset : Int64,
+) -> @bit.PackObject? {
+  let key = decoded_cache_key(pack_path, offset)
+  match db.decoded_cache.get(key) {
+    Some(obj) => {
+      touch_decoded_cache(db, key)
+      Some(obj)
+    }
+    None => None
+  }
+}
+
+///|
+fn put_decoded_cache(
+  db : ObjectDb,
+  pack_path : String,
+  offset : Int64,
+  obj : @bit.PackObject,
+) -> Unit {
+  if db.decoded_cache_limit <= 0 {
+    return
+  }
+  let key = decoded_cache_key(pack_path, offset)
+  match db.decoded_cache.get(key) {
+    Some(previous) =>
+      db.decoded_cache_bytes -= decoded_cache_entry_size(previous)
+    None => ()
+  }
+  db.decoded_cache[key] = obj
+  db.decoded_cache_bytes += decoded_cache_entry_size(obj)
+  touch_decoded_cache(db, key)
+  evict_decoded_cache(db)
 }
 
 ///|
@@ -351,6 +444,7 @@ pub fn ObjectDb::load_from_objects_dir(
     []
   }
   let pack_cache_limit = pack_cache_limit_from_env()
+  let decoded_cache_limit = decoded_cache_limit_from_env()
   {
     objects_dir,
     loose_paths,
@@ -359,6 +453,10 @@ pub fn ObjectDb::load_from_objects_dir(
     pack_cache: Map([]),
     pack_cache_order: [],
     pack_cache_limit,
+    decoded_cache: Map([]),
+    decoded_cache_order: [],
+    decoded_cache_bytes: 0,
+    decoded_cache_limit,
     prefer_packed: false,
     saw_corrupt_pack: false,
     skip_verify: false,
@@ -397,6 +495,7 @@ pub fn ObjectDb::load_lazy_from_objects_dir(
     []
   }
   let pack_cache_limit = pack_cache_limit_from_env()
+  let decoded_cache_limit = decoded_cache_limit_from_env()
   {
     objects_dir,
     loose_paths: Map([]),
@@ -405,6 +504,10 @@ pub fn ObjectDb::load_lazy_from_objects_dir(
     pack_cache: Map([]),
     pack_cache_order: [],
     pack_cache_limit,
+    decoded_cache: Map([]),
+    decoded_cache_order: [],
+    decoded_cache_bytes: 0,
+    decoded_cache_limit,
     prefer_packed: false,
     saw_corrupt_pack: false,
     skip_verify: false,
@@ -698,6 +801,26 @@ fn get_pack_bytes(
 }
 
 ///|
+/// Return a decoded packed object from the location cache when possible.
+/// Looking here, before reading the pack bytes, also makes repeated top-level
+/// ObjectDb::get calls avoid the pack-file cache entirely.
+fn get_cached_or_read_pack_object(
+  db : ObjectDb,
+  fs : &@bit.RepoFileSystem,
+  pack : PackIndex,
+  offset : Int64,
+  seen : Map[String, Bool],
+) -> @bit.PackObject raise @bit.GitError {
+  match get_decoded_cache(db, pack.pack_path, offset) {
+    Some(obj) => obj
+    None => {
+      let data = get_pack_bytes(db, fs, pack.pack_path)
+      read_pack_object_at(data, pack, offset, db, fs, seen)
+    }
+  }
+}
+
+///|
 fn get_from_packs(
   db : ObjectDb,
   fs : &@bit.RepoFileSystem,
@@ -711,8 +834,7 @@ fn get_from_packs(
       None => ()
       Some(offset) =>
         try {
-          let data = get_pack_bytes(db, fs, pack.pack_path)
-          let obj = read_pack_object_at(data, pack, offset, db, fs, seen)
+          let obj = get_cached_or_read_pack_object(db, fs, pack, offset, seen)
           if !db.skip_verify {
             let computed = obj.id.to_hex()
             if computed != hex {
@@ -736,8 +858,7 @@ fn get_from_packs(
         None => ()
         Some(offset) => {
           let pack = lazy_pack.get(fs) // ensure loaded
-          let data = get_pack_bytes(db, fs, pack.pack_path)
-          let obj = read_pack_object_at(data, pack, offset, db, fs, seen)
+          let obj = get_cached_or_read_pack_object(db, fs, pack, offset, seen)
           if !db.skip_verify {
             let computed = obj.id.to_hex()
             if computed != hex {
@@ -1223,6 +1344,10 @@ fn read_pack_object_at(
   fs : &@bit.RepoFileSystem,
   seen : Map[String, Bool],
 ) -> @bit.PackObject raise @bit.GitError {
+  match get_decoded_cache(db, pack.pack_path, offset) {
+    Some(obj) => return obj
+    None => ()
+  }
   let offset_i = offset_to_int(offset)
   let (type_id, size, next_offset) = @pack.decode_type_and_size_at(
     data, offset_i,
@@ -1230,7 +1355,7 @@ fn read_pack_object_at(
   if size < 0 || size > MAX_LOOSE_OBJECT_SIZE {
     raise @bit.GitError::PackfileError("Pack object size out of range: \{size}")
   }
-  match type_id {
+  let obj = match type_id {
     1 | 2 | 3 | 4 => {
       let obj_type = @pack.packfile_type_to_object_type(type_id)
       let (content, _after) = @zlib.zlib_decompress_at(
@@ -1334,6 +1459,8 @@ fn read_pack_object_at(
         "Unknown packfile object type: \{type_id}",
       )
   }
+  put_decoded_cache(db, pack.pack_path, offset, obj)
+  obj
 }
 
 ///|

--- a/modules/bit_lib/src/object_db_cache_test.mbt
+++ b/modules/bit_lib/src/object_db_cache_test.mbt
@@ -1,0 +1,84 @@
+///|
+test "object-db: reuses a decoded packed object without rereading its pack" {
+  let fs = @bit.TestFs::new()
+  ignore(init_repo(fs, "/repo")) catch {
+    _ => ()
+  }
+  let obj = @bit.PackObject::new(
+    @bit.ObjectType::Blob,
+    Bytes::from_array([b'c', b'a', b'c', b'h', b'e']),
+  )
+  let (pack, _) = @pack.create_packfile_with_delta_stats_compression_reuse(
+    [obj],
+    @bit.PackDeltaMode::NoDelta,
+    @bit.PackCompression::Default,
+    false,
+    0,
+    1,
+  )
+  let packed_objects = @pack.parse_packfile(pack)
+  let pack_base = "/repo/.git/objects/pack/pack-cache-test"
+  let pack_path = pack_base + ".pack"
+  fs.mkdir_p("/repo/.git/objects/pack")
+  fs.write_file(pack_path, pack)
+  @pack.write_pack_index_from_objects(
+    fs,
+    pack_base + ".idx",
+    pack,
+    packed_objects,
+  )
+
+  let db = ObjectDb::load(fs, "/repo/.git")
+  let id = packed_objects[0].id
+  assert_true(db.get(fs, id) is Some(_))
+  db.pack_cache.clear()
+  fs.remove_file(pack_path)
+
+  assert_true(db.get(fs, id) is Some(_))
+}
+
+///|
+test "object-db: caches a decoded delta base by pack location" {
+  let fs = @bit.TestFs::new()
+  ignore(init_repo(fs, "/repo")) catch {
+    _ => ()
+  }
+  let base = Bytes::from_array(FixedArray::makei(1024, fn(_) { b'a' }))
+  let child = Bytes::from_array(
+    FixedArray::makei(1024, fn(i) { if i == 1023 { b'b' } else { b'a' } }),
+  )
+  let (pack, _) = @pack.create_packfile_with_delta_stats_compression_reuse(
+    [
+      @bit.PackObject::new(@bit.ObjectType::Blob, base),
+      @bit.PackObject::new(@bit.ObjectType::Blob, child),
+    ],
+    @bit.PackDeltaMode::OfsDelta,
+    @bit.PackCompression::Default,
+    false,
+    10,
+    2,
+  )
+  let packed_objects = @pack.parse_packfile(pack)
+  let mut delta_id : @bit.ObjectId? = None
+  for obj in packed_objects {
+    let (type_id, _, _) = @pack.decode_type_and_size_at(pack, obj.offset)
+    if type_id == 6 || type_id == 7 {
+      delta_id = Some(obj.id)
+    }
+  }
+  guard delta_id is Some(id) else { fail("expected a delta entry") }
+
+  let pack_base = "/repo/.git/objects/pack/pack-delta-cache-test"
+  fs.mkdir_p("/repo/.git/objects/pack")
+  fs.write_file(pack_base + ".pack", pack)
+  @pack.write_pack_index_from_objects(
+    fs,
+    pack_base + ".idx",
+    pack,
+    packed_objects,
+  )
+  let db = ObjectDb::load(fs, "/repo/.git")
+
+  assert_true(db.get(fs, id) is Some(_))
+  assert_true(db.decoded_cache.length() >= 2)
+}

--- a/modules/bit_lib/src/pack_collect.mbt
+++ b/modules/bit_lib/src/pack_collect.mbt
@@ -225,6 +225,64 @@ pub fn collect_reachable_objects_from_commits(
 }
 
 ///|
+/// Collect objects reachable from `commits`, stopping before any commit in
+/// `excluded_commits`. This models upload-pack negotiation: a client's have
+/// commits delimit the history it already owns, so their trees and ancestors
+/// do not need a separate reachability walk.
+pub fn collect_reachable_objects_excluding_commits(
+  db : ObjectDb,
+  fs : &@bit.RepoFileSystem,
+  commits : Array[@bit.ObjectId],
+  excluded_commits : Array[@bit.ObjectId],
+) -> Array[@bit.PackObject] raise @bit.GitError {
+  let excluded : Map[String, Bool] = Map([])
+  for id in excluded_commits {
+    excluded[id.to_hex()] = true
+  }
+  let seen : Map[String, Bool] = Map([])
+  let out : Array[@bit.PackObject] = []
+  for commit_id in commits {
+    collect_commit_objects_until_excluded(
+      db, fs, commit_id, excluded, seen, out,
+    )
+  }
+  out
+}
+
+///|
+fn collect_commit_objects_until_excluded(
+  db : ObjectDb,
+  fs : &@bit.RepoFileSystem,
+  commit_id : @bit.ObjectId,
+  excluded : Map[String, Bool],
+  seen : Map[String, Bool],
+  out : Array[@bit.PackObject],
+) -> Unit raise @bit.GitError {
+  let hex = commit_id.to_hex()
+  if excluded.contains(hex) || seen.contains(hex) {
+    return
+  }
+  seen[hex] = true
+  let obj = db.get(fs, commit_id)
+  match obj {
+    None => raise @bit.GitError::InvalidObject("Missing commit object")
+    Some(o) => {
+      if o.obj_type != @bit.ObjectType::Commit {
+        raise @bit.GitError::InvalidObject("Object is not a commit")
+      }
+      out.push(o)
+      let info = @bit.parse_commit(o.data)
+      collect_tree_objects(db, fs, info.tree, seen, out)
+      for parent in info.parents {
+        collect_commit_objects_until_excluded(
+          db, fs, parent, excluded, seen, out,
+        )
+      }
+    }
+  }
+}
+
+///|
 fn collect_commit_objects(
   db : ObjectDb,
   fs : &@bit.RepoFileSystem,

--- a/modules/bit_lib/src/pack_collect_test.mbt
+++ b/modules/bit_lib/src/pack_collect_test.mbt
@@ -350,3 +350,32 @@ test "collect_reachable_objects_from_commits: deduplicates" {
   }
   assert_eq(shared_count, 1)
 }
+
+///|
+test "collect_reachable_objects_excluding_commits: stops at have commits" {
+  let fs = @bit.TestFs::new()
+  init_repo(fs, "/repo") catch {
+    _ => ()
+  }
+  fs.write_file("/repo/shared.txt", b"shared")
+  let base = commit(fs, fs, "/repo", "base", "test <test@test.com>", 1000L) catch {
+    _ => return ()
+  }
+  fs.write_file("/repo/new.txt", b"new")
+  let tip = commit(fs, fs, "/repo", "tip", "test <test@test.com>", 2000L) catch {
+    _ => return ()
+  }
+  let db = ObjectDb::load(fs, "/repo/.git") catch { _ => return () }
+
+  let objects = collect_reachable_objects_excluding_commits(db, fs, [tip], [
+    base,
+  ]) catch {
+    _ => return ()
+  }
+  let ids : Map[String, Bool] = Map([])
+  for obj in objects {
+    ids[obj.id.to_hex()] = true
+  }
+  assert_true(ids.contains(tip.to_hex()))
+  assert_true(!ids.contains(base.to_hex()))
+}

--- a/modules/bit_lib/src/pkg.generated.mbti
+++ b/modules/bit_lib/src/pkg.generated.mbti
@@ -61,6 +61,8 @@ pub fn collect_packed_ref_ids(&@bit_types.RepoFileSystem, String, Map[String, @b
 
 pub fn collect_reachable_objects(ObjectDb, &@bit_types.RepoFileSystem, @bit_object.ObjectId) -> Array[@bit_object.PackObject] raise @bit_object.GitError
 
+pub fn collect_reachable_objects_excluding_commits(ObjectDb, &@bit_types.RepoFileSystem, Array[@bit_object.ObjectId], Array[@bit_object.ObjectId]) -> Array[@bit_object.PackObject] raise @bit_object.GitError
+
 pub fn collect_reachable_objects_from_commits(ObjectDb, &@bit_types.RepoFileSystem, Array[@bit_object.ObjectId]) -> Array[@bit_object.PackObject] raise @bit_object.GitError
 
 pub fn collect_tree_blobs(ObjectDb, &@bit_types.RepoFileSystem, @bit_object.ObjectId) -> Array[@bit_object.ObjectId] raise @bit_object.GitError
@@ -953,6 +955,10 @@ pub struct ObjectDb {
   pack_cache : Map[String, Bytes]
   pack_cache_order : Array[String]
   pack_cache_limit : Int
+  decoded_cache : Map[String, @bit_object.PackObject]
+  decoded_cache_order : Array[String]
+  mut decoded_cache_bytes : Int
+  decoded_cache_limit : Int
   mut prefer_packed : Bool
   mut saw_corrupt_pack : Bool
   mut skip_verify : Bool

--- a/modules/bit_lib/src/upload_pack.mbt
+++ b/modules/bit_lib/src/upload_pack.mbt
@@ -410,28 +410,13 @@ pub fn upload_pack(
   // Collect objects reachable from wants
   let include_pack_objects_died = req.shallow.length() == 0 &&
     req.deepen is None
-  let objects = collect_reachable_objects_from_commits(db, fs, req.wants) catch {
+  let objects = collect_upload_pack_objects(db, fs, req.wants, req.haves) catch {
     err =>
       raise @bit.GitError::ProtocolError(
         upload_pack_error_message(err, include_pack_objects_died),
       )
   }
 
-  // If client has some objects, filter them out
-  if req.haves.length() > 0 {
-    let have_set : Map[String, Bool] = Map([])
-    let have_objects = collect_reachable_objects_from_commits(db, fs, req.haves)
-    for obj in have_objects {
-      have_set[obj.id.to_hex()] = true
-    }
-    let filtered : Array[@bit.PackObject] = []
-    for obj in objects {
-      if !have_set.contains(obj.id.to_hex()) {
-        filtered.push(obj)
-      }
-    }
-    return build_upload_pack_response(filtered, use_side_band, ack_ids)
-  }
   build_upload_pack_response(objects, use_side_band, ack_ids)
 }
 
@@ -469,11 +454,7 @@ fn build_upload_pack_response(
   }
   // NAK (no common commits)
   upload_push_bytes(out, @protocol.pktline_encode("NAK\n"))
-  // Create packfile
-  let pack = @pack.create_packfile_with_delta(
-    objects,
-    @bit.PackDeltaMode::NoDelta,
-  )
+  let pack = build_upload_packfile(objects)
   if use_side_band {
     // Send packfile via side-band-64k (band 1)
     let chunk_size = 65515 // 65520 - 4 (pkt-line header) - 1 (band byte)
@@ -505,6 +486,22 @@ fn build_upload_pack_response(
     }
   }
   Bytes::from_array(FixedArray::makei(out.length(), i => out[i]))
+}
+
+///|
+/// Build transfer packs with the same bounded OFS-delta search used by
+/// pack-objects. It reduces bytes-on-wire and the receiver's index-pack work
+/// without allowing unbounded delta chains.
+fn build_upload_packfile(objects : Array[@bit.PackObject]) -> Bytes {
+  let (pack, _) = @pack.create_packfile_with_delta_stats_compression_reuse(
+    objects,
+    @bit.PackDeltaMode::OfsDelta,
+    @bit.PackCompression::Default,
+    false,
+    50,
+    10,
+  )
+  pack
 }
 
 ///|
@@ -541,6 +538,22 @@ fn collect_have_acks_v2(
     }
   }
   out
+}
+
+///|
+/// Walk wants once, using the client's have commits as traversal boundaries.
+/// This avoids materializing and hashing the complete have-side object set.
+fn collect_upload_pack_objects(
+  db : ObjectDb,
+  fs : &@bit.RepoFileSystem,
+  wants : Array[@bit.ObjectId],
+  haves : Array[@bit.ObjectId],
+) -> Array[@bit.PackObject] raise @bit.GitError {
+  if haves.length() == 0 {
+    collect_reachable_objects_from_commits(db, fs, wants)
+  } else {
+    collect_reachable_objects_excluding_commits(db, fs, wants, haves)
+  }
 }
 
 ///|
@@ -760,7 +773,7 @@ pub fn upload_pack_v2(
   }
 
   // Collect objects reachable from wants
-  let objects = collect_reachable_objects_from_commits(db, fs, wants) catch {
+  let objects = collect_upload_pack_objects(db, fs, wants, req.haves) catch {
     err =>
       raise @bit.GitError::ProtocolError(upload_pack_error_message(err, true))
   }
@@ -770,25 +783,7 @@ pub fn upload_pack_v2(
     Some(f) => parse_filter_spec(f)
     None => @protocol.FilterSpec::NoFilter
   }
-  let objects = apply_filter_spec(objects, filter_spec)
-
-  // If client has some objects, filter them out
-  let filtered_objects = if req.haves.length() > 0 {
-    let have_set : Map[String, Bool] = Map([])
-    let have_objects = collect_reachable_objects_from_commits(db, fs, req.haves)
-    for obj in have_objects {
-      have_set[obj.id.to_hex()] = true
-    }
-    let filtered : Array[@bit.PackObject] = []
-    for obj in objects {
-      if !have_set.contains(obj.id.to_hex()) {
-        filtered.push(obj)
-      }
-    }
-    filtered
-  } else {
-    objects
-  }
+  let filtered_objects = apply_filter_spec(objects, filter_spec)
 
   // Build v2 response
   build_upload_pack_response_v2(filtered_objects, ack_ids, wanted_refs)
@@ -921,11 +916,7 @@ fn build_upload_pack_response_v2(
   // Send packfile-section header
   upload_push_bytes(out, @protocol.pktline_encode("packfile\n"))
 
-  // Create packfile
-  let pack = @pack.create_packfile_with_delta(
-    objects,
-    @bit.PackDeltaMode::NoDelta,
-  )
+  let pack = build_upload_packfile(objects)
 
   // Send packfile via side-band-64k (band 1)
   let chunk_size = 65515 // 65520 - 4 (pkt-line header) - 1 (band byte)

--- a/modules/bit_lib/src/upload_pack_wbtest.mbt
+++ b/modules/bit_lib/src/upload_pack_wbtest.mbt
@@ -1,0 +1,69 @@
+///|
+test "upload-pack: generated pack uses OFS deltas" {
+  let base = Bytes::from_array(FixedArray::makei(1024, fn(_) { b'a' }))
+  let child = Bytes::from_array(
+    FixedArray::makei(1024, fn(i) { if i == 1023 { b'b' } else { b'a' } }),
+  )
+  let pack = build_upload_packfile([
+    @bit.PackObject::new(@bit.ObjectType::Blob, base),
+    @bit.PackObject::new(@bit.ObjectType::Blob, child),
+  ])
+  let objects = @pack.parse_packfile(pack)
+  let mut found_delta = false
+  for obj in objects {
+    let (type_id, _, _) = @pack.decode_type_and_size_at(pack, obj.offset)
+    if type_id == 6 || type_id == 7 {
+      found_delta = true
+    }
+  }
+  assert_true(found_delta)
+}
+
+///|
+test "upload-pack: have commit excludes its history from the pack" {
+  let fs = @bit.TestFs::new()
+  ignore(init_repo(fs, "/repo")) catch {
+    _ => ()
+  }
+  fs.write_string("/repo/base.txt", "base\n")
+  add_paths(fs, fs, "/repo", ["base.txt"])
+  let base = commit(
+    fs, fs, "/repo", "base\n", "Test <t@example.com>", 1700000000L,
+  )
+  fs.write_string("/repo/tip.txt", "tip\n")
+  add_paths(fs, fs, "/repo", ["tip.txt"])
+  let tip = commit(
+    fs, fs, "/repo", "tip\n", "Test <t@example.com>", 1700000001L,
+  )
+  let response = upload_pack(fs, "/repo", {
+    wants: [tip],
+    haves: [base],
+    capabilities: [],
+    done: true,
+    shallow: [],
+    deepen: None,
+  })
+  let mut pack_start = -1
+  for i in 0..<(response.length() - 3) {
+    if response[i] == b'P' &&
+      response[i + 1] == b'A' &&
+      response[i + 2] == b'C' &&
+      response[i + 3] == b'K' {
+      pack_start = i
+      break
+    }
+  }
+  assert_true(pack_start >= 0)
+  let pack = Bytes::from_array(
+    FixedArray::makei(response.length() - pack_start, fn(i) {
+      response[pack_start + i]
+    }),
+  )
+  let packed_objects = @pack.parse_packfile(pack)
+  let ids : Map[String, Bool] = Map([])
+  for obj in packed_objects {
+    ids[obj.id.to_hex()] = true
+  }
+  assert_true(ids.contains(tip.to_hex()))
+  assert_true(!ids.contains(base.to_hex()))
+}

--- a/modules/bit_object/src/hasher.mbt
+++ b/modules/bit_object/src/hasher.mbt
@@ -98,11 +98,17 @@ pub fn hash_object_content_with_algo(
   obj_type : ObjectType,
   content : Bytes,
 ) -> ObjectId {
-  let state = HashState::new(algo)
   let header = "\{obj_type.to_string()} \{content.length()}\u0000"
-  state.update_string(header)
-  state.update(content)
-  state.finish()
+  match algo {
+    Sha1 =>
+      ObjectId::new(@hash.sha1_prefixed_raw(@utf8.encode(header), content))
+    Sha256 => {
+      let state = HashState::new(Sha256)
+      state.update_string(header)
+      state.update(content)
+      state.finish()
+    }
+  }
 }
 
 ///|

--- a/modules/bit_object/src/object.mbt
+++ b/modules/bit_object/src/object.mbt
@@ -132,11 +132,7 @@ pub fn create_object(
 ///|
 /// Hash object content (without compression) - optimized with incremental SHA1
 pub fn hash_object_content(obj_type : ObjectType, content : Bytes) -> ObjectId {
-  let state = Sha1State::new()
-  let header = "\{obj_type.to_string()} \{content.length()}\u0000"
-  state.update_string(header)
-  state.update(content)
-  state.finish()
+  hash_object_content_with_algo(Sha1, obj_type, content)
 }
 
 ///|

--- a/modules/bit_pack/src/delta_copy.mbt
+++ b/modules/bit_pack/src/delta_copy.mbt
@@ -1,0 +1,43 @@
+///| Copy one validated delta span into its output buffer.
+
+///|
+/// `apply_delta` checks all offsets and sizes before reaching this helper.
+/// Native builds use libc's tuned bulk copy; JavaScript and Wasm preserve the
+/// portable element-wise fallback.
+#cfg(target="native")
+#borrow(source, destination)
+extern "C" fn copy_delta_bytes_ffi(
+  source : Bytes,
+  source_offset : Int,
+  destination : FixedArray[Byte],
+  destination_offset : Int,
+  length : Int,
+) -> Unit = "bit_pack_copy_delta_bytes"
+
+///|
+#cfg(target="native")
+fn copy_delta_bytes(
+  source : Bytes,
+  source_offset : Int,
+  destination : FixedArray[Byte],
+  destination_offset : Int,
+  length : Int,
+) -> Unit {
+  copy_delta_bytes_ffi(
+    source, source_offset, destination, destination_offset, length,
+  )
+}
+
+///|
+#cfg(not(target="native"))
+fn copy_delta_bytes(
+  source : Bytes,
+  source_offset : Int,
+  destination : FixedArray[Byte],
+  destination_offset : Int,
+  length : Int,
+) -> Unit {
+  for i in 0..<length {
+    destination[destination_offset + i] = source[source_offset + i]
+  }
+}

--- a/modules/bit_pack/src/delta_copy_native.c
+++ b/modules/bit_pack/src/delta_copy_native.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <string.h>
+
+#ifndef MOONBIT_FFI_EXPORT
+#define MOONBIT_FFI_EXPORT __attribute__((visibility("default")))
+#endif
+
+/* Bounds are checked by apply_delta before this helper is called. */
+MOONBIT_FFI_EXPORT void bit_pack_copy_delta_bytes(
+    const uint8_t *source, int source_offset, uint8_t *destination,
+    int destination_offset, int length) {
+  if (length > 0) {
+    memcpy(destination + destination_offset, source + source_offset,
+           (size_t)length);
+  }
+}

--- a/modules/bit_pack/src/moon.pkg
+++ b/modules/bit_pack/src/moon.pkg
@@ -30,6 +30,7 @@ import {
 warnings = "-29"
 
 options(
+  "native-stub": [ "delta_copy_native.c" ],
   targets: {
     "bench_profile_test.mbt": [ "native" ],
     "bench_test.mbt": [ "native" ],

--- a/modules/bit_pack/src/packfile.mbt
+++ b/modules/bit_pack/src/packfile.mbt
@@ -9,6 +9,73 @@ fn pack_array_to_bytes(arr : Array[Byte]) -> Bytes {
 }
 
 ///|
+let pack_writer_crc32_poly : UInt = (Int::reinterpret_as_uint(237) << 24) |
+  (Int::reinterpret_as_uint(184) << 16) |
+  (Int::reinterpret_as_uint(131) << 8) |
+  Int::reinterpret_as_uint(32)
+
+///|
+let pack_writer_crc32_table : FixedArray[UInt] = FixedArray::makei(256, fn(i) {
+  let mut c = i.reinterpret_as_uint()
+  for _ in 0..<8 {
+    if (c & Int::reinterpret_as_uint(1)) == Int::reinterpret_as_uint(1) {
+      c = (c >> 1) ^ pack_writer_crc32_poly
+    } else {
+      c = c >> 1
+    }
+  }
+  c
+})
+
+///|
+/// Compute an entry CRC directly from the bytes just written to a pack.
+fn pack_writer_crc32_range(data : Array[Byte], start : Int, end : Int) -> UInt {
+  let mut crc : UInt = Int::reinterpret_as_uint(-1)
+  for i = start; i < end; i = i + 1 {
+    let index = UInt::reinterpret_as_int(
+      (crc ^ Int::reinterpret_as_uint(data[i].to_int())) &
+      Int::reinterpret_as_uint(255),
+    )
+    crc = (crc >> 8) ^ pack_writer_crc32_table[index]
+  }
+  crc ^ Int::reinterpret_as_uint(-1)
+}
+
+///|
+/// Return the object ID appropriate for the pack's hash algorithm.
+fn pack_writer_object_id(
+  obj : @bit.PackObject,
+  hash_size : Int,
+) -> @bit.ObjectId {
+  if obj.id.bytes.length() == hash_size {
+    obj.id
+  } else {
+    @bit.hash_object_content_with_algo(
+      hash_algo_from_size(hash_size),
+      obj.obj_type,
+      obj.data,
+    )
+  }
+}
+
+///|
+/// Preserve the original object content together with index metadata.
+fn pack_writer_metadata(
+  obj : @bit.PackObject,
+  offset : Int,
+  crc32 : UInt,
+  hash_size : Int,
+) -> @bit.PackObject {
+  @bit.PackObject::with_metadata(
+    obj.obj_type,
+    obj.data,
+    pack_writer_object_id(obj, hash_size),
+    offset,
+    crc32,
+  )
+}
+
+///|
 /// Compress pack data. Use stored when compression expands data.
 fn compress_pack_data(
   data : Bytes,
@@ -824,18 +891,50 @@ pub fn create_packfiles_with_size_limit(
   window : Int,
   hash_size? : Int = 20,
 ) -> (Array[Bytes], Int) {
+  let (pack_entries, delta_count) = create_packfiles_with_size_limit_and_metadata(
+    objects,
+    delta_mode,
+    compression,
+    reuse_only,
+    max_depth,
+    size_limit,
+    window,
+    hash_size~,
+  )
   let packs : Array[Bytes] = []
+  for entry in pack_entries {
+    packs.push(entry.0)
+  }
+  (packs, delta_count)
+}
+
+///|
+/// Create size-limited packfiles and retain index metadata for every entry.
+pub fn create_packfiles_with_size_limit_and_metadata(
+  objects : Array[@bit.PackObject],
+  delta_mode : @bit.PackDeltaMode,
+  compression : @bit.PackCompression,
+  reuse_only : Bool,
+  max_depth : Int,
+  size_limit : Int64,
+  window : Int,
+  hash_size? : Int = 20,
+) -> (Array[(Bytes, Array[@bit.PackObject])], Int) {
+  let packs : Array[(Bytes, Array[@bit.PackObject])] = []
   let mut total_delta_count = 0
   if objects.length() == 0 {
     packs.push(
-      finalize_pack(
-        {
-          let r : Array[Byte] = []
-          write_pack_header(r)
-          r
-        },
-        0,
-        hash_size~,
+      (
+        finalize_pack(
+          {
+            let r : Array[Byte] = []
+            write_pack_header(r)
+            r
+          },
+          0,
+          hash_size~,
+        ),
+        [],
       ),
     )
     return (packs, 0)
@@ -846,6 +945,7 @@ pub fn create_packfiles_with_size_limit(
   write_pack_header(result)
   let mut offset = 12
   let mut nr_written = 0
+  let mut written_objects : Array[@bit.PackObject] = []
   let window_by_type : Map[Int, Array[DeltaWindowEntry]] = Map([])
   for obj in objects {
     let key = obj.obj_type.to_packfile_type()
@@ -920,12 +1020,15 @@ pub fn create_packfiles_with_size_limit(
     if nr_written >= 1 &&
       (offset + written + hash_size).to_int64() >= size_limit {
       // Finalize current pack
-      packs.push(finalize_pack(result, nr_written, hash_size~))
+      packs.push(
+        (finalize_pack(result, nr_written, hash_size~), written_objects),
+      )
       // Start a new pack
       result = []
       write_pack_header(result)
       offset = 12
       nr_written = 0
+      written_objects = []
       window_by_type.clear()
       // Re-write the object without delta (base is in previous pack)
       let (written2, _) = pack_object_with_delta(
@@ -939,6 +1042,14 @@ pub fn create_packfiles_with_size_limit(
         hash_size~,
       )
       offset = 12 + written2
+      written_objects.push(
+        pack_writer_metadata(
+          obj,
+          12,
+          pack_writer_crc32_range(result, 12, offset),
+          hash_size,
+        ),
+      )
       let new_entries : Array[DeltaWindowEntry] = []
       new_entries.push({ offset: 12, obj, depth: 0, block_index: None })
       window_by_type[key] = new_entries
@@ -956,13 +1067,21 @@ pub fn create_packfiles_with_size_limit(
       if entries.length() > window_size {
         ignore(entries.remove(0))
       }
+      written_objects.push(
+        pack_writer_metadata(
+          obj,
+          offset,
+          pack_writer_crc32_range(temp, 0, written),
+          hash_size,
+        ),
+      )
       offset += written
       nr_written += 1
     }
   }
   // Finalize last pack
   if nr_written > 0 {
-    packs.push(finalize_pack(result, nr_written, hash_size~))
+    packs.push((finalize_pack(result, nr_written, hash_size~), written_objects))
   }
   (packs, total_delta_count)
 }
@@ -978,6 +1097,29 @@ pub fn create_packfile_with_delta_stats_compression_reuse(
   window : Int,
   hash_size? : Int = 20,
 ) -> (Bytes, Int) {
+  let (pack, delta_count, _) = create_packfile_with_delta_stats_compression_reuse_and_metadata(
+    objects,
+    delta_mode,
+    compression,
+    reuse_only,
+    max_depth,
+    window,
+    hash_size~,
+  )
+  (pack, delta_count)
+}
+
+///|
+/// Create a packfile and retain the index metadata collected while writing.
+pub fn create_packfile_with_delta_stats_compression_reuse_and_metadata(
+  objects : Array[@bit.PackObject],
+  delta_mode : @bit.PackDeltaMode,
+  compression : @bit.PackCompression,
+  reuse_only : Bool,
+  max_depth : Int,
+  window : Int,
+  hash_size? : Int = 20,
+) -> (Bytes, Int, Array[@bit.PackObject]) {
   let result : Array[Byte] = []
 
   // Magic: "PACK"
@@ -1016,6 +1158,7 @@ pub fn create_packfile_with_delta_stats_compression_reuse(
   let mut offset = 12
   let window_by_type : Map[Int, Array[DeltaWindowEntry]] = Map([])
   let mut delta_count = 0
+  let written_objects : Array[@bit.PackObject] = []
   for obj in sorted {
     let obj_offset = offset
     let key = obj.obj_type.to_packfile_type()
@@ -1084,7 +1227,16 @@ pub fn create_packfile_with_delta_stats_compression_reuse(
       precomputed,
       hash_size~,
     )
-    offset = offset + written
+    let packed_end = obj_offset + written
+    written_objects.push(
+      pack_writer_metadata(
+        obj,
+        obj_offset,
+        pack_writer_crc32_range(result, obj_offset, packed_end),
+        hash_size,
+      ),
+    )
+    offset = packed_end
     if used_delta {
       delta_count = delta_count + 1
     }
@@ -1106,7 +1258,7 @@ pub fn create_packfile_with_delta_stats_compression_reuse(
   for b in trailer.bytes {
     result.push(b)
   }
-  (pack_array_to_bytes(result), delta_count)
+  (pack_array_to_bytes(result), delta_count, written_objects)
 }
 
 ///|

--- a/modules/bit_pack/src/packfile_parse.mbt
+++ b/modules/bit_pack/src/packfile_parse.mbt
@@ -1205,10 +1205,8 @@ pub fn apply_delta(base : Bytes, delta : Bytes) -> Bytes raise @bit.GitError {
       if out_pos < 0 || cp_size > result_size - out_pos {
         raise @bit.GitError::PackfileError("Delta copy past result size")
       }
-      for i in 0..<cp_size {
-        out[out_pos] = base[cp_off + i]
-        out_pos += 1
-      }
+      copy_delta_bytes(base, cp_off, out, out_pos, cp_size)
+      out_pos += cp_size
     } else {
       let literal_len = opcode & 0x7f
       if literal_len == 0 {
@@ -1220,10 +1218,8 @@ pub fn apply_delta(base : Bytes, delta : Bytes) -> Bytes raise @bit.GitError {
       if literal_len > result_size - out_pos {
         raise @bit.GitError::PackfileError("Delta literal past result size")
       }
-      for i in 0..<literal_len {
-        out[out_pos] = delta[offset + i]
-        out_pos += 1
-      }
+      copy_delta_bytes(delta, offset, out, out_pos, literal_len)
+      out_pos += literal_len
       offset += literal_len
     }
   }

--- a/modules/bit_pack/src/packfile_test.mbt
+++ b/modules/bit_pack/src/packfile_test.mbt
@@ -87,6 +87,93 @@ test "packfile multiple objects" {
 }
 
 ///|
+test "packfile writer metadata builds the same index without reparsing" {
+  let obj1 = @bit.PackObject::new(
+    @bit.ObjectType::Blob,
+    Bytes::from_array([b'a']),
+  )
+  let obj2 = @bit.PackObject::new(
+    @bit.ObjectType::Blob,
+    Bytes::from_array([b'b']),
+  )
+  let (pack, _, written) = create_packfile_with_delta_stats_compression_reuse_and_metadata(
+    [obj1, obj2],
+    @bit.PackDeltaMode::NoDelta,
+    @bit.PackCompression::Default,
+    false,
+    0,
+    1,
+  )
+
+  assert_true(written.length() == 2)
+  assert_true(written[0].offset >= 12)
+  assert_true(written[1].offset > written[0].offset)
+  assert_true(written[0].crc32 != 0U)
+  let expected = build_pack_index(pack)
+  let actual = build_pack_index_from_objects(pack, written)
+  assert_true(actual.length() == expected.length())
+  for i in 0..<actual.length() {
+    assert_true(actual[i] == expected[i])
+  }
+}
+
+///|
+test "size-limited pack writer metadata builds indexes without reparsing" {
+  let obj1 = @bit.PackObject::new(
+    @bit.ObjectType::Blob,
+    Bytes::from_array([b'a', b'a', b'a', b'a', b'a', b'a', b'a', b'a']),
+  )
+  let obj2 = @bit.PackObject::new(
+    @bit.ObjectType::Blob,
+    Bytes::from_array([b'b', b'b', b'b', b'b', b'b', b'b', b'b', b'b']),
+  )
+  let (entries, _) = create_packfiles_with_size_limit_and_metadata(
+    [obj1, obj2],
+    @bit.PackDeltaMode::NoDelta,
+    @bit.PackCompression::Stored,
+    false,
+    0,
+    40L,
+    1,
+  )
+
+  assert_true(entries.length() == 2)
+  for entry in entries {
+    let expected = build_pack_index(entry.0)
+    let actual = build_pack_index_from_objects(entry.0, entry.1)
+    assert_true(actual.length() == expected.length())
+    for i in 0..<actual.length() {
+      assert_true(actual[i] == expected[i])
+    }
+  }
+}
+
+///|
+test "packfile writer metadata uses the requested SHA-256 object IDs" {
+  let obj = @bit.PackObject::new(
+    @bit.ObjectType::Blob,
+    Bytes::from_array([b's', b'h', b'a', b'2', b'5', b'6']),
+  )
+  let (pack, _, written) = create_packfile_with_delta_stats_compression_reuse_and_metadata(
+    [obj],
+    @bit.PackDeltaMode::NoDelta,
+    @bit.PackCompression::Default,
+    false,
+    0,
+    1,
+    hash_size=32,
+  )
+
+  let expected = build_pack_index(pack, hash_size=32)
+  let actual = build_pack_index_from_objects(pack, written, hash_size=32)
+  assert_true(written[0].id.bytes.length() == 32)
+  assert_true(actual.length() == expected.length())
+  for i in 0..<actual.length() {
+    assert_true(actual[i] == expected[i])
+  }
+}
+
+///|
 test "create commit packfile" {
   let content = Bytes::from_array([b'h', b'e', b'l', b'l', b'o', b'\n'])
   let commit = @bit.Commit::new(

--- a/modules/bit_pack/src/packfile_wbtest.mbt
+++ b/modules/bit_pack/src/packfile_wbtest.mbt
@@ -1,6 +1,20 @@
 ///| Whitebox tests for packfile delta encoding/decoding
 
 ///|
+test "delta copy: copies a byte range" {
+  let source = Bytes::from_array([b'a', b'b', b'c', b'd', b'e'])
+  let out : FixedArray[Byte] = FixedArray::make(5, b'_')
+
+  copy_delta_bytes(source, 1, out, 2, 3)
+
+  assert_true(out[0] == b'_')
+  assert_true(out[1] == b'_')
+  assert_true(out[2] == b'b')
+  assert_true(out[3] == b'c')
+  assert_true(out[4] == b'd')
+}
+
+///|
 test "delta: build and apply roundtrip" {
   let base = @utf8.encode("Hello, World!\n")
   let target = @utf8.encode("Hello, MoonBit!\n")

--- a/modules/bit_pack/src/pkg.generated.mbti
+++ b/modules/bit_pack/src/pkg.generated.mbti
@@ -33,7 +33,11 @@ pub fn create_packfile_with_delta_stats_compression(Array[@bit_object.PackObject
 
 pub fn create_packfile_with_delta_stats_compression_reuse(Array[@bit_object.PackObject], @bit_object.PackDeltaMode, @bit_object.PackCompression, Bool, Int, Int, hash_size? : Int) -> (Bytes, Int)
 
+pub fn create_packfile_with_delta_stats_compression_reuse_and_metadata(Array[@bit_object.PackObject], @bit_object.PackDeltaMode, @bit_object.PackCompression, Bool, Int, Int, hash_size? : Int) -> (Bytes, Int, Array[@bit_object.PackObject])
+
 pub fn create_packfiles_with_size_limit(Array[@bit_object.PackObject], @bit_object.PackDeltaMode, @bit_object.PackCompression, Bool, Int, Int64, Int, hash_size? : Int) -> (Array[Bytes], Int)
+
+pub fn create_packfiles_with_size_limit_and_metadata(Array[@bit_object.PackObject], @bit_object.PackDeltaMode, @bit_object.PackCompression, Bool, Int, Int64, Int, hash_size? : Int) -> (Array[(Bytes, Array[@bit_object.PackObject])], Int)
 
 pub fn decode_type_and_size_at(Bytes, Int) -> (Int, Int, Int) raise @bit_object.GitError
 


### PR DESCRIPTION
## Summary

- Cache pack/object lookups and reduce repeated traversal work in clone and log paths.
- Accelerate native SHA-1 object hashing on Apple Silicon while retaining portable fallbacks.
- Improve pack generation and delta handling, including native bulk copies for delta expansion.
- Add coverage for cache behavior, upload-pack delta generation, hashing, and delta copies.

## Root cause

Clone and pack traversal repeatedly performed avoidable lookup, hashing, and byte-copy work. Native Apple Silicon also fell back to scalar SHA-1 in the object-header hashing path.

## Validation

- moon test -p mizchi/bit_pack --target native --release
- moon test -p mizchi/bit_pack --target js
- moon test -p mizchi/bit_pack --target wasm
- moon fmt
- moon info
- git diff --check
- node tools/check-layers.mjs
- Release build and HTTPS clone profiling/benchmark comparison

compat-random-results/ is intentionally excluded; it is local reproduction data.