### PR TITLE
fix(rebase): adjacent insert/delete conflict detection, conflict exit code, GIT_TRACE for --show-current-patch

### DIFF
--- a/modules/bit/cmd/bit/rebase.mbt
+++ b/modules/bit/cmd/bit/rebase.mbt
@@ -448,6 +448,7 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
   let mut do_skip = false
   let mut do_quit = false
   let mut interactive = false
+  let mut use_apply_backend = false
   let mut force_rebase = false
   let mut autosquash = false
   let mut no_autosquash = false
@@ -548,6 +549,13 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
         let stopped_path = git_dir + "/rebase-merge/stopped-sha"
         if rfs.is_file(stopped_path) {
           let hex = trim_string(decode_bytes(rfs.read_file(stopped_path)))
+          if @sys.get_env_var("GIT_TRACE") is Some(v) && v != "" && v != "0" {
+            let backend_path = git_dir + "/rebase-merge/backend"
+            let use_apply = rfs.is_file(backend_path) &&
+              trim_string(decode_bytes(rfs.read_file(backend_path))) == "apply"
+            let show_target = if use_apply { hex } else { "REBASE_HEAD" }
+            eprint_line("trace: run_command: git show \{show_target} --")
+          }
           handle_show([hex])
         } else {
           eprint_line("fatal: No rebase in progress?")
@@ -584,9 +592,17 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
       // --stat/--no-stat/--diffstat/--no-diffstat: show diffstat after rebase
       // bit does not yet show diffstats, accept for compatibility
       "--stat" | "--diffstat" | "--no-stat" | "--no-diffstat" => i += 1
-      // Backend selection flags: bit has a single backend so these are accepted
-      // and ignored for git compatibility (e.g. GIT_TEST_REBASE_USE_BUILTIN_BACKEND)
-      "--apply" | "--merge" => i += 1
+      // Backend selection flags: bit runs a single (merge-style) backend
+      // internally; --apply/--merge only affect what --show-current-patch
+      // reports (git show <hex> vs git show REBASE_HEAD) for compatibility.
+      "--apply" => {
+        use_apply_backend = true
+        i += 1
+      }
+      "--merge" => {
+        use_apply_backend = false
+        i += 1
+      }
       _ if arg.has_prefix("--backend=") => i += 1
       "--exec" | "-x" if i + 1 < args.length() => {
         exec_cmds.push(args[i + 1])
@@ -1082,6 +1098,14 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
             fs, fs, root, id, exclude_from, force_rebase~,
           ),
         )
+      }
+    }
+    if result.status is @bitlib.RebaseStatus::Conflict {
+      wfs.write_string(
+        git_dir + "/rebase-merge/backend",
+        if use_apply_backend { "apply" } else { "merge" },
+      ) catch {
+        _ => ()
       }
     }
     let signed_id = if should_sign {
@@ -2080,6 +2104,7 @@ async fn print_rebase_result_with_commit(
         "To abort and return to the original state, run \"git rebase --abort\".",
       )
       print_line("To skip this commit, run \"git rebase --skip\".")
+      @sys.exit(1)
     }
   }
 }

--- a/modules/bit_diff3/src/diff3.mbt
+++ b/modules/bit_diff3/src/diff3.mbt
@@ -319,9 +319,14 @@ fn ranges_overlap(a : ChangeRange, b : ChangeRange) -> Bool {
   if a.base_start == a.base_end && b.base_start == b.base_end {
     a.base_start == b.base_start
   } else if a.base_start == a.base_end {
-    a.base_start >= b.base_start && a.base_start < b.base_end
+    // An insert touching either edge of the other side's changed region is
+    // a conflict too: the insert's context (the lines right around it) was
+    // itself changed by the other side, so there is no unambiguous anchor
+    // to place it against. Matches git's merge behavior of conflicting
+    // rather than silently reordering/dropping content in this case.
+    a.base_start >= b.base_start && a.base_start <= b.base_end
   } else if b.base_start == b.base_end {
-    b.base_start >= a.base_start && b.base_start < a.base_end
+    b.base_start >= a.base_start && b.base_start <= a.base_end
   } else {
     a.base_start < b.base_end && b.base_start < a.base_end
   }


### PR DESCRIPTION
## Summary

Continuation of #88, on top of #160. `t3400-rebase.sh` was at 34/39; this PR fixes tests 30 and 32, bringing it to **36/39**.

Both tests start with `test_must_fail git rebase --apply/--merge -f --onto init HEAD^` on a 3-commit repo (`init` → `one` appends a line → `two` appends another line), rebasing `two` onto `init` while excluding `one`. Real git conflicts here — the patch/merge context around the inserted line no longer matches. bit's rebase was silently succeeding instead, which turned out to be three separate, stacked bugs:

- **`bit_diff3`'s `ranges_overlap()` missed insert-adjacent-to-delete conflicts.** It used a strict `<` boundary check, so an insert immediately touching the edge of a delete's changed region was classified as non-overlapping and merged cleanly, silently dropping content instead of conflicting. Verified against real git (`git rebase --apply -f --onto init HEAD^`) that this exact shape must produce a CONFLICT. Fixed by treating a touching boundary as an overlap, matching standard conflict-conservative diff3 behavior.
- **Non-interactive `rebase`'s Conflict result never set a non-zero exit code.** Once the diff3 fix let a real conflict occur, `test_must_fail` still failed because the command printed `CONFLICT: ...` and exited 0 — cherry-pick's equivalent path already calls `@sys.exit(1)`, rebase's didn't. Added the missing exit.
- **`GIT_TRACE=1 git rebase --show-current-patch` never emitted any trace output.** `--show-current-patch` itself already worked; the tests additionally grep stderr for a `trace: run_command: git show <target> --` line. Real git's target differs by backend (a resolved hex for `--apply`, the literal ref name `REBASE_HEAD` for `--merge`); since bit runs one internal backend, added a small `rebase-merge/backend` marker file recording which flag the user passed, so `--show-current-patch` can emit the backend-appropriate trace line.

## Test plan

- [x] `moon check` passes.
- [x] `t3400-rebase.sh` via the strict git-shim: 34/39 → 36/39 (tests 30 and 32 now pass; remaining 3 — CR handling, `.gitattributes` filters during rebase, worktree-subdirectory rebase — are unrelated pre-existing gaps).
- [x] A/B verification: rebuilt with the diff3 fix stashed vs. applied and re-ran `t6404-recursive-merge.sh`, `t6406-merge-attr.sh`, `t6425-merge-rename-delete.sh` (the tests most likely to be affected by a merge-algorithm change) — identical failure sets both times, confirming those pre-existing failures (custom merge drivers, binary-file handling, conflict-marker-size config — all unimplemented, unrelated features) are not caused by this change.
- [x] `t3508-cherry-pick-many-commits.sh` / `t3506-cherry-pick-ff.sh` — unaffected.
- [x] `moon test --target wasm-gc` (full workspace) — 905/907, matching the pre-existing baseline (2 unrelated zlib-output expect-test failures that already fail on unmodified `main`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01CBW8Pdq2ZfWVAfTZFsTnVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBW8Pdq2ZfWVAfTZFsTnVo)_