### PR TITLE
fix(rebase): two-blob diff comparison, gitattributes filter smudge, worktree git-dir resolution

### DIFF
--- a/modules/bit/cmd/bit/checkout.mbt
+++ b/modules/bit/cmd/bit/checkout.mbt
@@ -333,20 +333,11 @@ fn checkout_branch_in_use_path(
   root : String,
   branch : String,
 ) -> String? raise Error {
-  let git_dir = resolve_git_dir(fs, root)
-  match @bitlib.read_head_ref(fs, git_dir) {
-    Branch(current) if current == branch => return None
-    _ => ()
-  }
-  match @bitlib.is_branch_checked_out(fs, root, branch) {
-    Some(path) =>
-      if normalize_path(path) == normalize_path(root) {
-        None
-      } else {
-        Some(path)
-      }
-    None => None
-  }
+  // Checks every worktree, not just the "current branch" shortcut: `git
+  // worktree add -f` can force two worktrees to share one branch, so the
+  // current worktree already being on `branch` doesn't rule out a conflict
+  // with a different worktree that also has it checked out.
+  @bitlib.is_branch_checked_out_elsewhere(fs, root, branch)
 }
 
 ///|

--- a/modules/bit/cmd/bit/diff.mbt
+++ b/modules/bit/cmd/bit/diff.mbt
@@ -1605,6 +1605,7 @@ async fn handle_diff(args : Array[String]) -> Unit raise Error {
   let mut rotate_to : String? = None
   let mut skip_to : String? = None
   let mut combined_specs : (String, String, String)? = None
+  let mut blob_pair_spec : (String, String, @bitcore.ObjectId, @bitcore.ObjectId)? = None
   let mut expect_orderfile = false
   let mut expect_output = false
   let mut expect_rotate_to = false
@@ -1858,7 +1859,14 @@ async fn handle_diff(args : Array[String]) -> Unit raise Error {
       ref_target = Some(revs[0])
       rest
     } else if revs.length() == 2 {
-      range_spec = Some(revs[0] + ".." + revs[1])
+      let blob_db = @bitlib.ObjectDb::load(rfs, repo_git_dir)
+      let blob_a = diff_resolve_blob_id(blob_db, rfs, repo_git_dir, revs[0])
+      let blob_b = diff_resolve_blob_id(blob_db, rfs, repo_git_dir, revs[1])
+      match (blob_a, blob_b) {
+        (Some(a_id), Some(b_id)) =>
+          blob_pair_spec = Some((revs[0], revs[1], a_id, b_id))
+        _ => range_spec = Some(revs[0] + ".." + revs[1])
+      }
       rest
     } else if revs.length() == 3 {
       combined_specs = Some((revs[0], revs[1], revs[2]))
@@ -1958,53 +1966,60 @@ async fn handle_diff(args : Array[String]) -> Unit raise Error {
     }
     _ => ()
   }
-  let all_files = match combined_specs {
-    Some((base, parent_a, parent_b)) =>
-      diff_combined_against_parents(rfs, repo_git_dir, base, parent_a, parent_b)
+  let all_files = match blob_pair_spec {
+    Some((old_spec, new_spec, old_id, new_id)) =>
+      diff_blob_pair_files(rfs, repo_git_dir, old_spec, new_spec, old_id, new_id)
     None =>
-      match range_spec {
-        Some(spec) => {
-          if submodule_mode {
-            let handled = try_handle_submodule_range_diff(
-              fs, root, git_dir, repo_git_dir, spec,
-            )
-            if handled {
-              return
-            }
-          }
-          let db = @bitlib.ObjectDb::load(rfs, repo_git_dir)
-          match resolve_submodule_diff_range(db, rfs, repo_git_dir, spec) {
-            Some((old_id, new_id)) => {
-              let old_tree = resolve_diff_tree_id(db, rfs, old_id)
-              let new_tree = resolve_diff_tree_id(db, rfs, new_id)
-              match (old_tree, new_tree) {
-                (Some(ot), Some(nt)) =>
-                  @bitdiff.diff_trees(rfs, repo_git_dir, Some(ot), nt, db~)
-                _ =>
+      match combined_specs {
+        Some((base, parent_a, parent_b)) =>
+          diff_combined_against_parents(
+            rfs, repo_git_dir, base, parent_a, parent_b,
+          )
+        None =>
+          match range_spec {
+            Some(spec) => {
+              if submodule_mode {
+                let handled = try_handle_submodule_range_diff(
+                  fs, root, git_dir, repo_git_dir, spec,
+                )
+                if handled {
+                  return
+                }
+              }
+              let db = @bitlib.ObjectDb::load(rfs, repo_git_dir)
+              match resolve_submodule_diff_range(db, rfs, repo_git_dir, spec) {
+                Some((old_id, new_id)) => {
+                  let old_tree = resolve_diff_tree_id(db, rfs, old_id)
+                  let new_tree = resolve_diff_tree_id(db, rfs, new_id)
+                  match (old_tree, new_tree) {
+                    (Some(ot), Some(nt)) =>
+                      @bitdiff.diff_trees(rfs, repo_git_dir, Some(ot), nt, db~)
+                    _ =>
+                      raise @bitcore.GitError::InvalidObject(
+                        "unsupported diff range: " + spec,
+                      )
+                  }
+                }
+                None =>
                   raise @bitcore.GitError::InvalidObject(
                     "unsupported diff range: " + spec,
                   )
               }
             }
             None =>
-              raise @bitcore.GitError::InvalidObject(
-                "unsupported diff range: " + spec,
-              )
-          }
-        }
-        None =>
-          if cached {
-            match ref_target {
-              Some(spec) =>
-                diff_cached_against_ref(fs, rfs, root, git_dir, spec)
-              None => @bitdiff.diff_index(fs, root)
-            }
-          } else {
-            match ref_target {
-              Some(spec) =>
-                diff_worktree_against_ref(fs, rfs, root, git_dir, spec)
-              None => @bitdiff.diff_worktree(fs, root)
-            }
+              if cached {
+                match ref_target {
+                  Some(spec) =>
+                    diff_cached_against_ref(fs, rfs, root, git_dir, spec)
+                  None => @bitdiff.diff_index(fs, root)
+                }
+              } else {
+                match ref_target {
+                  Some(spec) =>
+                    diff_worktree_against_ref(fs, rfs, root, git_dir, spec)
+                  None => @bitdiff.diff_worktree(fs, root)
+                }
+              }
           }
       }
   }
@@ -3054,6 +3069,72 @@ async fn try_handle_submodule_range_diff(
     handled = true
   }
   handled
+}
+
+///|
+/// Resolves `spec` to a blob object id, returning None if it does not
+/// resolve at all or resolves to a non-blob object (commit/tree/tag).
+fn diff_resolve_blob_id(
+  db : @bitlib.ObjectDb,
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  spec : String,
+) -> @bitcore.ObjectId? raise Error {
+  guard @bitrepo.rev_parse(rfs, git_dir, spec) is Some(oid) else {
+    return None
+  }
+  guard db.get(rfs, oid) is Some(obj) else { return None }
+  if obj.obj_type == @bitcore.ObjectType::Blob {
+    Some(oid)
+  } else {
+    None
+  }
+}
+
+///|
+/// The path portion of a `<rev>:<path>` blob spec, or the spec itself when
+/// it has no `:` (e.g. a bare blob sha).
+fn diff_blob_spec_display_path(spec : String) -> String {
+  match spec.find(":") {
+    Some(idx) if idx + 1 <= spec.length() =>
+      String::unsafe_substring(spec, start=idx + 1, end=spec.length())
+    _ => spec
+  }
+}
+
+///|
+/// Builds the (at most one entry) file list for `git diff <blob> <blob>`,
+/// the two-blob comparison form (e.g. `git diff a:CR HEAD:CR`).
+fn diff_blob_pair_files(
+  rfs : &@bitcore.RepoFileSystem,
+  git_dir : String,
+  old_spec : String,
+  new_spec : String,
+  old_id : @bitcore.ObjectId,
+  new_id : @bitcore.ObjectId,
+) -> Array[@bitdiff.DiffFile] raise Error {
+  if old_id == new_id {
+    return []
+  }
+  let db = @bitlib.ObjectDb::load(rfs, git_dir)
+  guard db.get(rfs, old_id) is Some(old_obj) else { return [] }
+  guard db.get(rfs, new_id) is Some(new_obj) else { return [] }
+  let path = diff_blob_spec_display_path(new_spec)
+  let path = if path.length() > 0 {
+    path
+  } else {
+    diff_blob_spec_display_path(old_spec)
+  }
+  [
+    {
+      path,
+      kind: @bitdiff.DiffKind::Modified,
+      old_content: Some(old_obj.data),
+      new_content: Some(new_obj.data),
+      old_mode: Some(0o100644),
+      new_mode: Some(0o100644),
+    },
+  ]
 }
 
 ///|

--- a/modules/bit/cmd/bit/pull.mbt
+++ b/modules/bit/cmd/bit/pull.mbt
@@ -574,8 +574,9 @@ async fn handle_pull(args : Array[String]) -> Unit raise Error {
         pull_apply_autostash(fs, fs, git_dir, root, autostash_state, quiet)
       }
     } else {
+      let filter_cmd = @bitlib.FilterCmd::{ run: @bitlibnative.run_filter_command }
       let result = @bitlib.rebase_start_with_onto(
-        fs, fs, root, tid, rebase_upstream,
+        fs, fs, root, tid, rebase_upstream, run_filter_cmd=filter_cmd,
       )
       match result.status {
         @bitlib.RebaseStatus::Complete =>

--- a/modules/bit/cmd/bit/rebase.mbt
+++ b/modules/bit/cmd/bit/rebase.mbt
@@ -925,8 +925,22 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
   // A second positional arg: switch to it first (like `bit checkout
   // <branch>`), so the rebase below operates on it as the current HEAD.
   // Reuses checkout's own worktree-lock / detached-HEAD / dirty-tree rules.
+  // Unlike plain checkout, this check is unconditional even when the
+  // target is already the current branch: rebase is about to rewrite the
+  // branch's history, which is unsafe if another worktree also has it
+  // checked out (e.g. via `git worktree add -f`, which lets one branch be
+  // shared by two worktrees).
   match switch_to_branch {
-    Some(target) => handle_checkout([target])
+    Some(target) => {
+      match @bitlib.is_branch_checked_out_elsewhere(rfs, root, target) {
+        Some(path) =>
+          raise @bitcore.GitError::InvalidObject(
+            "'\{target}' is already used by worktree at '\{path}'",
+          )
+        None => ()
+      }
+      handle_checkout([target])
+    }
     None => ()
   }
   // Require a clean worktree/index before starting a new rebase, unless

--- a/modules/bit/cmd/bit/rebase.mbt
+++ b/modules/bit/cmd/bit/rebase.mbt
@@ -442,6 +442,7 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
   check_and_exit_unsupported_attrs(root)
   let wfs : &@bitcore.FileSystem = fs
   let rfs : &@bitcore.RepoFileSystem = fs
+  let filter_cmd = @bitlib.FilterCmd::{ run: @bitlibnative.run_filter_command }
   // Parse arguments
   let mut do_continue = false
   let mut do_abort = false
@@ -788,7 +789,7 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
       print_interactive_rebase_result(result, quiet~)
     } else {
       let state_before = @bitlib.load_rebase_state(rfs, git_dir)
-      let result = @bitlib.rebase_continue(fs, fs, root)
+      let result = @bitlib.rebase_continue(fs, fs, root, run_filter_cmd=filter_cmd)
       let signed_id = if should_sign {
         match state_before {
           Some(state) =>
@@ -821,7 +822,7 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
       rebase_clear_signing_state(wfs, git_dir)
       print_line("Rebase aborted")
     } else {
-      @bitlib.rebase_abort(fs, fs, root) catch {
+      @bitlib.rebase_abort(fs, fs, root, run_filter_cmd=filter_cmd) catch {
         _ => @bitlib.clear_rebase_state(fs, fs, git_dir)
       }
       rebase_clear_signing_state(wfs, git_dir)
@@ -866,7 +867,7 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
       print_interactive_rebase_result(result, quiet~)
     } else {
       let state_before = @bitlib.load_rebase_state(rfs, git_dir)
-      let result = @bitlib.rebase_skip(fs, fs, root)
+      let result = @bitlib.rebase_skip(fs, fs, root, run_filter_cmd=filter_cmd)
       let signed_id = if should_sign {
         match state_before {
           Some(state) =>
@@ -1074,7 +1075,9 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
         }
         (
           oid,
-          @bitlib.rebase_start_with_onto(fs, fs, root, oid, id, force_rebase~),
+          @bitlib.rebase_start_with_onto(
+            fs, fs, root, oid, id, force_rebase~, run_filter_cmd=filter_cmd,
+          ),
         )
       }
       None => {
@@ -1096,6 +1099,7 @@ async fn handle_rebase(args : Array[String]) -> Unit raise Error {
           id,
           @bitlib.rebase_start_with_onto(
             fs, fs, root, id, exclude_from, force_rebase~,
+            run_filter_cmd=filter_cmd,
           ),
         )
       }

--- a/modules/bit_lib/src/gitattributes.mbt
+++ b/modules/bit_lib/src/gitattributes.mbt
@@ -408,6 +408,32 @@ pub fn read_filter_commands(
 }
 
 ///|
+/// Apply the external filter driver's smudge command (blob -> worktree),
+/// e.g. from `.gitattributes`' `filter=name`. Returns `content` unchanged
+/// when no filter is configured for the path, the filter is `lfs` (handled
+/// separately by pointer resolution), or no `run_filter_cmd` callback /
+/// smudge command is available.
+pub async fn apply_filter_smudge(
+  rfs : &@bit.RepoFileSystem,
+  content : Bytes,
+  attrs : FileEolAttrs,
+  root : String,
+  git_dir : String,
+  run_filter_cmd : FilterCmd?,
+) -> Bytes raise @bit.GitError {
+  match (attrs.filter, run_filter_cmd) {
+    (Some(name), Some(run_cmd)) if name != "lfs" => {
+      let (_, smudge_cmd) = read_filter_commands(rfs, git_dir, name)
+      match smudge_cmd {
+        Some(cmd) => (run_cmd.run)(root, git_dir, cmd, content)
+        None => content
+      }
+    }
+    _ => content
+  }
+}
+
+///|
 /// Check if .gitattributes has any filter= attributes (for storage runtime bypass).
 pub fn has_any_filter_attributes(
   rfs : &@bit.RepoFileSystem,

--- a/modules/bit_lib/src/js_api_exports.mbt
+++ b/modules/bit_lib/src/js_api_exports.mbt
@@ -1920,27 +1920,27 @@ pub fn js_tag_create_annotated(
 }
 
 ///|
-pub fn js_rebase_start(
+pub async fn js_rebase_start(
   host_id : Int,
   root : String,
   upstream : String,
 ) -> Result[JsRebaseResult, String] {
   let fs = js_make_host_fs(host_id)
-  js_wrap_error(() => {
+  js_wrap_error_async(async fn() -> JsRebaseResult raise @bit.GitError {
     let upstream_id = js_resolve_revision(fs, root, upstream)
     js_convert_rebase_result(rebase_start(fs, fs, root, upstream_id))
   })
 }
 
 ///|
-pub fn js_rebase_start_with_onto(
+pub async fn js_rebase_start_with_onto(
   host_id : Int,
   root : String,
   onto : String,
   upstream : String,
 ) -> Result[JsRebaseResult, String] {
   let fs = js_make_host_fs(host_id)
-  js_wrap_error(() => {
+  js_wrap_error_async(async fn() -> JsRebaseResult raise @bit.GitError {
     let onto_id = js_resolve_revision(fs, root, onto)
     let upstream_id = js_resolve_revision(fs, root, upstream)
     js_convert_rebase_result(
@@ -1950,27 +1950,36 @@ pub fn js_rebase_start_with_onto(
 }
 
 ///|
-pub fn js_rebase_continue(
+pub async fn js_rebase_continue(
   host_id : Int,
   root : String,
 ) -> Result[JsRebaseResult, String] {
   let fs = js_make_host_fs(host_id)
-  js_wrap_error(() => js_convert_rebase_result(rebase_continue(fs, fs, root)))
+  js_wrap_error_async(async fn() -> JsRebaseResult raise @bit.GitError {
+    js_convert_rebase_result(rebase_continue(fs, fs, root))
+  })
 }
 
 ///|
-pub fn js_rebase_abort(host_id : Int, root : String) -> Result[Unit, String] {
+pub async fn js_rebase_abort(
+  host_id : Int,
+  root : String,
+) -> Result[Unit, String] {
   let fs = js_make_host_fs(host_id)
-  js_wrap_error(() => rebase_abort(fs, fs, root))
+  js_wrap_error_async(async fn() -> Unit raise @bit.GitError {
+    rebase_abort(fs, fs, root)
+  })
 }
 
 ///|
-pub fn js_rebase_skip(
+pub async fn js_rebase_skip(
   host_id : Int,
   root : String,
 ) -> Result[JsRebaseResult, String] {
   let fs = js_make_host_fs(host_id)
-  js_wrap_error(() => js_convert_rebase_result(rebase_skip(fs, fs, root)))
+  js_wrap_error_async(async fn() -> JsRebaseResult raise @bit.GitError {
+    js_convert_rebase_result(rebase_skip(fs, fs, root))
+  })
 }
 
 ///|

--- a/modules/bit_lib/src/js_exports_wbtest.mbt
+++ b/modules/bit_lib/src/js_exports_wbtest.mbt
@@ -852,7 +852,7 @@ test "js exports: merge merges another branch by refname" {
 }
 
 ///|
-test "js exports: rebase start rebases current branch onto upstream refname" {
+async test "js exports: rebase start rebases current branch onto upstream refname" {
   let host_id = js_create_memory_host()
 
   js_exports_unwrap_ok("init", js_git_init(host_id, "/repo", "main"))

--- a/modules/bit_lib/src/rebase.mbt
+++ b/modules/bit_lib/src/rebase.mbt
@@ -36,6 +36,20 @@ pub enum RebaseStatus {
 }
 
 ///|
+/// Resolves the actual `.git` directory for `root`, following the
+/// `gitdir: <path>` pointer file used by linked worktrees (where
+/// `<root>/.git` is a file, not a directory, and the real admin dir lives
+/// under the main repo's `.git/worktrees/<name>`).
+fn rebase_resolve_git_dir(rfs : &@bit.RepoFileSystem, root : String) -> String {
+  let default_git_dir = join_path(root, ".git")
+  if rfs.is_file(default_git_dir) {
+    resolve_gitdir(rfs, default_git_dir)
+  } else {
+    default_git_dir
+  }
+}
+
+///|
 pub async fn fast_forward_to(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
@@ -43,7 +57,7 @@ pub async fn fast_forward_to(
   target : @bit.ObjectId,
   run_filter_cmd? : FilterCmd,
 ) -> Unit raise @bit.GitError {
-  let git_dir = join_path(root, ".git")
+  let git_dir = rebase_resolve_git_dir(rfs, root)
   let db = ObjectDb::load(rfs, git_dir)
   let tree_map = rebase_tree_map(db, rfs, target)
   rebase_update_head(fs, rfs, git_dir, target)
@@ -61,7 +75,7 @@ pub async fn rebase_onto(
   upstream : @bit.ObjectId,
   run_filter_cmd? : FilterCmd,
 ) -> @bit.ObjectId raise @bit.GitError {
-  let git_dir = join_path(root, ".git")
+  let git_dir = rebase_resolve_git_dir(rfs, root)
   let head = resolve_head_commit(rfs, git_dir)
   match head {
     None => {
@@ -87,7 +101,7 @@ pub async fn rebase_onto(
         let commit_map = rebase_tree_map_from_tree(db, rfs, info.tree)
         let changes = rebase_diff_maps(parent_map, commit_map)
         rebase_apply_changes(base_map, parent_map, changes)
-        let new_tree = rebase_write_tree_from_map(fs, git_dir, base_map)
+        let new_tree = rebase_write_tree_from_map(fs, rfs, git_dir, base_map)
         let new_commit = @bit.Commit::new(
           new_tree,
           [parent],
@@ -100,7 +114,7 @@ pub async fn rebase_onto(
           info.message,
         )
         let (new_id, compressed) = @bit.create_commit(new_commit)
-        rebase_write_object(fs, git_dir, new_id, compressed)
+        rebase_write_object(fs, rfs, git_dir, new_id, compressed)
         parent = new_id
       }
       rebase_update_head(fs, rfs, git_dir, parent)
@@ -460,6 +474,7 @@ fn rebase_apply_changes(
 ///|
 fn rebase_write_tree_from_map(
   fs : &@bit.FileSystem,
+  rfs : &@bit.RepoFileSystem,
   git_dir : String,
   map : Map[String, TreeEntryInfo],
 ) -> @bit.ObjectId raise @bit.GitError {
@@ -481,12 +496,13 @@ fn rebase_write_tree_from_map(
   }
   entries.sort_by((a, b) => String::lexical_compare(a.path, b.path))
   let rel_entries = entries.map(e => e)
-  rebase_write_tree_recursive(fs, git_dir, rel_entries)
+  rebase_write_tree_recursive(fs, rfs, git_dir, rel_entries)
 }
 
 ///|
 fn rebase_write_tree_recursive(
   fs : &@bit.FileSystem,
+  rfs : &@bit.RepoFileSystem,
   git_dir : String,
   entries : Array[IndexEntry],
 ) -> @bit.ObjectId raise @bit.GitError {
@@ -534,12 +550,12 @@ fn rebase_write_tree_recursive(
     }
   }
   for dir_name, list in dir_map {
-    let sub_id = rebase_write_tree_recursive(fs, git_dir, list)
+    let sub_id = rebase_write_tree_recursive(fs, rfs, git_dir, list)
     file_entries.push(@bit.TreeEntry::new("040000", dir_name, sub_id))
   }
   file_entries.sort_by((a, b) => String::lexical_compare(a.name, b.name))
   let (tree_id, compressed) = @bit.create_tree(file_entries)
-  rebase_write_object(fs, git_dir, tree_id, compressed)
+  rebase_write_object(fs, rfs, git_dir, tree_id, compressed)
   tree_id
 }
 
@@ -882,10 +898,14 @@ fn rebase_parse_int64(s : String) -> Int64 {
 ///|
 fn rebase_write_object(
   fs : &@bit.FileSystem,
+  rfs : &@bit.RepoFileSystem,
   git_dir : String,
   id : @bit.ObjectId,
   compressed : Bytes,
 ) -> Unit raise @bit.GitError {
+  // A linked worktree's git dir has no objects/ of its own; write through
+  // to the shared object store (main repo's git dir via "commondir").
+  let git_dir = object_storage_git_dir(rfs, git_dir)
   let hex = id.to_hex()
   let dir = join_path(
     git_dir,
@@ -1210,7 +1230,7 @@ pub async fn rebase_start_with_onto(
   force_rebase? : Bool = false,
   run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
-  let git_dir = join_path(root, ".git")
+  let git_dir = rebase_resolve_git_dir(rfs, root)
   // Check if rebase already in progress
   if is_rebase_in_progress(rfs, git_dir) {
     raise @bit.GitError::InvalidObject(
@@ -1299,7 +1319,7 @@ pub async fn rebase_continue(
   root : String,
   run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
-  let git_dir = join_path(root, ".git")
+  let git_dir = rebase_resolve_git_dir(rfs, root)
   let state = load_rebase_state(rfs, git_dir)
   guard state is Some(s) else {
     raise @bit.GitError::InvalidObject("No rebase in progress")
@@ -1331,7 +1351,7 @@ pub async fn rebase_continue(
     info.message,
   )
   let (new_id, compressed) = @bit.create_commit(new_commit)
-  rebase_write_object(fs, git_dir, new_id, compressed)
+  rebase_write_object(fs, rfs, git_dir, new_id, compressed)
   rebase_update_head(fs, rfs, git_dir, new_id)
   // Update state: move current to done, clear current
   let new_done = s.done.copy()
@@ -1368,7 +1388,7 @@ pub async fn rebase_abort(
   root : String,
   run_filter_cmd? : FilterCmd,
 ) -> Unit raise @bit.GitError {
-  let git_dir = join_path(root, ".git")
+  let git_dir = rebase_resolve_git_dir(rfs, root)
   let state = load_rebase_state(rfs, git_dir)
   guard state is Some(s) else {
     raise @bit.GitError::InvalidObject("No rebase in progress")
@@ -1406,7 +1426,7 @@ pub async fn rebase_skip(
   root : String,
   run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
-  let git_dir = join_path(root, ".git")
+  let git_dir = rebase_resolve_git_dir(rfs, root)
   let state = load_rebase_state(rfs, git_dir)
   guard state is Some(s) else {
     raise @bit.GitError::InvalidObject("No rebase in progress")
@@ -1682,7 +1702,7 @@ async fn rebase_apply_next(
   state : RebaseState,
   run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
-  let git_dir = join_path(root, ".git")
+  let git_dir = rebase_resolve_git_dir(rfs, root)
   let db = ObjectDb::load(rfs, git_dir)
   if state.todo.length() == 0 {
     // All done, finalize rebase
@@ -1779,7 +1799,7 @@ async fn rebase_apply_next(
     }
   }
   // No conflicts - create new commit
-  let new_tree = rebase_write_tree_from_map(fs, git_dir, base_map)
+  let new_tree = rebase_write_tree_from_map(fs, rfs, git_dir, base_map)
   let new_commit = @bit.Commit::new(
     new_tree,
     [base_id],
@@ -1792,7 +1812,7 @@ async fn rebase_apply_next(
     info.message,
   )
   let (new_id, compressed) = @bit.create_commit(new_commit)
-  rebase_write_object(fs, git_dir, new_id, compressed)
+  rebase_write_object(fs, rfs, git_dir, new_id, compressed)
   rebase_update_head(fs, rfs, git_dir, new_id)
   // Update state and continue
   let new_done = state.done.copy()
@@ -1931,7 +1951,8 @@ fn rebase_apply_changes_with_conflicts(
                   let (blob_id, compressed) = @bit.create_blob(content_bytes)
                   rebase_write_object(
                     fs,
-                    join_path(root, ".git"),
+                    rfs,
+                    rebase_resolve_git_dir(rfs, root),
                     blob_id,
                     compressed,
                   )

--- a/modules/bit_lib/src/rebase.mbt
+++ b/modules/bit_lib/src/rebase.mbt
@@ -36,34 +36,36 @@ pub enum RebaseStatus {
 }
 
 ///|
-pub fn fast_forward_to(
+pub async fn fast_forward_to(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
   target : @bit.ObjectId,
+  run_filter_cmd? : FilterCmd,
 ) -> Unit raise @bit.GitError {
   let git_dir = join_path(root, ".git")
   let db = ObjectDb::load(rfs, git_dir)
   let tree_map = rebase_tree_map(db, rfs, target)
   rebase_update_head(fs, rfs, git_dir, target)
-  rebase_write_worktree(fs, db, rfs, root, git_dir, tree_map)
+  rebase_write_worktree_filtered(fs, db, rfs, root, git_dir, tree_map, run_filter_cmd?)
   let entries = rebase_map_to_index(db, rfs, tree_map)
   write_index_entries(fs, git_dir, entries)
 }
 
 ///|
 /// Rebase current HEAD onto upstream commit (linear, no conflicts).
-pub fn rebase_onto(
+pub async fn rebase_onto(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
   upstream : @bit.ObjectId,
+  run_filter_cmd? : FilterCmd,
 ) -> @bit.ObjectId raise @bit.GitError {
   let git_dir = join_path(root, ".git")
   let head = resolve_head_commit(rfs, git_dir)
   match head {
     None => {
-      fast_forward_to(fs, rfs, root, upstream)
+      fast_forward_to(fs, rfs, root, upstream, run_filter_cmd?)
       return upstream
     }
     Some(h) => {
@@ -102,7 +104,7 @@ pub fn rebase_onto(
         parent = new_id
       }
       rebase_update_head(fs, rfs, git_dir, parent)
-      rebase_write_worktree(fs, db, rfs, root, git_dir, base_map)
+      rebase_write_worktree_filtered(fs, db, rfs, root, git_dir, base_map, run_filter_cmd?)
       let entries = rebase_map_to_index(db, rfs, base_map)
       write_index_entries(fs, git_dir, entries)
       parent
@@ -610,6 +612,85 @@ fn rebase_write_worktree_except(
 }
 
 ///|
+/// Same as `rebase_write_worktree`, but also runs the external filter
+/// driver's smudge command (from `.gitattributes`' `filter=name`) on each
+/// blob before writing it, matching git's checkout-time content conversion.
+async fn rebase_write_worktree_filtered(
+  fs : &@bit.FileSystem,
+  db : ObjectDb,
+  rfs : &@bit.RepoFileSystem,
+  root : String,
+  git_dir : String,
+  map : Map[String, TreeEntryInfo],
+  run_filter_cmd? : FilterCmd,
+) -> Unit raise @bit.GitError {
+  let files : Map[String, TreeFileEntry] = Map([])
+  for path, info in map {
+    files[path] = { id: info.id, mode: info.mode }
+  }
+  tree_ops_remove_missing_paths(fs, rfs, root, git_dir, files, false)
+  rebase_write_worktree_except_filtered(
+    fs, db, rfs, root, git_dir, map, [], run_filter_cmd?,
+  )
+}
+
+///|
+/// Same as `rebase_write_worktree_except`, but also runs the external
+/// filter driver's smudge command on each blob before writing it.
+async fn rebase_write_worktree_except_filtered(
+  fs : &@bit.FileSystem,
+  db : ObjectDb,
+  rfs : &@bit.RepoFileSystem,
+  root : String,
+  git_dir : String,
+  map : Map[String, TreeEntryInfo],
+  except : Array[String],
+  run_filter_cmd? : FilterCmd,
+) -> Unit raise @bit.GitError {
+  let autocrlf = read_autocrlf_setting(rfs, git_dir)
+  let core_eol = read_core_eol_setting(rfs, git_dir)
+  let except_set : Map[String, Bool] = Map([])
+  for path in except {
+    except_set[path] = true
+  }
+  for path, info in map {
+    if except_set.contains(path) {
+      continue // Skip conflicting files
+    }
+    let full = join_path(root, path)
+    if is_gitlink_mode_int(info.mode) {
+      fs.mkdir_p(full)
+      continue
+    }
+    if rfs.is_dir(full) {
+      let bit_marker = join_path(full, ".git")
+      if rfs.is_file(bit_marker) || rfs.is_dir(bit_marker) {
+        raise @bit.GitError::InvalidObject(
+          "Refusing to overwrite submodule: \{path}",
+        )
+      }
+    }
+    let obj = db.get(rfs, info.id)
+    match obj {
+      Some(o) => {
+        if o.obj_type != @bit.ObjectType::Blob {
+          raise @bit.GitError::InvalidObject("Object is not a blob")
+        }
+        let dir = rebase_parent_dir(full)
+        fs.mkdir_p(dir)
+        let attrs = resolve_eol_attrs(rfs, root, path)
+        let filtered = apply_filter_smudge(
+          rfs, o.data, attrs, root, git_dir, run_filter_cmd,
+        )
+        let output = smudge_for_checkout(filtered, attrs, autocrlf, core_eol~)
+        fs.write_file(full, output)
+      }
+      None => raise @bit.GitError::InvalidObject("Missing blob object")
+    }
+  }
+}
+
+///|
 fn rebase_map_to_index(
   db : ObjectDb,
   fs : &@bit.RepoFileSystem,
@@ -1108,24 +1189,26 @@ pub fn clear_rebase_state(
 
 ///|
 /// Start a rebase operation. Returns RebaseResult indicating status.
-pub fn rebase_start(
+pub async fn rebase_start(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
   upstream : @bit.ObjectId,
+  run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
-  rebase_start_with_onto(fs, rfs, root, upstream, upstream)
+  rebase_start_with_onto(fs, rfs, root, upstream, upstream, run_filter_cmd?)
 }
 
 ///|
 /// Start a rebase operation with an explicit new base.
-pub fn rebase_start_with_onto(
+pub async fn rebase_start_with_onto(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
   onto : @bit.ObjectId,
   upstream : @bit.ObjectId,
   force_rebase? : Bool = false,
+  run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
   let git_dir = join_path(root, ".git")
   // Check if rebase already in progress
@@ -1137,7 +1220,7 @@ pub fn rebase_start_with_onto(
   let head = resolve_head_commit(rfs, git_dir)
   match head {
     None => {
-      fast_forward_to(fs, rfs, root, onto)
+      fast_forward_to(fs, rfs, root, onto, run_filter_cmd?)
       return {
         status: RebaseStatus::Complete,
         commit_id: Some(onto),
@@ -1159,7 +1242,7 @@ pub fn rebase_start_with_onto(
       if chain.length() == 0 {
         if !force_rebase {
           if h != onto {
-            fast_forward_to(fs, rfs, root, onto)
+            fast_forward_to(fs, rfs, root, onto, run_filter_cmd?)
             return {
               status: RebaseStatus::Complete,
               commit_id: Some(onto),
@@ -1199,21 +1282,22 @@ pub fn rebase_start_with_onto(
       save_rebase_state(fs, git_dir, state)
       // Move HEAD to the new base before applying commits.
       rebase_update_head(fs, rfs, git_dir, onto)
-      rebase_write_worktree(fs, db, rfs, root, git_dir, onto_map)
+      rebase_write_worktree_filtered(fs, db, rfs, root, git_dir, onto_map, run_filter_cmd?)
       let entries = rebase_map_to_index(db, rfs, onto_map)
       write_index_entries(fs, git_dir, entries)
       // Start applying commits
-      rebase_apply_next(fs, rfs, root, state)
+      rebase_apply_next(fs, rfs, root, state, run_filter_cmd?)
     }
   }
 }
 
 ///|
 /// Continue rebase after resolving conflicts.
-pub fn rebase_continue(
+pub async fn rebase_continue(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
+  run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
   let git_dir = join_path(root, ".git")
   let state = load_rebase_state(rfs, git_dir)
@@ -1273,15 +1357,16 @@ pub fn rebase_continue(
   }
   save_rebase_state(fs, git_dir, new_state)
   // Continue with next commits
-  rebase_apply_next(fs, rfs, root, new_state)
+  rebase_apply_next(fs, rfs, root, new_state, run_filter_cmd?)
 }
 
 ///|
 /// Abort the current rebase and restore original state.
-pub fn rebase_abort(
+pub async fn rebase_abort(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
+  run_filter_cmd? : FilterCmd,
 ) -> Unit raise @bit.GitError {
   let git_dir = join_path(root, ".git")
   let state = load_rebase_state(rfs, git_dir)
@@ -1302,7 +1387,7 @@ pub fn rebase_abort(
   // Restore worktree to original HEAD
   let db = ObjectDb::load(rfs, git_dir)
   let tree_map = rebase_tree_map(db, rfs, s.orig_head)
-  rebase_write_worktree(fs, db, rfs, root, git_dir, tree_map) catch {
+  rebase_write_worktree_filtered(fs, db, rfs, root, git_dir, tree_map, run_filter_cmd?) catch {
     _ => ()
   }
   let entries = rebase_map_to_index(db, rfs, tree_map) catch { _ => [] }
@@ -1315,10 +1400,11 @@ pub fn rebase_abort(
 
 ///|
 /// Skip the current commit and continue rebase.
-pub fn rebase_skip(
+pub async fn rebase_skip(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
+  run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
   let git_dir = join_path(root, ".git")
   let state = load_rebase_state(rfs, git_dir)
@@ -1354,11 +1440,11 @@ pub fn rebase_skip(
     raise @bit.GitError::InvalidObject("No HEAD commit")
   }
   let tree_map = rebase_tree_map(db, rfs, h)
-  rebase_write_worktree(fs, db, rfs, root, git_dir, tree_map)
+  rebase_write_worktree_filtered(fs, db, rfs, root, git_dir, tree_map, run_filter_cmd?)
   let entries = rebase_map_to_index(db, rfs, tree_map)
   write_index_entries(fs, git_dir, entries)
   // Continue with next commits
-  rebase_apply_next(fs, rfs, root, new_state)
+  rebase_apply_next(fs, rfs, root, new_state, run_filter_cmd?)
 }
 
 ///|
@@ -1589,11 +1675,12 @@ fn rebase_changes_already_applied(
 
 ///|
 /// Apply the next commit in the todo list.
-fn rebase_apply_next(
+async fn rebase_apply_next(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
   state : RebaseState,
+  run_filter_cmd? : FilterCmd,
 ) -> RebaseResult raise @bit.GitError {
   let git_dir = join_path(root, ".git")
   let db = ObjectDb::load(rfs, git_dir)
@@ -1605,7 +1692,7 @@ fn rebase_apply_next(
       raise @bit.GitError::InvalidObject("No HEAD after rebase")
     }
     let final_tree_map = rebase_tree_map(db, rfs, final_id)
-    rebase_write_worktree(fs, db, rfs, root, git_dir, final_tree_map)
+    rebase_write_worktree_filtered(fs, db, rfs, root, git_dir, final_tree_map, run_filter_cmd?)
     let final_entries = rebase_map_to_index(db, rfs, final_tree_map)
     write_index_entries(fs, git_dir, final_entries)
     clear_rebase_state(fs, rfs, git_dir)
@@ -1656,7 +1743,7 @@ fn rebase_apply_next(
       rewritten: state.rewritten,
     }
     save_rebase_state(fs, git_dir, new_state)
-    return rebase_apply_next(fs, rfs, root, new_state)
+    return rebase_apply_next(fs, rfs, root, new_state, run_filter_cmd?)
   }
   // Try to apply changes, detecting conflicts
   let conflicts = rebase_apply_changes_with_conflicts(
@@ -1679,8 +1766,8 @@ fn rebase_apply_next(
     }
     save_rebase_state(fs, git_dir, new_state)
     // Write partially merged state to worktree and index (skip conflicting files)
-    rebase_write_worktree_except(
-      fs, db, rfs, root, git_dir, base_map, conflicts,
+    rebase_write_worktree_except_filtered(
+      fs, db, rfs, root, git_dir, base_map, conflicts, run_filter_cmd?,
     )
     let entries = rebase_map_to_index(db, rfs, base_map)
     write_index_entries(fs, git_dir, entries)
@@ -1729,7 +1816,7 @@ fn rebase_apply_next(
   }
   save_rebase_state(fs, git_dir, new_state)
   // Recursively apply next
-  rebase_apply_next(fs, rfs, root, new_state)
+  rebase_apply_next(fs, rfs, root, new_state, run_filter_cmd?)
 }
 
 ///|

--- a/modules/bit_lib/src/rebase_interactive.mbt
+++ b/modules/bit_lib/src/rebase_interactive.mbt
@@ -1751,7 +1751,7 @@ fn interactive_cherry_pick(
         info.message,
       )
       let (new_id, compressed) = @bit.create_commit(new_commit)
-      rebase_write_object(fs, git_dir, new_id, compressed)
+      rebase_write_object(fs, rfs, git_dir, new_id, compressed)
       rebase_update_head(fs, rfs, git_dir, new_id)
       let tree_map = rebase_tree_map_from_tree(db, rfs, info.tree)
       rebase_write_worktree(fs, db, rfs, root, git_dir, tree_map)
@@ -1801,7 +1801,7 @@ fn interactive_cherry_pick(
     }
   }
   // Create new commit
-  let new_tree = rebase_write_tree_from_map(fs, git_dir, base_map)
+  let new_tree = rebase_write_tree_from_map(fs, rfs, git_dir, base_map)
   let new_commit = @bit.Commit::new(
     new_tree,
     [base_id],
@@ -1814,7 +1814,7 @@ fn interactive_cherry_pick(
     info.message,
   )
   let (new_id, compressed) = @bit.create_commit(new_commit)
-  rebase_write_object(fs, git_dir, new_id, compressed)
+  rebase_write_object(fs, rfs, git_dir, new_id, compressed)
   rebase_update_head(fs, rfs, git_dir, new_id)
   // Update worktree + index
   rebase_write_worktree(fs, db, rfs, root, git_dir, base_map)
@@ -1853,7 +1853,7 @@ fn interactive_amend_head_message(
     new_message,
   )
   let (new_id, compressed) = @bit.create_commit(new_commit)
-  rebase_write_object(fs, git_dir, new_id, compressed)
+  rebase_write_object(fs, rfs, git_dir, new_id, compressed)
   rebase_update_head(fs, rfs, git_dir, new_id)
 }
 
@@ -1927,7 +1927,7 @@ async fn interactive_squash_into_head(
     }
   }
   // Create new commit replacing HEAD with squashed tree
-  let new_tree = rebase_write_tree_from_map(fs, git_dir, base_map)
+  let new_tree = rebase_write_tree_from_map(fs, rfs, git_dir, base_map)
   let new_commit = @bit.Commit::new(
     new_tree,
     head_info.parents,
@@ -1940,7 +1940,7 @@ async fn interactive_squash_into_head(
     final_msg,
   )
   let (new_id, compressed) = @bit.create_commit(new_commit)
-  rebase_write_object(fs, git_dir, new_id, compressed)
+  rebase_write_object(fs, rfs, git_dir, new_id, compressed)
   rebase_update_head(fs, rfs, git_dir, new_id)
   // Update worktree + index
   rebase_write_worktree(fs, db, rfs, root, git_dir, base_map)
@@ -1996,7 +1996,7 @@ pub async fn interactive_rebase_continue_impl(
         head_info.message,
       )
       let (new_id, compressed) = @bit.create_commit(new_commit)
-      rebase_write_object(fs, git_dir, new_id, compressed)
+      rebase_write_object(fs, rfs, git_dir, new_id, compressed)
       rebase_update_head(fs, rfs, git_dir, new_id)
     }
     // Record commit mapping for update-refs after amend
@@ -2044,7 +2044,7 @@ pub async fn interactive_rebase_continue_impl(
       info.message,
     )
     let (new_id, compressed) = @bit.create_commit(new_commit)
-    rebase_write_object(fs, git_dir, new_id, compressed)
+    rebase_write_object(fs, rfs, git_dir, new_id, compressed)
     rebase_update_head(fs, rfs, git_dir, new_id)
     // Record commit mapping for update-refs
     if s.update_refs.length() > 0 {

--- a/modules/bit_lib/src/rebase_test.mbt
+++ b/modules/bit_lib/src/rebase_test.mbt
@@ -10,7 +10,7 @@ fn setup_repo_rebase() -> @bit.TestFs {
 }
 
 ///|
-test "rebase: start with onto rebases commits onto new base" {
+async test "rebase: start with onto rebases commits onto new base" {
   let fs = setup_repo_rebase()
   fs.write_string("/repo/a.txt", "A\n")
   add_paths(fs, fs, "/repo", ["a.txt"])
@@ -68,7 +68,7 @@ test "rebase: start with onto rebases commits onto new base" {
 }
 
 ///|
-test "rebase: start fast-forwards when HEAD is behind upstream" {
+async test "rebase: start fast-forwards when HEAD is behind upstream" {
   let fs = setup_repo_rebase()
   fs.write_string("/repo/a.txt", "A\n")
   add_paths(fs, fs, "/repo", ["a.txt"])
@@ -96,7 +96,7 @@ test "rebase: start fast-forwards when HEAD is behind upstream" {
 }
 
 ///|
-test "rebase: start skips commit whose patch already exists upstream" {
+async test "rebase: start skips commit whose patch already exists upstream" {
   let fs = setup_repo_rebase()
   let base_content = "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
   fs.write_string("/repo/stuff", base_content)

--- a/modules/bit_lib/src/worktree_admin.mbt
+++ b/modules/bit_lib/src/worktree_admin.mbt
@@ -84,6 +84,30 @@ pub fn is_branch_checked_out(
 }
 
 ///|
+/// Check if a branch is checked out in a worktree other than `root` (e.g.
+/// after `git worktree add -f` lets two worktrees share one branch, and the
+/// current worktree happens to be one of them). Returns the other
+/// worktree's path if found, None otherwise.
+pub fn is_branch_checked_out_elsewhere(
+  fs : &@bit.RepoFileSystem,
+  root : String,
+  branch : String,
+) -> String? raise @bit.GitError {
+  let normalized_root = normalize_path(root)
+  let worktrees = list_worktrees(fs, root)
+  for wt in worktrees {
+    match wt.branch {
+      Some(b) =>
+        if b == branch && normalize_path(wt.path) != normalized_root {
+          return Some(wt.path)
+        }
+      None => continue
+    }
+  }
+  None
+}
+
+///|
 /// Create a new linked worktree.
 pub fn create_worktree(
   fs : &@bit.FileSystem,

--- a/modules/bitx_rebase_ai/src/rebase_ai.mbt
+++ b/modules/bitx_rebase_ai/src/rebase_ai.mbt
@@ -780,7 +780,7 @@ fn normalized_round_limit(options : AiRebaseOptions) -> Int {
 }
 
 ///|
-fn continue_until_non_conflict(
+async fn continue_until_non_conflict(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
@@ -820,7 +820,7 @@ fn continue_until_non_conflict(
 }
 
 ///|
-pub fn ai_rebase_start(
+pub async fn ai_rebase_start(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
@@ -835,7 +835,7 @@ pub fn ai_rebase_start(
 }
 
 ///|
-pub fn ai_rebase_continue(
+pub async fn ai_rebase_continue(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
@@ -858,7 +858,7 @@ pub fn ai_rebase_continue(
 }
 
 ///|
-pub fn ai_rebase_skip(
+pub async fn ai_rebase_skip(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,
@@ -870,7 +870,7 @@ pub fn ai_rebase_skip(
 }
 
 ///|
-pub fn ai_rebase_abort(
+pub async fn ai_rebase_abort(
   fs : &@bit.FileSystem,
   rfs : &@bit.RepoFileSystem,
   root : String,

--- a/tools/verify-lib-js-treeshake.mjs
+++ b/tools/verify-lib-js-treeshake.mjs
@@ -3,7 +3,11 @@ import { gzipSync } from "node:zlib";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-const MAX_MINIMAL_RAW_BYTES = 161_000;
+// Rebase's gitattributes filter-driver support requires the rebase JS
+// exports to be async (js_wrap_error_async), which pulls in more of the
+// async plumbing even for the minimal bundle. Raised from 161_000 to give
+// headroom above the current actual size (~162_215 bytes).
+const MAX_MINIMAL_RAW_BYTES = 163_000;
 const MAX_MINIMAL_GZIP_BYTES = 40_000;
 const MAX_MINIMAL_RATIO = 0.70;
 


### PR DESCRIPTION
## Summary

Follow-up to #161, closing out the remaining `t3400-rebase.sh` failures from #88. The suite is now **39/39** (was 34/39).

- **`git diff <blob> <blob>` two-blob comparison form** (`f35c2f93`): the two-revision branch of `diff`'s argument parser routed every pair of resolved revisions through the tree-diff range path (`rev0..rev1`), which only accepts commit/tree ids and rejects blob ids with "unsupported diff range". Detect when both operands resolve to blob objects and diff their contents directly instead. Fixes test 25 ("Rebase a commit that sprinkles CRs in"), whose final assertion is exactly this two-blob diff form — the rebase itself already worked correctly.

- **`.gitattributes` filter-driver smudge support for rebase** (`ffaacec6`): only the "clean" direction of a `filter=<name>` gitattributes filter (worktree → blob, used by `git add`) was implemented anywhere in the codebase. The "smudge" direction (blob → worktree) was never run, so a branch with a custom clean/smudge filter lost its smudge conversion whenever non-interactive rebase rewrote the worktree. Threads an async `run_filter_cmd` callback through the non-interactive rebase engine specifically (spawning the filter subprocess is inherently async here), leaving interactive rebase's separate code path untouched. Fixes test 31 ("rebase --apply and .gitattributes").

- **Worktree git-dir resolution for non-interactive rebase** (`24d008e5`): every non-interactive rebase entry point recomputed `git_dir` as a naive `join_path(root, ".git")`. For a linked worktree, `.git` is a *file* (a `gitdir:` pointer), not a directory, so the first `is_dir`/path-append under it threw `IOError("Not a directory")` — masked whenever the rebase didn't need worktree-local state, which is why plain worktree tests (no subdirectory step) happened to pass. Also fixes `rebase_write_object` writing new commit/tree objects to a bogus worktree-local `objects/` dir instead of the shared store. Fixes test 38 ("rebase when inside worktree subdirectory").

  Fixing that git-dir resolution exposed a second, narrower bug: checking out a branch force-shared across two worktrees (`git worktree add -f`) silently succeeded when it should refuse — the in-use check only looked at the *first* worktree it found and short-circuited whenever the target matched the current worktree's own branch. Added `is_branch_checked_out_elsewhere` and scoped its use carefully: plain `bit checkout <current-branch>` stays an unconditional no-op (confirmed required by `t2400-worktree-add.sh` test 19), while rebase's two-arg "switch to branch" step gets an unconditional check since it's about to rewrite that branch's history. Fixes test 34 ("switch to branch checked out elsewhere fails").

## Test plan

- [x] `t3400-rebase.sh`: 39/39 (was 34/39)
- [x] `t2400-worktree-add.sh` test 19 ("not die on re-checking out current branch") passes
- [x] `t2060-switch.sh`, `t2014-checkout-switch.sh`: no new regressions vs. baseline
- [x] `t7201-co.sh`, `t3404-rebase-interactive.sh`: baseline comparison confirmed pre-existing failures are unrelated to these changes
- [x] `t5520-pull.sh`: 80/80
- [x] `moon check`: clean
- [x] `moon test` for `bit_lib`/`bitx_rebase_ai` packages: 305/305 (full-workspace `moon test` hits a pre-existing moonc linker ICE in this environment, reproduces on unmodified baseline too, unrelated to these changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBW8Pdq2ZfWVAfTZFsTnVo)_