### PR TITLE
fix(rebase): fork-point, two-arg form, notes copying, untracked protection, mode-blindness, and stale-worktree bugs

### DIFF
--- a/modules/bit/cmd/bit/checkout.mbt
+++ b/modules/bit/cmd/bit/checkout.mbt
@@ -685,6 +685,10 @@ async fn checkout_with_promisor_retry(
     if @bitlib.is_sparse_checkout_enabled(fs, git_dir) {
       @bitlib.sparse_checkout_reapply(fs, fs, root)
     }
+    @bitlibnative.apply_worktree_modes_from_commit(fs, fs, root, git_dir, id) catch {
+      err if @async.is_cancellation_error(err) => raise err
+      _ => ()
+    }
     return id
   }
   raise @bitcore.GitError::InvalidObject(

--- a/modules/bit/cmd/bit/cherry_pick.mbt
+++ b/modules/bit/cmd/bit/cherry_pick.mbt
@@ -1,6 +1,6 @@
 ///|
 fn cherry_pick_is_supported_noop_arg(arg : String) -> Bool {
-  arg == "--ff"
+  arg == "--3way" || arg == "--ff"
 }
 
 ///|

--- a/modules/bit/cmd/bit/cherry_pick.mbt
+++ b/modules/bit/cmd/bit/cherry_pick.mbt
@@ -1,11 +1,64 @@
 ///|
 fn cherry_pick_is_supported_noop_arg(arg : String) -> Bool {
-  arg == "-3" || arg == "--3way" || arg == "--ff"
+  arg == "--ff"
 }
 
 ///|
 fn cherry_pick_is_positional_arg(arg : String) -> Bool {
   arg == "-" || !arg.has_prefix("-")
+}
+
+///|
+/// Parses git's `-<n>` shorthand (e.g. `-2`, `-3`) used by `git cherry-pick
+/// -<n> <commit>` to mean "the last n commits (first-parent history) ending
+/// at <commit>". Returns None for anything else, including the bare `-`
+/// (handled separately as a positional arg).
+fn cherry_pick_parse_count_arg(arg : String) -> Int? {
+  if !arg.has_prefix("-") || arg.length() < 2 {
+    return None
+  }
+  let rest = String::unsafe_substring(arg, start=1, end=arg.length())
+  for ch in rest {
+    if ch < '0' || ch > '9' {
+      return None
+    }
+  }
+  let n = @string.parse_int(rest) catch { _ => -1 }
+  if n >= 0 {
+    Some(n)
+  } else {
+    None
+  }
+}
+
+///|
+/// Collects the last `n` commits (first-parent history, oldest first) ending
+/// at `target`, for `git cherry-pick -<n> <commit>`.
+fn cherry_pick_collect_last_n_commits(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  target : @bitcore.ObjectId,
+  n : Int,
+) -> Array[@bitcore.ObjectId] raise Error {
+  let db = @bitlib.ObjectDb::load(rfs, git_dir)
+  let commits : Array[@bitcore.ObjectId] = []
+  let mut current : @bitcore.ObjectId? = Some(target)
+  while current is Some(cid) && commits.length() < n {
+    commits.push(cid)
+    current = match db.get(rfs, cid) {
+      Some(obj) if obj.obj_type == @bitcore.ObjectType::Commit => {
+        let info = @bitcore.parse_commit(obj.data)
+        if info.parents.length() > 0 {
+          Some(info.parents[0])
+        } else {
+          None
+        }
+      }
+      _ => None
+    }
+  }
+  commits.rev_in_place()
+  commits
 }
 
 ///|
@@ -60,6 +113,7 @@ async fn handle_cherry_pick(args : Array[String]) -> Unit raise Error {
   let mut signoff = false
   let mut add_cherry_pick_note = false
   let unsupported_args : Array[String] = []
+  let mut pick_count : Int? = None
   // Parse arguments
   let mut commit_spec : String? = None
   for arg in args {
@@ -79,6 +133,8 @@ async fn handle_cherry_pick(args : Array[String]) -> Unit raise Error {
       add_cherry_pick_note = true
     } else if cherry_pick_is_supported_noop_arg(arg) {
       use_threeway = true
+    } else if cherry_pick_parse_count_arg(arg) is Some(n) {
+      pick_count = Some(n)
     } else {
       unsupported_args.push(arg)
     }
@@ -130,7 +186,16 @@ async fn handle_cherry_pick(args : Array[String]) -> Unit raise Error {
     }
   }
   let commit_ids : Array[@bitcore.ObjectId] = []
-  if use_threeway {
+  if pick_count is Some(n) {
+    let replay_commits = cherry_pick_collect_last_n_commits(rfs, git_dir, cid, n)
+    if replay_commits.length() > 0 {
+      for replay_id in replay_commits {
+        commit_ids.push(replay_id)
+      }
+    } else {
+      commit_ids.push(cid)
+    }
+  } else if use_threeway {
     match @bitlib.resolve_head_commit(rfs, git_dir) {
       Some(head_id) =>
         match rev_parse_find_merge_base(rfs, git_dir, head_id, cid) {

--- a/modules/bit/cmd/bit/cherry_pick_wbtest.mbt
+++ b/modules/bit/cmd/bit/cherry_pick_wbtest.mbt
@@ -1,8 +1,16 @@
 ///|
 test "cherry-pick: 3way flags are accepted without fallback" {
-  assert_true(cherry_pick_is_supported_noop_arg("-3"))
   assert_true(cherry_pick_is_supported_noop_arg("--3way"))
   assert_false(cherry_pick_is_supported_noop_arg("--abort"))
+}
+
+///|
+test "cherry-pick: -<n> is parsed as a pick-count, not a noop flag" {
+  assert_eq(cherry_pick_parse_count_arg("-3"), Some(3))
+  assert_eq(cherry_pick_parse_count_arg("-12"), Some(12))
+  assert_eq(cherry_pick_parse_count_arg("-"), None)
+  assert_eq(cherry_pick_parse_count_arg("--abort"), None)
+  assert_false(cherry_pick_is_supported_noop_arg("-3"))
 }
 
 ///|

--- a/modules/bit/cmd/bit/rebase.mbt
+++ b/modules/bit/cmd/bit/rebase.mbt
@@ -461,6 +461,9 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
   let strategy_options : Array[String] = []
   let mut onto : String? = None
   let mut upstream : String? = None
+  // git rebase [<upstream>] [<branch>]: a second positional arg means
+  // "switch to <branch> first, then rebase it onto <upstream>".
+  let mut switch_to_branch : String? = None
   let mut gpg_sign : Bool? = None
   let mut signing_key : String? = None
   let mut i = 0
@@ -658,11 +661,19 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
       _ if arg.has_prefix("--empty=") => i += 1
       // Bare "-" is the "previous branch" revision shorthand, not an option.
       "-" => {
-        upstream = Some(arg)
+        if upstream is None {
+          upstream = Some(arg)
+        } else if switch_to_branch is None {
+          switch_to_branch = Some(arg)
+        }
         i += 1
       }
       _ if !arg.has_prefix("-") => {
-        upstream = Some(arg)
+        if upstream is None {
+          upstream = Some(arg)
+        } else if switch_to_branch is None {
+          switch_to_branch = Some(arg)
+        }
         i += 1
       }
       _ if arg.has_prefix("-") => {
@@ -893,6 +904,13 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
         Some(v) => v.to_lower() == "true"
         None => false
       }
+  }
+  // A second positional arg: switch to it first (like `bit checkout
+  // <branch>`), so the rebase below operates on it as the current HEAD.
+  // Reuses checkout's own worktree-lock / detached-HEAD / dirty-tree rules.
+  match switch_to_branch {
+    Some(target) => handle_checkout([target])
+    None => ()
   }
   // Require a clean worktree/index before starting a new rebase, unless
   // --autostash (or rebase.autoStash) will stash the dirty state for us.

--- a/modules/bit/cmd/bit/rebase.mbt
+++ b/modules/bit/cmd/bit/rebase.mbt
@@ -957,13 +957,21 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
   }
   // Start new rebase
   // Resolve upstream: --root mode doesn't need an upstream argument
+  // fork_point_ref is set only when the upstream was auto-resolved (no
+  // explicit <upstream> given), matching git's rule that --fork-point
+  // detection only kicks in by default in that case.
+  let mut fork_point_ref : String? = None
   let id : @bitcore.ObjectId = if root_mode {
     // Use empty tree OID as a sentinel; actual root handling is in the lib layer
     @bitcore.ObjectId::from_hex("4b825dc642cb6eb9a060e54bf899d15363647a20")
   } else {
     let effective_upstream = match upstream {
       Some(u) => Some(u)
-      None => rebase_resolve_default_upstream(rfs, git_dir)
+      None => {
+        let resolved = rebase_resolve_default_upstream(rfs, git_dir)
+        fork_point_ref = resolved
+        resolved
+      }
     }
     guard effective_upstream is Some(ref_name) else {
       raise @bitcore.GitError::InvalidObject(
@@ -1053,11 +1061,28 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
           @bitlib.rebase_start_with_onto(fs, fs, root, oid, id, force_rebase~),
         )
       }
-      None =>
+      None => {
+        let exclude_from = match fork_point_ref {
+          Some(ref_name) => {
+            let head_id = @bitrepo.rev_parse(fs, git_dir, "HEAD")
+            match head_id {
+              Some(hid) =>
+                match rebase_fork_point(rfs, git_dir, ref_name, hid) {
+                  Some(fp) => fp
+                  None => id
+                }
+              None => id
+            }
+          }
+          None => id
+        }
         (
           id,
-          @bitlib.rebase_start_with_onto(fs, fs, root, id, id, force_rebase~),
+          @bitlib.rebase_start_with_onto(
+            fs, fs, root, id, exclude_from, force_rebase~,
+          ),
         )
+      }
     }
     let signed_id = if should_sign {
       rebase_sign_complete_result(
@@ -1343,6 +1368,71 @@ fn rebase_resolve_default_upstream(
   match branches.get(branch) {
     Some(cfg) if cfg.merges.length() > 0 => Some(cfg.merges[0])
     _ => None
+  }
+}
+
+///|
+/// git merge-base --fork-point semantics: when no explicit <upstream> is
+/// given, `git rebase` doesn't just exclude commits reachable from
+/// @{upstream}'s *current* tip — it walks @{upstream}'s reflog to find where
+/// the current branch actually forked from it, since @{upstream} may have
+/// since moved (e.g. been reset backward). That reflog-derived commit, not
+/// the live tip, is the correct exclusion baseline for "which commits does
+/// this rebase need to replay" — the target to attach onto is still the
+/// live tip.
+///
+/// Algorithm: collect every commit ever recorded in upstream_ref's reflog
+/// (old + new id per entry), keep the ones that are ancestors of `head_id`,
+/// then keep only the "maximal" ones among those — not themselves an
+/// ancestor of another qualifying candidate. If exactly one remains, that's
+/// the fork point; otherwise (none, or an ambiguous multiple) there's no
+/// unique fork point and the caller should fall back to the plain tip.
+fn rebase_fork_point(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  upstream_ref : String,
+  head_id : @bitcore.ObjectId,
+) -> @bitcore.ObjectId? {
+  let entries = @bitlib.read_reflog(rfs, git_dir, upstream_ref) catch {
+    _ => []
+  }
+  if entries.length() == 0 {
+    return None
+  }
+  let seen : Map[String, Bool] = Map([])
+  let candidates : Array[@bitcore.ObjectId] = []
+  for entry in entries {
+    for id in [entry.old_id, entry.new_id] {
+      let hex = id.to_hex()
+      if !seen.contains(hex) {
+        seen[hex] = true
+        candidates.push(id)
+      }
+    }
+  }
+  let qualifying : Array[@bitcore.ObjectId] = []
+  for candidate in candidates {
+    if @bitlib.is_ancestor_of(rfs, git_dir, candidate, head_id) {
+      qualifying.push(candidate)
+    }
+  }
+  let maximal : Array[@bitcore.ObjectId] = []
+  for a in qualifying {
+    let mut dominated = false
+    for b in qualifying {
+      if a != b && @bitlib.is_ancestor_of(rfs, git_dir, a, b) {
+        dominated = true
+        break
+      }
+    }
+    if !dominated {
+      maximal.push(a)
+    }
+  }
+  if maximal.length() == 1 {
+    Some(maximal[0])
+  } else {
+    None
   }
 }
 

--- a/modules/bit/cmd/bit/rebase.mbt
+++ b/modules/bit/cmd/bit/rebase.mbt
@@ -1070,12 +1070,133 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
       wfs, git_dir, should_sign, effective_signing_key, result,
     )
     print_rebase_result_with_commit(result, signed_id, quiet~)
+    if result.status is @bitlib.RebaseStatus::Complete {
+      rebase_copy_notes_after_rewrite(wfs, rfs, git_dir, result.rewritten)
+    }
     // Autostash pop on success
     if autostash_oid is Some(_) &&
       result.status is @bitlib.RebaseStatus::Complete {
       rebase_autostash_pop(wfs, rfs, root)
     }
   }
+}
+
+///|
+/// notes.rewrite.rebase (default true) + notes.rewriteRef: after a
+/// successful rebase, copy each rewritten commit's note (if any) from its
+/// old id to its new id, for every notes ref selected by notes.rewriteRef
+/// (exact ref names, or a "refs/notes/*"-style prefix glob).
+async fn rebase_copy_notes_after_rewrite(
+  wfs : &@bitcore.FileSystem,
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  rewritten : Array[(@bitcore.ObjectId, @bitcore.ObjectId)],
+) -> Unit raise Error {
+  if rewritten.length() == 0 {
+    return
+  }
+  let enabled = match
+    @bitlib.read_config_value(
+      rfs,
+      git_dir + "/config",
+      "notes",
+      "rewrite.rebase",
+    ) {
+    Some(v) => v.to_lower() != "false"
+    None => true
+  }
+  if !enabled {
+    return
+  }
+  let patterns = @bitlib.read_config_values(
+    rfs,
+    git_dir + "/config",
+    "notes",
+    "rewriteRef",
+  )
+  if patterns.length() == 0 {
+    return
+  }
+  let common_git_dir = notes_resolve_common_git_dir(rfs, git_dir)
+  let target_refs = rebase_resolve_notes_rewrite_refs(
+    rfs, common_git_dir, patterns,
+  )
+  for notes_ref in target_refs {
+    for pair in rewritten {
+      let (old_id, new_id) = pair
+      if rebase_note_exists(rfs, git_dir, common_git_dir, notes_ref, old_id.to_hex()) {
+        // force=true: internal rewrite copying (unlike `git notes copy`) is
+        // not asking the user to confirm, and a rebase can deterministically
+        // reproduce the same new commit id it produced last time (e.g. when
+        // replaying the exact same commit onto the exact same base again),
+        // in which case the destination note already legitimately exists.
+        notes_copy(
+          wfs, rfs, git_dir, common_git_dir, notes_ref, old_id.to_hex(), new_id.to_hex(),
+          true,
+        )
+      }
+    }
+  }
+}
+
+///|
+fn rebase_resolve_notes_rewrite_refs(
+  rfs : &@bitcore.RepoFileSystem,
+  common_git_dir : String,
+  patterns : Array[String],
+) -> Array[String] {
+  let seen : Map[String, Bool] = Map([])
+  let out : Array[String] = []
+  for pattern in patterns {
+    if pattern.has_suffix("/*") {
+      let prefix = String::unsafe_substring(
+        pattern,
+        start=0,
+        end=pattern.length() - 1,
+      )
+      let refs = @bitlib.list_refs_with_ids(rfs, common_git_dir, Some(prefix))
+      for pair in refs.to_array() {
+        let name = pair.0
+        if !seen.contains(name) {
+          seen[name] = true
+          out.push(name)
+        }
+      }
+    } else if !seen.contains(pattern) {
+      seen[pattern] = true
+      out.push(pattern)
+    }
+  }
+  out
+}
+
+///|
+fn rebase_note_exists(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  common_git_dir : String,
+  notes_ref : String,
+  hex : String,
+) -> Bool {
+  let commit_id = @bitlib.resolve_ref(rfs, git_dir, notes_ref) catch {
+    _ => None
+  }
+  guard commit_id is Some(cid) else { return false }
+  let db = @bitlib.ObjectDb::load(rfs, common_git_dir) catch {
+    _ => return false
+  }
+  let obj = db.get(rfs, cid) catch { _ => None }
+  guard obj is Some(o) else { return false }
+  let commit_info = @bitcore.parse_commit(o.data) catch { _ => return false }
+  let collected = notes_collect_all(rfs, db, commit_info.tree) catch {
+    _ => return false
+  }
+  for pair in collected {
+    if pair.0 == hex {
+      return true
+    }
+  }
+  false
 }
 
 ///|

--- a/modules/bit_lib/src/cherry_pick.mbt
+++ b/modules/bit_lib/src/cherry_pick.mbt
@@ -104,7 +104,8 @@ pub fn cherry_pick(
     match parent_files.get(path) {
       None => added_files[path] = file_entry
       Some(parent_entry) =>
-        if parent_entry.id != file_entry.id {
+        if parent_entry.id != file_entry.id ||
+          parent_entry.mode != file_entry.mode {
           modified_files[path] = file_entry
         }
     }
@@ -142,9 +143,10 @@ pub fn cherry_pick(
         // File doesn't exist in head - add it
         result_files[path] = file_entry
       Some(head_entry) =>
-        // Check if head has the same content as parent
+        // Check if head has the same content and mode as parent
         match parent_files.get(path) {
-          Some(parent_entry) if parent_entry.id == head_entry.id =>
+          Some(parent_entry) if parent_entry.id == head_entry.id &&
+            parent_entry.mode == head_entry.mode =>
             // No conflict - head hasn't changed the file
             result_files[path] = file_entry
           _ => {
@@ -160,9 +162,10 @@ pub fn cherry_pick(
   for path in deleted_files {
     match result_files.get(path) {
       Some(head_entry) =>
-        // Check if head has the same content as parent
+        // Check if head has the same content and mode as parent
         match parent_files.get(path) {
-          Some(parent_entry) if parent_entry.id == head_entry.id => {
+          Some(parent_entry) if parent_entry.id == head_entry.id &&
+            parent_entry.mode == head_entry.mode => {
             // No conflict - safe to delete
             let _ = result_files.remove(path)
           }

--- a/modules/bit_lib/src/rebase.mbt
+++ b/modules/bit_lib/src/rebase.mbt
@@ -12,6 +12,9 @@ pub struct RebaseState {
   author : String
   author_time : Int64
   author_tz : String
+  // old commit id -> new (rewritten) commit id, in application order.
+  // Mirrors git's .git/rebase-merge/rewritten-list.
+  rewritten : Array[(@bit.ObjectId, @bit.ObjectId)]
 }
 
 ///|
@@ -19,6 +22,10 @@ pub struct RebaseResult {
   status : RebaseStatus
   commit_id : @bit.ObjectId?
   conflicts : Array[String]
+  // old commit id -> new (rewritten) commit id, populated once the rebase
+  // completes. Empty for fast-forward / nothing-to-rebase results, since no
+  // commit ids change in those cases.
+  rewritten : Array[(@bit.ObjectId, @bit.ObjectId)]
 }
 
 ///|
@@ -892,6 +899,17 @@ fn save_rebase_state(
     }
     None => ()
   }
+  // Write rewritten-list: "<old sha> <new sha>" per line, matching git's
+  // own on-disk format (used to drive notes.rewrite.rebase copying).
+  if state.rewritten.length() > 0 {
+    let rewritten_lines = state.rewritten.map(pair => pair.0.to_hex() +
+      " " +
+      pair.1.to_hex())
+    fs.write_string(
+      join_path(state_dir, "rewritten-list"),
+      rewritten_lines.join("\n") + "\n",
+    )
+  }
 }
 
 ///|
@@ -920,6 +938,36 @@ pub fn load_rebase_state(
   } else {
     ""
   }
+  let rewritten_list_path = join_path(state_dir, "rewritten-list")
+  let rewritten : Array[(@bit.ObjectId, @bit.ObjectId)] = if fs.is_file(
+    rewritten_list_path,
+  ) {
+    let content = @utf8.decode_lossy(fs.read_file(rewritten_list_path)[:])
+    let out : Array[(@bit.ObjectId, @bit.ObjectId)] = []
+    for line_view in content.split("\n") {
+      let line = line_view.to_owned()
+      if line.length() == 0 {
+        continue
+      }
+      match line.find(" ") {
+        Some(idx) => {
+          let old_hex = String::unsafe_substring(line, start=0, end=idx)
+          let new_hex = String::unsafe_substring(
+            line,
+            start=idx + 1,
+            end=line.length(),
+          )
+          out.push(
+            (@bit.ObjectId::from_hex(old_hex), @bit.ObjectId::from_hex(new_hex)),
+          )
+        }
+        None => ()
+      }
+    }
+    out
+  } else {
+    []
+  }
   Some({
     onto: @bit.ObjectId::from_hex(onto_hex),
     orig_head: @bit.ObjectId::from_hex(orig_head_hex),
@@ -931,6 +979,7 @@ pub fn load_rebase_state(
     author: "",
     author_time: 0L,
     author_tz: "+0000",
+    rewritten,
   })
 }
 
@@ -1056,6 +1105,7 @@ pub fn rebase_start_with_onto(
         status: RebaseStatus::Complete,
         commit_id: Some(onto),
         conflicts: [],
+        rewritten: [],
       }
     }
     Some(h) => {
@@ -1064,6 +1114,7 @@ pub fn rebase_start_with_onto(
           status: RebaseStatus::NothingToRebase,
           commit_id: Some(h),
           conflicts: [],
+          rewritten: [],
         }
       }
       let db = ObjectDb::load(rfs, git_dir)
@@ -1076,12 +1127,14 @@ pub fn rebase_start_with_onto(
               status: RebaseStatus::Complete,
               commit_id: Some(onto),
               conflicts: [],
+              rewritten: [],
             }
           }
           return {
             status: RebaseStatus::NothingToRebase,
             commit_id: Some(h),
             conflicts: [],
+            rewritten: [],
           }
         }
       }
@@ -1102,6 +1155,7 @@ pub fn rebase_start_with_onto(
         author: "",
         author_time: 0L,
         author_tz: "+0000",
+        rewritten: [],
       }
       save_rebase_state(fs, git_dir, state)
       // Move HEAD to the new base before applying commits.
@@ -1164,6 +1218,8 @@ pub fn rebase_continue(
   if new_todo.length() > 0 {
     ignore(new_todo.remove(0))
   }
+  let new_rewritten = s.rewritten.copy()
+  new_rewritten.push((current_id, new_id))
   let new_state : RebaseState = {
     onto: s.onto,
     orig_head: s.orig_head,
@@ -1175,6 +1231,7 @@ pub fn rebase_continue(
     author: "",
     author_time: 0L,
     author_tz: "+0000",
+    rewritten: new_rewritten,
   }
   save_rebase_state(fs, git_dir, new_state)
   // Continue with next commits
@@ -1249,6 +1306,7 @@ pub fn rebase_skip(
     author: "",
     author_time: 0L,
     author_tz: "+0000",
+    rewritten: s.rewritten,
   }
   save_rebase_state(fs, git_dir, new_state)
   // Reset worktree to current HEAD
@@ -1519,7 +1577,12 @@ fn rebase_apply_next(
       let ref_path = join_path(git_dir, state.head_name)
       fs.write_string(ref_path, final_id.to_hex() + "\n")
     }
-    return { status: RebaseStatus::Complete, commit_id: head, conflicts: [] }
+    return {
+      status: RebaseStatus::Complete,
+      commit_id: head,
+      conflicts: [],
+      rewritten: state.rewritten,
+    }
   }
   let commit_id = state.todo[0]
   let info = rebase_parse_commit_full(db, rfs, commit_id)
@@ -1552,6 +1615,7 @@ fn rebase_apply_next(
       author: "",
       author_time: 0L,
       author_tz: "+0000",
+      rewritten: state.rewritten,
     }
     save_rebase_state(fs, git_dir, new_state)
     return rebase_apply_next(fs, rfs, root, new_state)
@@ -1573,6 +1637,7 @@ fn rebase_apply_next(
       author: info.author,
       author_time: info.author_time,
       author_tz: info.author_tz,
+      rewritten: state.rewritten,
     }
     save_rebase_state(fs, git_dir, new_state)
     // Write partially merged state to worktree and index (skip conflicting files)
@@ -1585,6 +1650,7 @@ fn rebase_apply_next(
       status: RebaseStatus::Conflict,
       commit_id: Some(commit_id),
       conflicts,
+      rewritten: state.rewritten,
     }
   }
   // No conflicts - create new commit
@@ -1608,6 +1674,8 @@ fn rebase_apply_next(
   new_done.push(commit_id)
   let new_todo = state.todo.copy()
   ignore(new_todo.remove(0))
+  let new_rewritten = state.rewritten.copy()
+  new_rewritten.push((commit_id, new_id))
   let new_state : RebaseState = {
     onto: state.onto,
     orig_head: state.orig_head,
@@ -1619,6 +1687,7 @@ fn rebase_apply_next(
     author: "",
     author_time: 0L,
     author_tz: "+0000",
+    rewritten: new_rewritten,
   }
   save_rebase_state(fs, git_dir, new_state)
   // Recursively apply next

--- a/modules/bit_lib/src/rebase.mbt
+++ b/modules/bit_lib/src/rebase.mbt
@@ -284,6 +284,38 @@ fn collect_ancestors(
 }
 
 ///|
+/// Refuse to move HEAD onto `target_map` if doing so would silently
+/// overwrite an untracked file on disk, mirroring the check an ordinary
+/// checkout performs. Only paths `target_map` actually writes are checked
+/// (not a full worktree scan), since those are the only ones about to be
+/// clobbered by `rebase_write_worktree`.
+fn rebase_check_untracked_conflicts(
+  rfs : &@bit.RepoFileSystem,
+  git_dir : String,
+  root : String,
+  target_map : Map[String, TreeEntryInfo],
+) -> Unit raise @bit.GitError {
+  let index_paths : Map[String, Bool] = Map([])
+  for entry in read_index_entries(rfs, git_dir) {
+    index_paths[entry.path] = true
+  }
+  let conflicts : Array[String] = []
+  for pair in target_map.to_array() {
+    let path = pair.0
+    if !index_paths.contains(path) && rfs.is_file(join_path(root, path)) {
+      conflicts.push(path)
+    }
+  }
+  if conflicts.length() > 0 {
+    conflicts.sort()
+    let listed = conflicts.map(p => "\t" + p).join("\n")
+    raise @bit.GitError::InvalidObject(
+      "The following untracked working tree files would be overwritten by checkout:\n\{listed}\nPlease move or remove them before you switch branches.\nAborting",
+    )
+  }
+}
+
+///|
 fn rebase_tree_map(
   db : ObjectDb,
   fs : &@bit.RepoFileSystem,
@@ -1143,6 +1175,8 @@ pub fn rebase_start_with_onto(
         HeadRef::Branch(name) => "refs/heads/" + name
         HeadRef::Detached(_) => ""
       }
+      let onto_map = rebase_tree_map(db, rfs, onto)
+      rebase_check_untracked_conflicts(rfs, git_dir, root, onto_map)
       // Create initial state
       let state : RebaseState = {
         onto,
@@ -1160,7 +1194,6 @@ pub fn rebase_start_with_onto(
       save_rebase_state(fs, git_dir, state)
       // Move HEAD to the new base before applying commits.
       rebase_update_head(fs, rfs, git_dir, onto)
-      let onto_map = rebase_tree_map(db, rfs, onto)
       rebase_write_worktree(fs, db, rfs, root, git_dir, onto_map)
       let entries = rebase_map_to_index(db, rfs, onto_map)
       write_index_entries(fs, git_dir, entries)

--- a/modules/bit_lib/src/rebase.mbt
+++ b/modules/bit_lib/src/rebase.mbt
@@ -550,6 +550,11 @@ fn rebase_write_worktree(
   git_dir : String,
   map : Map[String, TreeEntryInfo],
 ) -> Unit raise @bit.GitError {
+  let files : Map[String, TreeFileEntry] = Map([])
+  for path, info in map {
+    files[path] = { id: info.id, mode: info.mode }
+  }
+  tree_ops_remove_missing_paths(fs, rfs, root, git_dir, files, false)
   rebase_write_worktree_except(fs, db, rfs, root, git_dir, map, [])
 }
 
@@ -1441,7 +1446,7 @@ fn rebase_get_patch_tree_entries(
             result.push(sub)
           }
         } else {
-          result.push((path, entry.id.to_hex()))
+          result.push((path, entry.id.to_hex() + ":" + entry.mode))
         }
       }
     }

--- a/modules/bit_lib/src/revparse.mbt
+++ b/modules/bit_lib/src/revparse.mbt
@@ -10,6 +10,12 @@ pub fn rev_parse(
     let needle = substring_revparse(spec, 2, spec.length())
     return resolve_commit_message_search_all_refs(fs, git_dir, needle)
   }
+  if spec.has_suffix("}") && spec.find("@{") is Some(_) {
+    match resolve_reflog_numeric_selector(fs, git_dir, spec) {
+      Some(id) => return Some(id)
+      None => ()
+    }
+  }
   match parse_commit_message_search_spec(spec) {
     Some((base_spec, needle)) =>
       return resolve_commit_message_search(fs, git_dir, base_spec, needle)
@@ -790,6 +796,45 @@ pub fn parse_rev_parse_short_length(value : String) -> Int? {
     result = result * 10 + (c.to_int() - '0'.to_int())
   }
   Some(result)
+}
+
+///|
+/// Resolve a reflog numeric selector like `main@{2}` or `@{0}` (`@{2}` counts
+/// backward from the ref's current position: `@{0}` is where it points now,
+/// `@{1}` is its previous position, and so on). Returns None for anything
+/// that isn't this exact numeric form (e.g. `@{upstream}`, `@{2.days.ago}`),
+/// leaving those to their own resolution paths.
+fn resolve_reflog_numeric_selector(
+  fs : &@bit.RepoFileSystem,
+  git_dir : String,
+  spec : String,
+) -> @bit.ObjectId? raise @bit.GitError {
+  guard parse_reflog_selector(spec) is Some((raw_refname, index)) else {
+    return None
+  }
+  let refname = if raw_refname.length() == 0 {
+    match read_head_ref(fs, git_dir) {
+      HeadRef::Branch(name) => "refs/heads/" + name
+      HeadRef::Detached(_) => return None
+    }
+  } else {
+    raw_refname
+  }
+  let entries = read_reflog(fs, git_dir, refname)
+  let len = entries.length()
+  if index == 0 && len == 0 {
+    return resolve_ref(fs, git_dir, refname)
+  }
+  if index < len {
+    return Some(entries[len - 1 - index].new_id)
+  }
+  if index == len && len > 0 {
+    let old_id = entries[0].old_id
+    if old_id != @bit.ObjectId::zero() {
+      return Some(old_id)
+    }
+  }
+  None
 }
 
 ///|

--- a/modules/bit_lib/src/tree_ops.mbt
+++ b/modules/bit_lib/src/tree_ops.mbt
@@ -423,6 +423,7 @@ fn tree_ops_remove_missing_paths(
   preserve_removed_gitlinks : Bool,
 ) -> Unit raise @bit.GitError {
   let entries = read_index_entries(rfs, git_dir)
+  let emptied_candidates : Array[String] = []
   for entry in entries {
     if files.contains(entry.path) {
       continue
@@ -430,6 +431,7 @@ fn tree_ops_remove_missing_paths(
     let path = join_path(root, entry.path)
     if rfs.is_file(path) {
       fs.remove_file(path)
+      emptied_candidates.push(parent_dir(path))
     } else if is_gitlink_mode_int(entry.mode) && rfs.is_dir(path) {
       let bit_marker = join_path(path, ".git")
       if preserve_removed_gitlinks &&
@@ -437,6 +439,39 @@ fn tree_ops_remove_missing_paths(
         continue
       }
       remove_worktree_path_recursive(fs, rfs, path)
+    }
+  }
+  tree_ops_prune_empty_dirs(fs, rfs, root, emptied_candidates)
+}
+
+///|
+/// Remove directories left empty by tree_ops_remove_missing_paths, walking
+/// upward from each candidate until a non-empty directory or `root` is
+/// reached. Best-effort: any I/O error just stops pruning that branch
+/// rather than failing the checkout that triggered it.
+fn tree_ops_prune_empty_dirs(
+  fs : &@bit.FileSystem,
+  rfs : &@bit.RepoFileSystem,
+  root : String,
+  candidate_dirs : Array[String],
+) -> Unit {
+  let normalized_root = normalize_path(root)
+  let visited : Map[String, Bool] = Map([])
+  for start_dir in candidate_dirs {
+    let mut dir = start_dir
+    while dir.length() > 0 &&
+          normalize_path(dir) != normalized_root &&
+          !visited.contains(dir) {
+      visited[dir] = true
+      if !rfs.is_dir(dir) {
+        break
+      }
+      let children = rfs.readdir(dir) catch { _ => [""] }
+      if children.length() > 0 {
+        break
+      }
+      fs.remove_dir(dir) catch { _ => break }
+      dir = parent_dir(dir)
     }
   }
 }


### PR DESCRIPTION
## Summary

Continuation of #88. PR #159 merged the first round of `t3400-rebase.sh` fixes (dirty-tree check, `-q`, `-` shorthand, `--quit`, default upstream). Several more commits were pushed to this branch afterward but never got their own PR — this PR covers all of that unmerged work plus a new round of fixes found while root-causing the remaining failures, taking `t3400-rebase.sh` from 18/39 to **34/39** passing.

### Previously pushed, never in a PR
- `git rebase <upstream> <branch>` two-arg form (reuses `handle_checkout`'s worktree-lock/detached-HEAD rules).
- `notes.rewrite.rebase` / `notes.rewriteRef` support: rewritten commits are tracked and persisted to `.git/rebase-merge/rewritten-list`, and notes are copied after a successful rebase.
- Refuse to silently overwrite untracked files when moving HEAD to the new base (matches git's checkout-style protection).
- `git merge-base --fork-point` semantics for the no-explicit-`<upstream>` default, walking `@{upstream}`'s reflog instead of just its current tip. Also fixed `<ref>@{N}` numeric reflog-index resolution in `rev_parse` (a parser for it existed but nothing called it).

### New this round
- **`tree_ops_remove_missing_paths`** (ordinary `checkout`/`switch_branch`) never pruned directories left empty after removing stale tracked files — e.g. moving a file into a new subdirectory on one branch left the empty directory behind when switching away from it.
- **`rebase_get_patch_tree_entries`** computed patch-id fingerprints from blob content only, ignoring file mode. A mode-only commit (`chmod +x`) hashed identically to an unrelated commit that happened to add the same content, so `rebase_patch_id_exists_in_ancestors` falsely treated the mode-change commit as already upstream and silently dropped it.
- Ordinary `bit checkout <branch>` never applied tracked file mode bits to the worktree — `apply_worktree_modes_from_commit` was only wired into clone/submodule-init. This was masked by the patch-id bug above (mode changes never survived a rebase to be checked out) and surfaced once that was fixed.
- **`rebase_write_worktree`** (used by every full-tree worktree materialization in `rebase.mbt`: fast-forward, non-interactive finalize, abort, skip) only ever wrote files present in the target tree and never removed worktree files tracked before the rebase but absent from the new base — the actual root cause of the recurring untracked-file leftovers chasing tests #21/#22/#23 across the last few rounds.
- Cherry-pick's modified-file diff compared blob id only, so pure mode changes were silently dropped the same way.
- Added `git cherry-pick -<n> <commit>` (replay the last n commits by first-parent history), replacing a hardcoded "`-3` is a no-op 3-way flag" hack that only coincidentally passed its one test.

## Remaining gaps (left open, documented on #88)

5 of the original failures remain: `--show-current-patch` + `GIT_TRACE` infrastructure (2 tests), `.gitattributes` filter-driven content transforms during rebase, a `git diff <rev>:<path>..<rev>:<path>` range-diff syntax gap unrelated to rebase, and one worktree-subdirectory case whose root cause wasn't pinned down despite deep investigation.

## Test plan

- [x] `moon check` passes.
- [x] Built `bit` natively and real `git`/`test-tool` from `third_party/git`; ran `t3400-rebase.sh` through the strict git-shim before/after each fix: 18/39 → 34/39 passing.
- [x] `t3508-cherry-pick-many-commits.sh` / `t3506-cherry-pick-ff.sh` — no new regressions (identical pass/fail set to baseline).
- [x] `moon test --target wasm-gc` (full workspace) — 905/907, matching the pre-existing baseline (2 unrelated zlib-output expect-test failures that already fail on unmodified `main`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CBW8Pdq2ZfWVAfTZFsTnVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBW8Pdq2ZfWVAfTZFsTnVo)_