### PR TITLE
fix(repo): resolve index mtimes through filesystem

### DIFF
--- a/docs/demo/storage.js
+++ b/docs/demo/storage.js
@@ -125,6 +125,7 @@ const snapshotToSummary = (snapshot) => {
 
 export const createSnapshotHost = () => {
   const files = new Map();
+  const mtimes = new Map();
   const dirs = new Set(["/"]);
 
   const host = {
@@ -135,6 +136,11 @@ export const createSnapshotHost = () => {
       const normalized = normalizePath(path);
       ensureDirectoryChain(dirs, parentDir(normalized));
       files.set(normalized, cloneBytes(content));
+      const now = Date.now();
+      mtimes.set(normalized, [
+        Math.floor(now / 1000),
+        (now % 1000) * 1_000_000,
+      ]);
     },
     writeString(path, content) {
       host.writeFile(path, encoder.encode(String(content)));
@@ -144,6 +150,7 @@ export const createSnapshotHost = () => {
       if (!files.delete(normalized)) {
         throw new Error(`File not found: ${normalized}`);
       }
+      mtimes.delete(normalized);
     },
     removeDir(path) {
       const normalized = normalizePath(path);
@@ -197,8 +204,17 @@ export const createSnapshotHost = () => {
     isFile(path) {
       return files.has(normalizePath(path));
     },
+    mtime(path) {
+      const normalized = normalizePath(path);
+      const value = mtimes.get(normalized);
+      if (!value) {
+        throw new Error(`File not found: ${normalized}`);
+      }
+      return value;
+    },
     reset() {
       files.clear();
+      mtimes.clear();
       dirs.clear();
       dirs.add("/");
     },
@@ -211,6 +227,11 @@ export const createSnapshotHost = () => {
         const normalized = normalizePath(file.path);
         ensureDirectoryChain(dirs, parentDir(normalized));
         files.set(normalized, cloneBytes(file.data));
+        const now = Date.now();
+        mtimes.set(normalized, [
+          Math.floor(now / 1000),
+          (now % 1000) * 1_000_000,
+        ]);
       }
     },
     exportSnapshot() {

--- a/modules/bit/cmd/bit/osfs.mbt
+++ b/modules/bit/cmd/bit/osfs.mbt
@@ -70,3 +70,11 @@ pub impl @bitcore.RepoFileSystem for OsFs with fn is_file(_self, path) {
     _ => false
   }
 }
+
+///|
+pub impl @bitcore.RepoFileSystem for OsFs with fn mtime(self, path) {
+  match @bitio.worktree_entry_meta_sync(self, path) {
+    Some(meta) => meta.mtime()
+    None => raise @bitcore.GitError::IoError("Unable to stat path: \{path}")
+  }
+}

--- a/modules/bit/cmd/git-bit/moon.pkg
+++ b/modules/bit/cmd/git-bit/moon.pkg
@@ -5,6 +5,7 @@ import {
   "mizchi/bit_types" @types,
   "mizchi/bit_config" @config_parse,
   "mizchi/bit_hash" @bithash,
+  "mizchi/bit_io" @bitio,
   "mizchi/bit_lib" @bitlib,
   "mizchi/bit_repo_ops" @bitrepo,
   "mizchi/bit_utils" @string_utils,

--- a/modules/bit/cmd/git-bit/osfs.mbt
+++ b/modules/bit/cmd/git-bit/osfs.mbt
@@ -70,3 +70,11 @@ pub impl @bitcore.RepoFileSystem for OsFs with fn is_file(_self, path) {
     _ => false
   }
 }
+
+///|
+pub impl @bitcore.RepoFileSystem for OsFs with fn mtime(self, path) {
+  match @bitio.worktree_entry_meta_sync(self, path) {
+    Some(meta) => meta.mtime()
+    None => raise @bitcore.GitError::IoError("Unable to stat path: \{path}")
+  }
+}

--- a/modules/bit/pkg.generated.mbti
+++ b/modules/bit/pkg.generated.mbti
@@ -61,7 +61,7 @@ pub fn sha256_prefix(Bytes, Int) -> @bit_object.ObjectId
 
 pub fn verify_tree_entry_name(String) -> Unit raise @bit_object.GitError
 
-pub fn write_git_metadata(@bit_repo.ObjectStore, @bit_object.ObjectId, String, String, &@bit_types.FileSystem, String) -> Unit raise @bit_object.GitError
+pub fn write_git_metadata(@bit_repo.ObjectStore, @bit_object.ObjectId, String, String, &@bit_types.FileSystem, String, &@bit_types.RepoFileSystem) -> Unit raise @bit_object.GitError
 
 // Errors
 

--- a/modules/bit_core/src/pkg.generated.mbti
+++ b/modules/bit_core/src/pkg.generated.mbti
@@ -61,7 +61,7 @@ pub fn sha256_prefix(Bytes, Int) -> @bit_object.ObjectId
 
 pub fn verify_tree_entry_name(String) -> Unit raise @bit_object.GitError
 
-pub fn write_git_metadata(@bit_repo.ObjectStore, @bit_object.ObjectId, String, String, &@bit_types.FileSystem, String) -> Unit raise @bit_object.GitError
+pub fn write_git_metadata(@bit_repo.ObjectStore, @bit_object.ObjectId, String, String, &@bit_types.FileSystem, String, &@bit_types.RepoFileSystem) -> Unit raise @bit_object.GitError
 
 // Errors
 

--- a/modules/bit_io/src/test_fs.mbt
+++ b/modules/bit_io/src/test_fs.mbt
@@ -180,6 +180,11 @@ pub impl RepoFileSystem for TestFs with fn is_file(self, path) {
 }
 
 ///|
+pub impl RepoFileSystem for TestFs with fn mtime(_self, _path) {
+  (0, 0)
+}
+
+///|
 fn string_to_bytes(s : String) -> Bytes {
   let out : Array[Byte] = []
   for c in s {

--- a/modules/bit_io_native/src/upload_pack_process.mbt
+++ b/modules/bit_io_native/src/upload_pack_process.mbt
@@ -1281,7 +1281,9 @@ pub async fn clone_process_to_fs(
           fs, root, refname, commit_id, remote, filter,
         )
       } else if effective_no_checkout {
-        @bit.write_git_metadata(store, commit_id, refname, remote, fs, root)
+        @bit.write_git_metadata(
+          store, commit_id, refname, remote, fs, root, rfs,
+        )
       } else {
         @bit.materialize_clone_to_fs(
           store, commit_id, refname, remote, fs, root, rfs,

--- a/modules/bit_lib/src/js_exports_wbtest.mbt
+++ b/modules/bit_lib/src/js_exports_wbtest.mbt
@@ -381,6 +381,20 @@ test "js exports: memory host supports local git flow" {
 }
 
 ///|
+test "js exports: memory host exposes file mtime" {
+  let host_id = js_create_memory_host()
+  js_exports_unwrap_ok(
+    "hostWriteString",
+    js_host_write_string(host_id, "/file.txt", "content"),
+  )
+  let fs = js_make_host_fs(host_id)
+  let (seconds, nanoseconds) = @bit.RepoFileSystem::mtime(fs, "/file.txt")
+  assert_true(seconds > 0)
+  assert_true(nanoseconds >= 0 && nanoseconds < 1_000_000_000)
+  js_destroy_host(host_id)
+}
+
+///|
 test "js exports: signed commit stores gpgsig header" {
   let host_id = js_create_memory_host()
 

--- a/modules/bit_lib/src/js_host_bridge.mbt
+++ b/modules/bit_lib/src/js_host_bridge.mbt
@@ -240,6 +240,38 @@ extern "js" fn lib_js_host_is_file(host_id : Int, path : String) -> Bool =
   #| }
 
 ///|
+extern "js" fn lib_js_host_mtime(host_id : Int, path : String) -> Array[Int]? =
+  #| (hostId, path) => {
+  #|   const state = globalThis.__bitGitJsState ??= { nextHostId: 1, hosts: new Map() };
+  #|   const host = state.hosts.get(hostId);
+  #|   if (!host) {
+  #|     globalThis.__bitGitJsLastError = `bit-git js host ${hostId} not found`;
+  #|     return { $tag: 0 };
+  #|   }
+  #|   if (typeof host.mtime !== 'function') {
+  #|     globalThis.__bitGitJsLastError = 'bit-git js host.mtime(path) is required';
+  #|     return { $tag: 0 };
+  #|   }
+  #|   try {
+  #|     const value = host.mtime(path);
+  #|     if (!Array.isArray(value) || value.length !== 2) {
+  #|       globalThis.__bitGitJsLastError = 'bit-git js host.mtime(path) must return [seconds, nanoseconds]';
+  #|       return { $tag: 0 };
+  #|     }
+  #|     const seconds = Number(value[0]);
+  #|     const nanoseconds = Number(value[1]);
+  #|     if (!Number.isInteger(seconds) || !Number.isInteger(nanoseconds)) {
+  #|       globalThis.__bitGitJsLastError = 'bit-git js host.mtime(path) must return integer seconds and nanoseconds';
+  #|       return { $tag: 0 };
+  #|     }
+  #|     return { $tag: 1, _0: [seconds, nanoseconds] };
+  #|   } catch (error) {
+  #|     globalThis.__bitGitJsLastError = String(error?.message ?? error);
+  #|     return { $tag: 0 };
+  #|   }
+  #| }
+
+///|
 extern "js" fn lib_js_create_memory_host() -> Int =
   #| () => {
   #|   const state = globalThis.__bitGitJsState ??= { nextHostId: 1, hosts: new Map() };
@@ -281,6 +313,7 @@ extern "js" fn lib_js_create_memory_host() -> Int =
   #|   };
   #|   const createHost = () => {
   #|     const files = new Map();
+  #|     const mtimes = new Map();
   #|     const dirs = new Set(['/']);
   #|     return {
   #|       mkdirP(path) {
@@ -290,6 +323,11 @@ extern "js" fn lib_js_create_memory_host() -> Int =
   #|         const normalized = normalizePath(path);
   #|         ensureDirs(dirs, parentDir(normalized));
   #|         files.set(normalized, Uint8Array.from(content));
+  #|         const now = Date.now();
+  #|         mtimes.set(normalized, [
+  #|           Math.floor(now / 1000),
+  #|           (now % 1000) * 1_000_000,
+  #|         ]);
   #|       },
   #|       writeString(path, content) {
   #|         this.writeFile(path, encoder.encode(String(content)));
@@ -299,6 +337,7 @@ extern "js" fn lib_js_create_memory_host() -> Int =
   #|         if (!files.delete(normalized)) {
   #|           throw new Error(`File not found: ${normalized}`);
   #|         }
+  #|         mtimes.delete(normalized);
   #|       },
   #|       removeDir(path) {
   #|         const normalized = normalizePath(path);
@@ -348,6 +387,14 @@ extern "js" fn lib_js_create_memory_host() -> Int =
   #|       },
   #|       isFile(path) {
   #|         return files.has(normalizePath(path));
+  #|       },
+  #|       mtime(path) {
+  #|         const normalized = normalizePath(path);
+  #|         const value = mtimes.get(normalized);
+  #|         if (!value) {
+  #|           throw new Error(`File not found: ${normalized}`);
+  #|         }
+  #|         return value;
   #|       },
   #|       readString(path) {
   #|         return decoder.decode(this.readFile(path));
@@ -463,4 +510,12 @@ impl @bit.RepoFileSystem for LibJsHostFs with fn is_dir(self, path) {
 ///|
 impl @bit.RepoFileSystem for LibJsHostFs with fn is_file(self, path) {
   lib_js_host_is_file(self.host_id, path)
+}
+
+///|
+impl @bit.RepoFileSystem for LibJsHostFs with fn mtime(self, path) {
+  match lib_js_host_mtime(self.host_id, path) {
+    Some(value) => (value[0], value[1])
+    None => raise @bit.GitError::IoError(js_host_error_message())
+  }
 }

--- a/modules/bit_osfs/moon.mod
+++ b/modules/bit_osfs/moon.mod
@@ -4,6 +4,7 @@ version = "0.45.5"
 
 import {
   "mizchi/bit_core@0.45.5",
+  "mizchi/bit_io@0.45.5",
   "mizchi/bit_object@0.45.5",
   "mizchi/bit_types@0.45.5",
   "moonbitlang/x@0.4.40",

--- a/modules/bit_osfs/src/moon.pkg
+++ b/modules/bit_osfs/src/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "mizchi/bit_core" @bit,
+  "mizchi/bit_io" @io,
   "mizchi/bit_object" @object,
   "mizchi/bit_types" @types,
   "moonbitlang/core/debug",

--- a/modules/bit_osfs/src/osfs.mbt
+++ b/modules/bit_osfs/src/osfs.mbt
@@ -106,3 +106,11 @@ pub impl @bit.RepoFileSystem for OsFs with fn is_file(_self, path) {
     _ => false
   }
 }
+
+///|
+pub impl @bit.RepoFileSystem for OsFs with fn mtime(self, path) {
+  match @io.worktree_entry_meta_sync(self, path) {
+    Some(meta) => meta.mtime()
+    None => raise @bit.GitError::IoError("Unable to stat path: \{path}")
+  }
+}

--- a/modules/bit_protocol/src/upload_pack_http_common.mbt
+++ b/modules/bit_protocol/src/upload_pack_http_common.mbt
@@ -313,7 +313,9 @@ pub async fn clone_to_fs_with_http(
       None => ()
       Some((refname, commit_id)) =>
         if no_checkout {
-          @bit.write_git_metadata(store, commit_id, refname, remote, fs, root)
+          @bit.write_git_metadata(
+            store, commit_id, refname, remote, fs, root, rfs,
+          )
         } else {
           @bit.materialize_clone_to_fs(
             store, commit_id, refname, remote, fs, root, rfs,

--- a/modules/bit_repo/src/materialize.mbt
+++ b/modules/bit_repo/src/materialize.mbt
@@ -11,7 +11,7 @@ pub fn materialize_clone_to_fs(
   rfs : &@types.RepoFileSystem,
 ) -> Unit raise @object.GitError {
   checkout_commit_to_fs(store, commit_id, fs, root, rfs)
-  write_git_metadata(store, commit_id, refname, remote_url, fs, root)
+  write_git_metadata(store, commit_id, refname, remote_url, fs, root, rfs)
 }
 
 ///|
@@ -22,6 +22,7 @@ pub fn write_git_metadata(
   remote_url : String,
   fs : &@types.FileSystem,
   root : String,
+  rfs : &@types.RepoFileSystem,
 ) -> Unit raise @object.GitError {
   let git_dir = join_path(root, ".git")
   fs.mkdir_p(git_dir)
@@ -35,7 +36,7 @@ pub fn write_git_metadata(
   write_config(fs, git_dir, remote_url)
   write_packed_refs(fs, git_dir)
   write_alternates(fs, git_dir)
-  write_index_v2(store, fs, git_dir, commit_id, root)
+  write_index_v2(store, fs, rfs, git_dir, commit_id, root)
 }
 
 ///|
@@ -105,6 +106,7 @@ fn write_alternates(
 fn write_index_v2(
   store : ObjectStore,
   fs : &@types.FileSystem,
+  rfs : &@types.RepoFileSystem,
   git_dir : String,
   commit_id : @object.ObjectId,
   root : String,
@@ -121,11 +123,11 @@ fn write_index_v2(
   push_u32_be(out, 2)
   push_u32_be(out, entries.length())
   for e in entries {
-    // Stat the file to get actual mtime
-    let full_path = join_path(root, e.path)
-    let (mtime_sec, mtime_nsec) = match @io.lstat_entry_meta(full_path) {
-      Some(meta) => meta.mtime()
-      None => (0, 0)
+    // Gitlinks represent submodule directories, not files we can stat here.
+    let (mtime_sec, mtime_nsec) = if e.mode == 0o160000 {
+      (0, 0)
+    } else {
+      rfs.mtime(join_path(root, e.path))
     }
     // Git index v2 entry format (62 bytes fixed + variable name):
     // ctime_sec (4) + ctime_nsec (4)

--- a/modules/bit_repo/src/materialize_wbtest.mbt
+++ b/modules/bit_repo/src/materialize_wbtest.mbt
@@ -1,10 +1,98 @@
 ///| Reproduction test for hq clone index ordering bug.
 
 ///|
+priv struct IndexMtimeFs {
+  inner : @io.TestFs
+  mtime : (Int, Int)?
+}
+
+///|
+impl @types.RepoFileSystem for IndexMtimeFs with fn read_file(self, path) {
+  self.inner.read_file(path)
+}
+
+///|
+impl @types.RepoFileSystem for IndexMtimeFs with fn readdir(self, path) {
+  self.inner.readdir(path)
+}
+
+///|
+impl @types.RepoFileSystem for IndexMtimeFs with fn is_dir(self, path) {
+  self.inner.is_dir(path)
+}
+
+///|
+impl @types.RepoFileSystem for IndexMtimeFs with fn is_file(self, path) {
+  self.inner.is_file(path)
+}
+
+///|
+impl @types.RepoFileSystem for IndexMtimeFs with fn mtime(self, _path) {
+  match self.mtime {
+    Some(value) => value
+    None => raise @object.GitError::IoError("mtime must not be queried")
+  }
+}
+
+///|
+test "write_index_v2 obtains mtimes from the repository filesystem" {
+  let (store, commit_id) = build_commit_for_prefix_like_paths_wbtest()
+  let fs = @io.TestFs::new()
+  let rfs : IndexMtimeFs = { inner: fs, mtime: Some((0x01020304, 0x05060708)) }
+  write_index_v2(store, fs, rfs, "/repo/.git", commit_id, "/repo")
+  let index = fs.read_file("/repo/.git/index")
+  @test.assert_eq(read_u32_be_wbtest(index, 12), 0x01020304)
+  @test.assert_eq(read_u32_be_wbtest(index, 16), 0x05060708)
+  @test.assert_eq(read_u32_be_wbtest(index, 20), 0x01020304)
+  @test.assert_eq(read_u32_be_wbtest(index, 24), 0x05060708)
+}
+
+///|
+test "write_index_v2 keeps zero mtimes for gitlinks" {
+  let store = ObjectStore::new()
+  let gitlink_id = @object.hash_object_content(
+    @object.ObjectType::Commit,
+    @utf8.encode("submodule"),
+  )
+  let tree_raw = @object.serialize_tree([
+    @object.TreeEntry::new("160000", "submodule", gitlink_id),
+  ])
+  let tree_id = @object.hash_object_content(@object.ObjectType::Tree, tree_raw)
+  let commit = @object.Commit::new(
+    tree_id,
+    [],
+    "Test <test@example.com>",
+    1700000000L,
+    "+0000",
+    "Test <test@example.com>",
+    1700000000L,
+    "+0000",
+    "gitlink\n",
+  )
+  let commit_raw = @object.serialize_commit_content(commit)
+  let commit_id = @object.hash_object_content(
+    @object.ObjectType::Commit,
+    commit_raw,
+  )
+  store.add_objects([
+    @object.PackObject::new(@object.ObjectType::Tree, tree_raw),
+    @object.PackObject::new(@object.ObjectType::Commit, commit_raw),
+  ])
+  let fs = @io.TestFs::new()
+  let rfs : IndexMtimeFs = { inner: fs, mtime: None }
+  write_index_v2(store, fs, rfs, "/repo/.git", commit_id, "/repo")
+  let index = fs.read_file("/repo/.git/index")
+  @test.assert_eq(read_u32_be_wbtest(index, 12), 0)
+  @test.assert_eq(read_u32_be_wbtest(index, 16), 0)
+  @test.assert_eq(read_u32_be_wbtest(index, 20), 0)
+  @test.assert_eq(read_u32_be_wbtest(index, 24), 0)
+}
+
+///|
 test "write_index_v2 writes Git lexical path order" {
   let (store, commit_id) = build_commit_for_index_order_wbtest()
   let fs = @io.TestFs::new()
-  write_index_v2(store, fs, "/repo/.git", commit_id, "/repo") catch {
+  write_index_v2(store, fs, fs, "/repo/.git", commit_id, "/repo") catch {
     err => fail("write_index_v2 failed: \{err}")
   }
   let index_bytes = fs.read_file("/repo/.git/index") catch {
@@ -20,7 +108,7 @@ test "write_index_v2 writes Git lexical path order" {
 test "write_index_v2 keeps lexical order for prefix-like paths" {
   let (store, commit_id) = build_commit_for_prefix_like_paths_wbtest()
   let fs = @io.TestFs::new()
-  write_index_v2(store, fs, "/repo/.git", commit_id, "/repo") catch {
+  write_index_v2(store, fs, fs, "/repo/.git", commit_id, "/repo") catch {
     err => fail("write_index_v2 failed: \{err}")
   }
   let index_bytes = fs.read_file("/repo/.git/index") catch {

--- a/modules/bit_repo/src/moon.pkg
+++ b/modules/bit_repo/src/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "mizchi/bit_types" @types,
   "mizchi/bit_object" @object,
-  "mizchi/bit_io" @io,
   "moonbitlang/core/encoding/utf8",
 }
 

--- a/modules/bit_repo/src/pkg.generated.mbti
+++ b/modules/bit_repo/src/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub fn read_shallow_boundaries(&@bit_types.RepoFileSystem, String) -> Array[@bit
 
 pub fn verify_tree_entry_name(String) -> Unit raise @bit_object.GitError
 
-pub fn write_git_metadata(ObjectStore, @bit_object.ObjectId, String, String, &@bit_types.FileSystem, String) -> Unit raise @bit_object.GitError
+pub fn write_git_metadata(ObjectStore, @bit_object.ObjectId, String, String, &@bit_types.FileSystem, String, &@bit_types.RepoFileSystem) -> Unit raise @bit_object.GitError
 
 // Errors
 

--- a/modules/bit_types/src/contracts.mbt
+++ b/modules/bit_types/src/contracts.mbt
@@ -15,6 +15,8 @@ pub(open) trait RepoFileSystem {
   fn readdir(Self, String) -> Array[String] raise GitError
   fn is_dir(Self, String) -> Bool
   fn is_file(Self, String) -> Bool
+  /// Return the modification time as `(seconds, nanoseconds)`.
+  fn mtime(Self, String) -> (Int, Int) raise GitError
 }
 
 ///|

--- a/modules/bit_types/src/pkg.generated.mbti
+++ b/modules/bit_types/src/pkg.generated.mbti
@@ -68,5 +68,6 @@ pub(open) trait RepoFileSystem {
   fn readdir(Self, String) -> Array[String] raise @bit_object.GitError
   fn is_dir(Self, String) -> Bool
   fn is_file(Self, String) -> Bool
+  fn mtime(Self, String) -> (Int, Int) raise @bit_object.GitError
 }
 

--- a/modules/bit_vfs/src/fs_wbtest.mbt
+++ b/modules/bit_vfs/src/fs_wbtest.mbt
@@ -69,6 +69,11 @@ impl @bit.RepoFileSystem for CountingFs with fn is_file(self, path) {
 }
 
 ///|
+impl @bit.RepoFileSystem for CountingFs with fn mtime(self, path) {
+  self.fs.mtime(path)
+}
+
+///|
 impl @bit.FileSystem for CountingFs with fn mkdir_p(self, path) {
   self.fs.mkdir_p(path)
 }

--- a/modules/bitx_hub/src/js_hub_host_bridge.mbt
+++ b/modules/bitx_hub/src/js_hub_host_bridge.mbt
@@ -105,6 +105,38 @@ extern "js" fn hub_js_host_is_file(host_id : Int, path : String) -> Bool =
   #|   return host?.isFile?.(path) ?? false;
   #| }
 
+///|
+extern "js" fn hub_js_host_mtime(host_id : Int, path : String) -> Array[Int]? =
+  #| (hostId, path) => {
+  #|   const state = globalThis.__bitGitJsState ??= { nextHostId: 1, hosts: new Map() };
+  #|   const host = state.hosts.get(hostId);
+  #|   if (!host) {
+  #|     globalThis.__bitGitJsLastError = `host ${hostId} not found`;
+  #|     return { $tag: 0 };
+  #|   }
+  #|   if (typeof host.mtime !== 'function') {
+  #|     globalThis.__bitGitJsLastError = 'host.mtime(path) is required';
+  #|     return { $tag: 0 };
+  #|   }
+  #|   try {
+  #|     const value = host.mtime(path);
+  #|     if (!Array.isArray(value) || value.length !== 2) {
+  #|       globalThis.__bitGitJsLastError = 'host.mtime(path) must return [seconds, nanoseconds]';
+  #|       return { $tag: 0 };
+  #|     }
+  #|     const seconds = Number(value[0]);
+  #|     const nanoseconds = Number(value[1]);
+  #|     if (!Number.isInteger(seconds) || !Number.isInteger(nanoseconds)) {
+  #|       globalThis.__bitGitJsLastError = 'host.mtime(path) must return integer seconds and nanoseconds';
+  #|       return { $tag: 0 };
+  #|     }
+  #|     return { $tag: 1, _0: [seconds, nanoseconds] };
+  #|   } catch (error) {
+  #|     globalThis.__bitGitJsLastError = String(error?.message ?? error);
+  #|     return { $tag: 0 };
+  #|   }
+  #| }
+
 // --- Trait implementations ---
 
 ///|
@@ -174,4 +206,12 @@ impl @bit.RepoFileSystem for HubJsHostFs with fn is_dir(self, path) {
 ///|
 impl @bit.RepoFileSystem for HubJsHostFs with fn is_file(self, path) {
   hub_js_host_is_file(self.host_id, path)
+}
+
+///|
+impl @bit.RepoFileSystem for HubJsHostFs with fn mtime(self, path) {
+  match hub_js_host_mtime(self.host_id, path) {
+    Some(value) => (value[0], value[1])
+    None => raise @bit.GitError::IoError(hub_js_host_last_error())
+  }
 }

--- a/npm/lib.js
+++ b/npm/lib.js
@@ -131,7 +131,8 @@ const isBackendObject = (value) => (
   typeof value.readFile === "function" &&
   typeof value.readdir === "function" &&
   typeof value.isDir === "function" &&
-  typeof value.isFile === "function"
+  typeof value.isFile === "function" &&
+  typeof value.mtime === "function"
 );
 
 const isTransportObject = (value) => (
@@ -509,6 +510,7 @@ const createMemoryBackendImpl = () => {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const files = new Map();
+  const mtimes = new Map();
   const dirs = new Set(["/"]);
 
   const normalizePath = (path) => {
@@ -557,6 +559,11 @@ const createMemoryBackendImpl = () => {
       const normalized = normalizePath(path);
       ensureDirs(parentDir(normalized));
       files.set(normalized, Uint8Array.from(content));
+      const now = Date.now();
+      mtimes.set(normalized, [
+        Math.floor(now / 1000),
+        (now % 1000) * 1_000_000,
+      ]);
     },
     writeString(path, content) {
       this.writeFile(path, encoder.encode(String(content)));
@@ -566,6 +573,7 @@ const createMemoryBackendImpl = () => {
       if (!files.delete(normalized)) {
         throw new Error(`File not found: ${normalized}`);
       }
+      mtimes.delete(normalized);
     },
     removeDir(path) {
       const normalized = normalizePath(path);
@@ -615,6 +623,14 @@ const createMemoryBackendImpl = () => {
     },
     isFile(path) {
       return files.has(normalizePath(path));
+    },
+    mtime(path) {
+      const normalized = normalizePath(path);
+      const value = mtimes.get(normalized);
+      if (!value) {
+        throw new Error(`File not found: ${normalized}`);
+      }
+      return value;
     },
     readString(path) {
       return decoder.decode(this.readFile(path));

--- a/tools/bit-git.mjs
+++ b/tools/bit-git.mjs
@@ -131,7 +131,8 @@ const isBackendObject = (value) => (
   typeof value.readFile === "function" &&
   typeof value.readdir === "function" &&
   typeof value.isDir === "function" &&
-  typeof value.isFile === "function"
+  typeof value.isFile === "function" &&
+  typeof value.mtime === "function"
 );
 
 const isTransportObject = (value) => (
@@ -509,6 +510,7 @@ const createMemoryBackendImpl = () => {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const files = new Map();
+  const mtimes = new Map();
   const dirs = new Set(["/"]);
 
   const normalizePath = (path) => {
@@ -557,6 +559,11 @@ const createMemoryBackendImpl = () => {
       const normalized = normalizePath(path);
       ensureDirs(parentDir(normalized));
       files.set(normalized, Uint8Array.from(content));
+      const now = Date.now();
+      mtimes.set(normalized, [
+        Math.floor(now / 1000),
+        (now % 1000) * 1_000_000,
+      ]);
     },
     writeString(path, content) {
       this.writeFile(path, encoder.encode(String(content)));
@@ -566,6 +573,7 @@ const createMemoryBackendImpl = () => {
       if (!files.delete(normalized)) {
         throw new Error(`File not found: ${normalized}`);
       }
+      mtimes.delete(normalized);
     },
     removeDir(path) {
       const normalized = normalizePath(path);
@@ -615,6 +623,14 @@ const createMemoryBackendImpl = () => {
     },
     isFile(path) {
       return files.has(normalizePath(path));
+    },
+    mtime(path) {
+      const normalized = normalizePath(path);
+      const value = mtimes.get(normalized);
+      if (!value) {
+        throw new Error(`File not found: ${normalized}`);
+      }
+      return value;
     },
     readString(path) {
       return decoder.decode(this.readFile(path));

--- a/tools/demo-relay.test.mjs
+++ b/tools/demo-relay.test.mjs
@@ -12,7 +12,10 @@ import {
   relayPollUrl,
   relayPublishUrl,
 } from "../docs/demo/relay_state.js";
-import { readStorageProfileFromSearch } from "../docs/demo/storage.js";
+import {
+  createSnapshotHost,
+  readStorageProfileFromSearch,
+} from "../docs/demo/storage.js";
 
 test("shareable search params preserve relay target, editor label, and session", () => {
   const draft = readRelayDraftFromSearch(
@@ -34,6 +37,22 @@ test("storage profile stays deterministic and browser-safe", () => {
   assert.equal(readStorageProfileFromSearch(""), "default");
   assert.equal(readStorageProfileFromSearch("?profile=Host Tab"), "host-tab");
   assert.equal(readStorageProfileFromSearch("?profile=../Client"), "client");
+});
+
+test("snapshot host exposes file modification times", () => {
+  const host = createSnapshotHost();
+  host.writeString("/repo/file.txt", "content");
+
+  const [seconds, nanoseconds] = host.mtime("/repo/file.txt");
+  assert.ok(seconds > 0);
+  assert.ok(nanoseconds >= 0 && nanoseconds < 1_000_000_000);
+
+  const snapshot = host.exportSnapshot();
+  host.removeFile("/repo/file.txt");
+  assert.throws(() => host.mtime("/repo/file.txt"), /File not found/);
+
+  host.replaceSnapshot(snapshot);
+  assert.equal(host.mtime("/repo/file.txt").length, 2);
 });
 
 test("relay URL helpers derive base, room, publish, and poll endpoints", () => {

--- a/tools/lib-js-git-ops.mjs
+++ b/tools/lib-js-git-ops.mjs
@@ -31,6 +31,7 @@ function createVirtualHost() {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const files = new Map();
+  const mtimes = new Map();
   const dirs = new Set(["/"]);
 
   const normalizePath = (path) => {
@@ -79,6 +80,11 @@ function createVirtualHost() {
       const normalized = normalizePath(path);
       ensureDirs(parentDir(normalized));
       files.set(normalized, Uint8Array.from(content));
+      const now = Date.now();
+      mtimes.set(normalized, [
+        Math.floor(now / 1000),
+        (now % 1000) * 1_000_000,
+      ]);
     },
     writeString(path, content) {
       this.writeFile(path, encoder.encode(String(content)));
@@ -88,6 +94,7 @@ function createVirtualHost() {
       if (!files.delete(normalized)) {
         throw new Error(`File not found: ${normalized}`);
       }
+      mtimes.delete(normalized);
     },
     removeDir(path) {
       const normalized = normalizePath(path);
@@ -137,6 +144,14 @@ function createVirtualHost() {
     },
     isFile(path) {
       return files.has(normalizePath(path));
+    },
+    mtime(path) {
+      const normalized = normalizePath(path);
+      const value = mtimes.get(normalized);
+      if (!value) {
+        throw new Error(`File not found: ${normalized}`);
+      }
+      return value;
     },
     readString(path) {
       return decoder.decode(this.readFile(path));

--- a/tools/lib-js-minimal.mjs
+++ b/tools/lib-js-minimal.mjs
@@ -13,6 +13,7 @@ function assert(condition, message) {
 function createVirtualHost() {
   const encoder = new TextEncoder();
   const files = new Map();
+  const mtimes = new Map();
   const dirs = new Set(["/"]);
 
   const normalizePath = (path) => {
@@ -61,6 +62,11 @@ function createVirtualHost() {
       const normalized = normalizePath(path);
       ensureDirs(parentDir(normalized));
       files.set(normalized, Uint8Array.from(content));
+      const now = Date.now();
+      mtimes.set(normalized, [
+        Math.floor(now / 1000),
+        (now % 1000) * 1_000_000,
+      ]);
     },
     writeString(path, content) {
       this.writeFile(path, encoder.encode(String(content)));
@@ -70,6 +76,7 @@ function createVirtualHost() {
       if (!files.delete(normalized)) {
         throw new Error(`File not found: ${normalized}`);
       }
+      mtimes.delete(normalized);
     },
     removeDir(path) {
       const normalized = normalizePath(path);
@@ -119,6 +126,14 @@ function createVirtualHost() {
     },
     isFile(path) {
       return files.has(normalizePath(path));
+    },
+    mtime(path) {
+      const normalized = normalizePath(path);
+      const value = mtimes.get(normalized);
+      if (!value) {
+        throw new Error(`File not found: ${normalized}`);
+      }
+      return value;
     },
   };
 }

--- a/tools/verify-libgit2-js.mjs
+++ b/tools/verify-libgit2-js.mjs
@@ -23,6 +23,7 @@ function createVirtualHost() {
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const files = new Map();
+  const mtimes = new Map();
   const dirs = new Set(["/"]);
 
   const normalizePath = (path) => {
@@ -71,6 +72,11 @@ function createVirtualHost() {
       const normalized = normalizePath(path);
       ensureDirs(parentDir(normalized));
       files.set(normalized, Uint8Array.from(content));
+      const now = Date.now();
+      mtimes.set(normalized, [
+        Math.floor(now / 1000),
+        (now % 1000) * 1_000_000,
+      ]);
     },
     writeString(path, content) {
       this.writeFile(path, encoder.encode(String(content)));
@@ -80,6 +86,7 @@ function createVirtualHost() {
       if (!files.delete(normalized)) {
         throw new Error(`File not found: ${normalized}`);
       }
+      mtimes.delete(normalized);
     },
     removeDir(path) {
       const normalized = normalizePath(path);
@@ -129,6 +136,14 @@ function createVirtualHost() {
     },
     isFile(path) {
       return files.has(normalizePath(path));
+    },
+    mtime(path) {
+      const normalized = normalizePath(path);
+      const value = mtimes.get(normalized);
+      if (!value) {
+        throw new Error(`File not found: ${normalized}`);
+      }
+      return value;
     },
     readString(path) {
       return decoder.decode(this.readFile(path));


### PR DESCRIPTION
## Why

`write_index_v2` read mtimes through the process-global `lstat` provider, bypassing the `RepoFileSystem` supplied by its caller. That makes capability-scoped, in-memory, and JavaScript-backed filesystems observe the wrong filesystem while materializing a clone.

## What changed

- Add required `mtime(path)` support to `RepoFileSystem`.
- Route index metadata reads through the caller-provided repository filesystem.
- Update the OS, test, VFS, and JavaScript host adapters to implement the contract.
- Extend the JavaScript memory host to record file mtimes and expose them as `[seconds, nanoseconds]`.

## Why this is correct

The index writer now reads every file attribute through the same filesystem object that owns the checkout. A regression test supplies a sentinel mtime and verifies that both ctime and mtime fields in the generated index contain that value.

## Scope

This intentionally makes `RepoFileSystem` implementations add `mtime`; it does not add async filesystem APIs or change unrelated repository operations.