### PR TITLE
Fix stale git-compat binary paths + add selective-publish tooling

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -648,6 +648,21 @@ local publishMoon: Task = new {
   deps { releaseCheck }
 }
 
+local publishChanged: Task = new {
+  name = "publish-changed"
+  description = "Report which Moon modules changed since the last release (dry run)"
+  cmd = "moon run --target native tools/publish-changed.mbtx"
+  cache = false
+}
+
+local publishChangedApply: Task = new {
+  name = "publish-changed-apply"
+  description = "Publish only the Moon modules that changed since the last release"
+  cmd = "moon run --target native tools/publish-changed.mbtx -- --apply"
+  cache = false
+  deps { releaseCheck }
+}
+
 // -- default ------------------------------------------------------------
 
 local default: Task = new {
@@ -743,6 +758,8 @@ tasks {
 
   releaseCheck
   publishMoon
+  publishChanged
+  publishChangedApply
   releaseNpm
   releaseNpmDryRun
 }

--- a/Test.pkl
+++ b/Test.pkl
@@ -57,6 +57,10 @@ tests {
     cmd = "node --test tools/module-publish-graph.test.mjs"
   }
   new {
+    name = "publish-changed"
+    cmd = "node --test tools/publish-changed.test.mjs"
+  }
+  new {
     name = "pkfire-test-inputs"
     cmd = "node --test tools/taskfile.test.mjs"
   }

--- a/e2e/test_git_compat_hashes.sh
+++ b/e2e/test_git_compat_hashes.sh
@@ -7,9 +7,15 @@ set -e
 
 TEST_DIR=$(cd "$(dirname "$0")" && pwd)
 PROJECT_ROOT=$(cd "$TEST_DIR/.." && pwd)
-BIT="${MOONGIT:-$PROJECT_ROOT/target/native/release/build/cmd/bit/bit.exe}"
+BIT="${MOONGIT:-$PROJECT_ROOT/_build/native/release/build/mizchi/bit/bit.exe}"
+if [ ! -f "$BIT" ] && [ -f "$PROJECT_ROOT/target/native/release/build/mizchi/bit/bit.exe" ]; then
+    BIT="$PROJECT_ROOT/target/native/release/build/mizchi/bit/bit.exe"
+fi
 if [ ! -f "$BIT" ] && [ -f "$PROJECT_ROOT/_build/native/release/build/cmd/bit/bit.exe" ]; then
     BIT="$PROJECT_ROOT/_build/native/release/build/cmd/bit/bit.exe"
+fi
+if [ ! -f "$BIT" ] && [ -f "$PROJECT_ROOT/target/native/release/build/cmd/bit/bit.exe" ]; then
+    BIT="$PROJECT_ROOT/target/native/release/build/cmd/bit/bit.exe"
 fi
 if [ ! -f "$BIT" ] && [ -f "$PROJECT_ROOT/tools/git-shim/moon" ]; then
     BIT="$PROJECT_ROOT/tools/git-shim/moon"
@@ -18,6 +24,9 @@ fi
 if [ ! -f "$BIT" ]; then
     echo "Building bit..."
     (cd "$PROJECT_ROOT" && moon build --target native --release)
+fi
+if [ ! -f "$BIT" ] && [ -f "$PROJECT_ROOT/_build/native/release/build/mizchi/bit/bit.exe" ]; then
+    BIT="$PROJECT_ROOT/_build/native/release/build/mizchi/bit/bit.exe"
 fi
 
 # Colors

--- a/t/t0024-relay-bit-relay-e2e.sh
+++ b/t/t0024-relay-bit-relay-e2e.sh
@@ -4,7 +4,9 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT_CANDIDATE="$(cd "$SCRIPT_DIR/.." && pwd)"
-if [ -z "${MOONGIT:-}" ] && [ -f "$PROJECT_ROOT_CANDIDATE/_build/native/release/build/cmd/bit/bit.exe" ]; then
+if [ -z "${MOONGIT:-}" ] && [ -f "$PROJECT_ROOT_CANDIDATE/_build/native/release/build/mizchi/bit/bit.exe" ]; then
+    export MOONGIT="$PROJECT_ROOT_CANDIDATE/_build/native/release/build/mizchi/bit/bit.exe"
+elif [ -z "${MOONGIT:-}" ] && [ -f "$PROJECT_ROOT_CANDIDATE/_build/native/release/build/cmd/bit/bit.exe" ]; then
     export MOONGIT="$PROJECT_ROOT_CANDIDATE/_build/native/release/build/cmd/bit/bit.exe"
 fi
 

--- a/t/t1301-midx-corruption.sh
+++ b/t/t1301-midx-corruption.sh
@@ -8,7 +8,11 @@ test_description='multi-pack-index corruption regressions'
 TEST_DIRECTORY=$(cd "$(dirname "$0")" && pwd)
 . "$TEST_DIRECTORY/test-lib.sh"
 
-if test -x "$BIT_BUILD_DIR/target/native/release/build/cmd/bit/bit.exe"; then
+if test -x "$BIT_BUILD_DIR/_build/native/release/build/mizchi/bit/bit.exe"; then
+	BIT="$BIT_BUILD_DIR/_build/native/release/build/mizchi/bit/bit.exe"
+elif test -x "$BIT_BUILD_DIR/target/native/release/build/mizchi/bit/bit.exe"; then
+	BIT="$BIT_BUILD_DIR/target/native/release/build/mizchi/bit/bit.exe"
+elif test -x "$BIT_BUILD_DIR/target/native/release/build/cmd/bit/bit.exe"; then
 	BIT="$BIT_BUILD_DIR/target/native/release/build/cmd/bit/bit.exe"
 elif test -x "$BIT_BUILD_DIR/_build/native/release/build/cmd/bit/bit.exe"; then
 	BIT="$BIT_BUILD_DIR/_build/native/release/build/cmd/bit/bit.exe"

--- a/t/t9003-fetch-up-to-date.sh
+++ b/t/t9003-fetch-up-to-date.sh
@@ -8,7 +8,11 @@ test_description='bit fetch is quiet when up to date'
 TEST_DIRECTORY=$(cd "$(dirname "$0")" && pwd)
 . "$TEST_DIRECTORY/test-lib.sh"
 
-if test -x "$BIT_BUILD_DIR/target/native/release/build/cmd/bit/bit.exe"; then
+if test -x "$BIT_BUILD_DIR/_build/native/release/build/mizchi/bit/bit.exe"; then
+	BIT="$BIT_BUILD_DIR/_build/native/release/build/mizchi/bit/bit.exe"
+elif test -x "$BIT_BUILD_DIR/target/native/release/build/mizchi/bit/bit.exe"; then
+	BIT="$BIT_BUILD_DIR/target/native/release/build/mizchi/bit/bit.exe"
+elif test -x "$BIT_BUILD_DIR/target/native/release/build/cmd/bit/bit.exe"; then
 	BIT="$BIT_BUILD_DIR/target/native/release/build/cmd/bit/bit.exe"
 elif test -x "$BIT_BUILD_DIR/_build/native/release/build/cmd/bit/bit.exe"; then
 	BIT="$BIT_BUILD_DIR/_build/native/release/build/cmd/bit/bit.exe"

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -21,7 +21,11 @@ fi
 BIT_BUILD_DIR="${TEST_DIRECTORY%/t}"
 
 # Find bit binary
-if test -x "$BIT_BUILD_DIR/target/release/build/cmd/bit/bit"; then
+if test -x "$BIT_BUILD_DIR/_build/native/release/build/mizchi/bit/bit.exe"; then
+	BIT="$BIT_BUILD_DIR/_build/native/release/build/mizchi/bit/bit.exe"
+elif test -x "$BIT_BUILD_DIR/target/native/release/build/mizchi/bit/bit.exe"; then
+	BIT="$BIT_BUILD_DIR/target/native/release/build/mizchi/bit/bit.exe"
+elif test -x "$BIT_BUILD_DIR/target/release/build/cmd/bit/bit"; then
 	BIT="$BIT_BUILD_DIR/target/release/build/cmd/bit/bit"
 elif test -x "$BIT_BUILD_DIR/target/release/build/cmd/bit/bit.exe"; then
 	BIT="$BIT_BUILD_DIR/target/release/build/cmd/bit/bit.exe"

--- a/tools/compare-real-git.sh
+++ b/tools/compare-real-git.sh
@@ -4,7 +4,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-BIT_BIN="${BIT_BIN:-$PROJECT_DIR/_build/native/release/build/cmd/bit/bit.exe}"
+BIT_BIN="${BIT_BIN:-$PROJECT_DIR/_build/native/release/build/mizchi/bit/bit.exe}"
 BENCH_DIR="${BENCH_DIR:-/tmp/git_benchmark}"
 REPO_URL="${REPO_URL:-https://github.com/expressjs/express.git}"
 

--- a/tools/flaker-run-git-compat-tests.mjs
+++ b/tools/flaker-run-git-compat-tests.mjs
@@ -81,7 +81,7 @@ function ensurePrepared() {
   const shimMoon = join(root, "tools/git-shim/moon");
   const builtBit = join(
     root,
-    "_build/native/release/build/cmd/bit/bit.exe",
+    "_build/native/release/build/mizchi/bit/bit.exe",
   );
   const action = resolveShimRefreshAction({
     shimExists: existsSync(shimMoon),

--- a/tools/publish-changed.mbtx
+++ b/tools/publish-changed.mbtx
@@ -1,0 +1,504 @@
+// Lerna-style selective publish for the bit workspace's many `modules/*`
+// packages: diff each package's directory against the last "Release vX.Y.Z"
+// commit and only `moon publish` the ones that actually changed, in
+// dependency order.
+//
+// Usage (from repo root):
+//   moon run --target native tools/publish-changed.mbtx
+//     -- report which modules changed since the last release (dry run)
+//   moon run --target native tools/publish-changed.mbtx -- --apply
+//     -- actually run `moon publish` for the changed modules
+//   moon run --target native tools/publish-changed.mbtx -- --since <git-ref> [--apply]
+//     -- compare against an explicit ref instead of the last Release commit
+
+import {
+  "moonbitlang/async@0.19.4",
+  "moonbitlang/async@0.19.4/process",
+  "moonbitlang/x@0.4.40/fs",
+  "moonbitlang/x@0.4.40/sys",
+  "moonbitlang/core/json",
+}
+
+///|
+pub(all) suberror ScriptError {
+  Fail(String)
+} derive(Debug)
+
+///|
+pub impl Show for ScriptError with fn output(self, logger) {
+  match self {
+    Fail(message) => logger.write_string(message)
+  }
+}
+
+///|
+struct ModuleInfo {
+  name : String
+  version : String
+  dir : String
+  dir_basename : String
+  deps : Array[String]
+}
+
+// -- tiny moon.mod parsing -------------------------------------------------
+
+///|
+fn extract_quoted_strings(text : String) -> Array[String] {
+  let result : Array[String] = []
+  let mut in_quote = false
+  let mut quote_start = 0
+  for i, c in text {
+    if c == '"' {
+      if in_quote {
+        result.push(String::unsafe_substring(text, start=quote_start + 1, end=i))
+        in_quote = false
+      } else {
+        quote_start = i
+        in_quote = true
+      }
+    }
+  }
+  result
+}
+
+///|
+fn quoted_field(content : String, field : String) -> String? {
+  for raw_line in content.split("\n") {
+    let line = raw_line.trim().to_owned()
+    if !line.has_prefix(field) {
+      continue
+    }
+    let after_field = String::unsafe_substring(
+      line,
+      start=field.length(),
+      end=line.length(),
+    )
+    let after_ws = after_field.trim_start(chars=" \t").to_owned()
+    if !after_ws.has_prefix("=") {
+      continue
+    }
+    let after_eq = String::unsafe_substring(
+      after_ws,
+      start=1,
+      end=after_ws.length(),
+    )
+    let value_part = after_eq.trim_start(chars=" \t").to_owned()
+    if !value_part.has_prefix("\"") {
+      continue
+    }
+    let rest = String::unsafe_substring(value_part, start=1, end=value_part.length())
+    match rest.find("\"") {
+      Some(idx) => return Some(String::unsafe_substring(rest, start=0, end=idx))
+      None => continue
+    }
+  }
+  None
+}
+
+///|
+fn internal_dep_names(content : String) -> Array[String] {
+  let marker = "import {"
+  let after = match content.find(marker) {
+    Some(idx) =>
+      String::unsafe_substring(
+        content,
+        start=idx + marker.length(),
+        end=content.length(),
+      )
+    None => ""
+  }
+  let block = match after.find("}") {
+    Some(idx2) => String::unsafe_substring(after, start=0, end=idx2)
+    None => after
+  }
+  let result : Array[String] = []
+  for entry in extract_quoted_strings(block) {
+    match entry.find("@") {
+      Some(at_idx) =>
+        result.push(String::unsafe_substring(entry, start=0, end=at_idx))
+      None => result.push(entry)
+    }
+  }
+  result
+}
+
+///|
+fn load_workspace_modules(root : String) -> Array[ModuleInfo] raise ScriptError {
+  let modules_dir = root + "/modules"
+  let entries = try @fs.read_dir(modules_dir) catch {
+    err => raise ScriptError::Fail("cannot read \{modules_dir}: \{err}")
+  }
+  entries.sort()
+  let result : Array[ModuleInfo] = []
+  for entry in entries {
+    let dir = modules_dir + "/" + entry
+    let is_dir = try @fs.is_dir(dir) catch { _ => false }
+    if !is_dir {
+      continue
+    }
+    let manifest_path = dir + "/moon.mod"
+    if !@fs.path_exists(manifest_path) {
+      continue
+    }
+    let content = try @fs.read_file_to_string(manifest_path) catch {
+      err => raise ScriptError::Fail("cannot read \{manifest_path}: \{err}")
+    }
+    let name = match quoted_field(content, "name") {
+      Some(v) => v
+      None => raise ScriptError::Fail("\{manifest_path}: missing name field")
+    }
+    let version = match quoted_field(content, "version") {
+      Some(v) => v
+      None => raise ScriptError::Fail("\{manifest_path}: missing version field")
+    }
+    result.push({
+      name,
+      version,
+      dir,
+      dir_basename: entry,
+      deps: internal_dep_names(content),
+    })
+  }
+  result
+}
+
+// -- dependency ordering ----------------------------------------------------
+
+///|
+fn topological_layers(
+  modules : Array[ModuleInfo],
+) -> Array[Array[ModuleInfo]] raise ScriptError {
+  let by_name : Map[String, ModuleInfo] = Map::new()
+  for m in modules {
+    by_name.set(m.name, m)
+  }
+  let mut remaining = modules.copy()
+  let published : Array[String] = []
+  let layers : Array[Array[ModuleInfo]] = []
+  while remaining.length() > 0 {
+    let ready : Array[ModuleInfo] = []
+    let still : Array[ModuleInfo] = []
+    for m in remaining {
+      let mut ok = true
+      for d in m.deps {
+        if by_name.contains(d) && !published.contains(d) {
+          ok = false
+        }
+      }
+      if ok {
+        ready.push(m)
+      } else {
+        still.push(m)
+      }
+    }
+    if ready.length() == 0 {
+      let names : Array[String] = []
+      for m in remaining {
+        names.push(m.name)
+      }
+      raise ScriptError::Fail("workspace module dependency cycle: \{names}")
+    }
+    ready.sort_by(fn(a, b) { String::compare(a.name, b.name) })
+    for m in ready {
+      published.push(m.name)
+    }
+    layers.push(ready)
+    remaining = still
+  }
+  layers
+}
+
+// -- git helpers --------------------------------------------------------
+
+///|
+async fn git_output(args : Array[String]) -> String raise ScriptError {
+  let (code, stdout, stderr) = try @process.collect_output("git", args) catch {
+    err => raise ScriptError::Fail("failed to spawn git \{args}: \{err}")
+  }
+  let out = try stdout.text() catch { _ => "" }
+  if code != 0 {
+    let err_text = try stderr.text() catch { _ => "" }
+    raise ScriptError::Fail(
+      "git \{args} failed (\{code}): \{err_text.trim().to_owned()}",
+    )
+  }
+  out
+}
+
+///|
+fn first_line(s : String) -> String {
+  match s.find("\n") {
+    Some(i) => String::unsafe_substring(s, start=0, end=i)
+    None => s
+  }
+}
+
+///|
+/// Returns (sha, subject) of the last commit that looks like a release, or
+/// the repo's root commit if no such commit exists yet.
+async fn find_anchor_commit() -> (String, String) raise ScriptError {
+  let out = git_output([
+    "log", "-n", "1", "--format=%H\t%s", "--grep=^Release v", "-i", "HEAD",
+  ])
+  let trimmed = out.trim().to_owned()
+  if trimmed.length() > 0 {
+    match trimmed.find("\t") {
+      Some(i) =>
+        return (
+          String::unsafe_substring(trimmed, start=0, end=i),
+          String::unsafe_substring(trimmed, start=i + 1, end=trimmed.length()),
+        )
+      None => return (trimmed, "")
+    }
+  }
+  let root_out = git_output(["rev-list", "--max-parents=0", "HEAD"])
+  let root_sha = first_line(root_out.trim().to_owned())
+  (root_sha, "(root commit, no prior release found)")
+}
+
+///|
+/// Names of `modules/*` directories with content changes (excluding the
+/// `moon.mod` file itself, since a release commit bumps every module's
+/// `moon.mod` in lockstep regardless of whether that module's own code
+/// changed).
+async fn changed_module_dirs(anchor : String) -> Array[String] raise ScriptError {
+  let out = git_output(["diff", "--name-only", anchor, "HEAD", "--", "modules"])
+  let changed : Array[String] = []
+  for raw_line in out.split("\n") {
+    let path = raw_line.trim().to_owned()
+    if path.length() == 0 || !path.has_prefix("modules/") {
+      continue
+    }
+    let rest = String::unsafe_substring(path, start=8, end=path.length())
+    match rest.find("/") {
+      None => continue
+      Some(si) => {
+        let mod_dir = String::unsafe_substring(rest, start=0, end=si)
+        let sub = String::unsafe_substring(rest, start=si + 1, end=rest.length())
+        if sub != "moon.mod" && !changed.contains(mod_dir) {
+          changed.push(mod_dir)
+        }
+      }
+    }
+  }
+  changed
+}
+
+// -- mooncakes registry (used only under --apply) ------------------------
+
+///|
+fn registry_index_path(name : String) -> String {
+  let home = match @sys.get_env_var("HOME") {
+    Some(h) => h
+    None => "/root"
+  }
+  home + "/.moon/registry/index/user/" + name + ".index"
+}
+
+///|
+fn registry_has_version(m : ModuleInfo) -> Bool {
+  let path = registry_index_path(m.name)
+  if !@fs.path_exists(path) {
+    return false
+  }
+  let content = try @fs.read_file_to_string(path) catch { _ => "" }
+  for raw_line in content.split("\n") {
+    let line = raw_line.trim().to_owned()
+    if line.length() == 0 {
+      continue
+    }
+    let parsed = try @json.parse(line) catch { _ => Json::null() }
+    match parsed {
+      Json::Object(obj) =>
+        match obj.get("version") {
+          Some(Json::String(v)) =>
+            if v == m.version {
+              return true
+            }
+          _ => ()
+        }
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+async fn refresh_registry() -> Unit raise ScriptError {
+  let code = try @process.run("moon", ["update"], inherit_env=true) catch {
+    err => raise ScriptError::Fail("failed to spawn moon update: \{err}")
+  }
+  if code != 0 {
+    raise ScriptError::Fail("moon update failed (\{code})")
+  }
+}
+
+///|
+async fn wait_for_layer(layer : Array[ModuleInfo]) -> Unit raise ScriptError {
+  let mut attempt = 0
+  while attempt < 10 {
+    refresh_registry()
+    let mut all_present = true
+    for m in layer {
+      if !registry_has_version(m) {
+        all_present = false
+      }
+    }
+    if all_present {
+      return
+    }
+    try @async.sleep(1000 * (attempt + 1)) catch {
+      err => raise ScriptError::Fail("interrupted while waiting: \{err}")
+    }
+    attempt += 1
+  }
+  let missing : Array[String] = []
+  for m in layer {
+    if !registry_has_version(m) {
+      missing.push(m.name)
+    }
+  }
+  raise ScriptError::Fail(
+    "published modules did not reach the registry index: \{missing}",
+  )
+}
+
+// -- reporting + publish --------------------------------------------------
+
+///|
+fn arg_value_after(args : Array[String], flag : String) -> String? {
+  let mut i = 0
+  while i < args.length() {
+    if args[i] == flag && i + 1 < args.length() {
+      return Some(args[i + 1])
+    }
+    i += 1
+  }
+  None
+}
+
+///|
+async fn main_async() -> Unit {
+  let args = @sys.get_cli_args()
+  let apply = args.contains("--apply")
+  let root = "."
+  let modules = try load_workspace_modules(root) catch {
+    err => {
+      println("error: \{err}")
+      @sys.exit(1)
+      return
+    }
+  }
+  let (anchor_sha, anchor_subject) = try (
+    match arg_value_after(args, "--since") {
+      Some(refname) => (refname, "(explicit --since ref)")
+      None => find_anchor_commit()
+    }
+  ) catch {
+    err => {
+      println("error: \{err}")
+      @sys.exit(1)
+      return
+    }
+  }
+  let changed_dirs = try changed_module_dirs(anchor_sha) catch {
+    err => {
+      println("error: \{err}")
+      @sys.exit(1)
+      return
+    }
+  }
+  println("comparing against \{anchor_sha} \{anchor_subject}")
+  println("")
+  let layers = try topological_layers(modules) catch {
+    err => {
+      println("error: \{err}")
+      @sys.exit(1)
+      return
+    }
+  }
+  let publish_layers : Array[Array[ModuleInfo]] = []
+  for layer in layers {
+    let changed_in_layer : Array[ModuleInfo] = []
+    for m in layer {
+      let changed = changed_dirs.contains(m.dir_basename)
+      let mark = if changed { "changed  " } else { "unchanged" }
+      println("  [\{mark}] \{m.name}@\{m.version}")
+      if changed {
+        changed_in_layer.push(m)
+      }
+    }
+    if changed_in_layer.length() > 0 {
+      publish_layers.push(changed_in_layer)
+    }
+  }
+  println("")
+  let total_changed = changed_dirs.length()
+  if total_changed == 0 {
+    println("no modules changed since \{anchor_sha} — nothing to publish")
+    return
+  }
+  println("\{total_changed} module(s) changed; publish order:")
+  let mut n = 0
+  for layer in publish_layers {
+    for m in layer {
+      n += 1
+      println("  \{n}. \{m.name}@\{m.version}")
+    }
+  }
+  if !apply {
+    println("")
+    println("(dry run — pass --apply to actually run `moon publish`)")
+    return
+  }
+  println("")
+  let dirty = try git_output(["status", "--porcelain"]) catch {
+    err => {
+      println("error: \{err}")
+      @sys.exit(1)
+      return
+    }
+  }
+  if dirty.trim().to_owned().length() > 0 {
+    println("error: refusing to publish from a dirty worktree")
+    @sys.exit(1)
+    return
+  }
+  let whoami_code = @process.run("moon", ["whoami"], inherit_env=true)
+  if whoami_code != 0 {
+    println("error: `moon whoami` failed (\{whoami_code}); are you logged in?")
+    @sys.exit(1)
+    return
+  }
+  try {
+    refresh_registry()
+    for layer in publish_layers {
+      let newly_published : Array[ModuleInfo] = []
+      for m in layer {
+        if registry_has_version(m) {
+          println("\{m.name}@\{m.version} already published, skipping")
+          continue
+        }
+        println("publishing \{m.name}@\{m.version}")
+        let code = @process.run("moon", ["-C", m.dir, "publish"], inherit_env=true)
+        if code != 0 {
+          raise ScriptError::Fail("moon -C \{m.dir} publish failed (\{code})")
+        }
+        newly_published.push(m)
+      }
+      if newly_published.length() > 0 {
+        wait_for_layer(newly_published)
+      }
+    }
+  } catch {
+    err => {
+      println("error: \{err}")
+      @sys.exit(1)
+    }
+  }
+}
+
+///|
+fn main {
+  @async.run_async_main(main_async)
+}

--- a/tools/publish-changed.test.mjs
+++ b/tools/publish-changed.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const runScript = (args) => spawnSync(
+  "moon",
+  ["run", "--target", "native", "tools/publish-changed.mbtx", "--", ...args],
+  { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+);
+
+test("publish-changed never publishes without the --apply gate", () => {
+  const source = readFileSync(
+    new URL("./publish-changed.mbtx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /if !apply \{/);
+  assert.match(source, /dry run — pass --apply/);
+  assert.match(source, /refusing to publish from a dirty worktree/);
+});
+
+test("reports no changes when compared against HEAD itself", () => {
+  const result = runScript(["--since", "HEAD"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /no modules changed since HEAD — nothing to publish/);
+});

--- a/tools/run-git-compat-random.sh
+++ b/tools/run-git-compat-random.sh
@@ -152,6 +152,8 @@ set +e
 
   bin_path=""
   for candidate in \
+    "_build/native/release/build/mizchi/bit/bit.exe" \
+    "_build/native/debug/build/mizchi/bit/bit.exe" \
     "_build/native/release/build/cmd/bit/bit.exe" \
     "_build/native/debug/build/cmd/bit/bit.exe"; do
     if [ -f "$candidate" ]; then
@@ -160,7 +162,7 @@ set +e
     fi
   done
   if [ -z "$bin_path" ]; then
-    echo "bit binary not found in _build/native/*/build/cmd/bit/bit.exe" >&2
+    echo "bit binary not found in _build/native/*/build/{mizchi,cmd}/bit/bit.exe" >&2
     exit 1
   fi
   cp "$bin_path" tools/git-shim/moon

--- a/tools/test-ai.sh
+++ b/tools/test-ai.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BIT_BIN="${BIT_BIN:-$ROOT_DIR/_build/native/release/build/cmd/bit/bit.exe}"
+BIT_BIN="${BIT_BIN:-$ROOT_DIR/_build/native/release/build/mizchi/bit/bit.exe}"
 DEBUG_ROOT="${DEBUG_ROOT:-$ROOT_DIR/tmp}"
 DEBUG_REPO="${DEBUG_REPO:-}"
 TEST_AI_SKIP_DEMO="${TEST_AI_SKIP_DEMO:-0}"


### PR DESCRIPTION
## Summary

- Fixes #83 (Git Compat Randomized failed). The 2026-07-11 `modules/` monorepo reorg (`13d87291`) moved the native build output from `_build/native/{release,debug}/build/cmd/bit/bit.exe` to `.../build/mizchi/bit/bit.exe`, but several scripts that resolve the `bit` binary by hardcoded path were never updated. `tools/run-git-compat-random.sh` — the script behind the "Git Compat Randomized" cron workflow — hit this hardest: its binary lookup ran *before* any tests, so every scheduled run since the reorg failed at "bit binary not found" without ever executing a single sampled test script. The regular `ci.yml` git-compat jobs never hit this because they resolve the binary dynamically (`find _build/native -name bit.exe`) before staging it into `tools/git-shim/moon`.
- Adds `tools/publish-changed.mbtx`: a lerna-style selective-publish tool for the 41 `modules/*` packages, since releasing all of them in lockstep on every release means publishing packages with no real changes. It diffs each package directory against the last `Release vX.Y.Z` commit (ignoring the `moon.mod` version-bump churn itself) and publishes only the changed ones, in dependency order.

## What changed

**Binary path fix** (9 files): added the `mizchi/bit` path as the primary candidate (keeping the old `cmd/bit` path as a fallback) in `tools/run-git-compat-random.sh`, `t/test-lib.sh`, `t/t9003-fetch-up-to-date.sh`, `t/t1301-midx-corruption.sh`, `t/t0024-relay-bit-relay-e2e.sh`, and `e2e/test_git_compat_hashes.sh`; updated the single hardcoded default in `tools/compare-real-git.sh`, `tools/test-ai.sh`, and `tools/flaker-run-git-compat-tests.mjs`.

**Selective publish tool**: `tools/publish-changed.mbtx` (a standalone MoonBit script run via `moon run --target native tools/publish-changed.mbtx`), wired into `Taskfile.pkl` as `publish-changed` (dry-run report) / `publish-changed-apply` (actually publish), with a companion test in `tools/publish-changed.test.mjs` registered in `Test.pkl`.

## Test plan

- [x] Simulated the fixed binary-resolution logic against the real `_build/` layout — resolves to `_build/native/release/build/mizchi/bit/bit.exe`.
- [x] `bash -n` syntax-checked all 8 modified shell scripts; `node --check` on the modified `.mjs` file.
- [x] `node --test tools/flaker-git-compat.test.mjs` — unaffected, still 7/7 passing.
- [x] `tools/publish-changed.mbtx` verified end-to-end: correctly identifies the 13 modules changed since the last release, in valid dependency order, and correctly reports "no changes" when compared against `HEAD` itself.
- [x] `node --test tools/publish-changed.test.mjs` — 2/2 passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBW8Pdq2ZfWVAfTZFsTnVo)_