### PR TITLE
Prepare selective patch releases

### DIFF
--- a/modules/bit/cmd/bit/add.mbt
+++ b/modules/bit/cmd/bit/add.mbt
@@ -395,7 +395,7 @@ fn add_apply_intent_to_add(
           fs,
           git_dir,
           @bitcore.ObjectType::Blob,
-          Bytes::default(),
+          Default::default(),
           algo~,
         )
         @bitlib.compat_record_blob_mapping(
@@ -403,7 +403,7 @@ fn add_apply_intent_to_add(
           rfs,
           git_dir,
           created,
-          Bytes::default(),
+          Default::default(),
         )
         empty_id = Some(created)
         created

--- a/modules/bit/cmd/bit/blame.mbt
+++ b/modules/bit/cmd/bit/blame.mbt
@@ -99,7 +99,7 @@ fn blame_read_path_diff_driver(
   }
   let text = decode_bytes(
     fs.read_file(attr_path) catch {
-      _ => Bytes::default()
+      _ => Default::default()
     },
   )
   let mut diff_driver : String? = None

--- a/modules/bit/cmd/bit/cat_file.mbt
+++ b/modules/bit/cmd/bit/cat_file.mbt
@@ -2824,7 +2824,7 @@ fn cat_file_read_path_attrs(
   if fs.is_file(attr_path) {
     let text = decode_bytes(
       fs.read_file(attr_path) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     for line_view in text.split("\n") {

--- a/modules/bit/cmd/bit/check_attr.mbt
+++ b/modules/bit/cmd/bit/check_attr.mbt
@@ -124,7 +124,7 @@ fn check_attr_load_rules(
   if fs.is_file(root_attr) {
     let content = decode_bytes(
       fs.read_file(root_attr) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     check_attr_parse_rules(content, rules)
@@ -134,7 +134,7 @@ fn check_attr_load_rules(
   if fs.is_file(info_attr) {
     let content = decode_bytes(
       fs.read_file(info_attr) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     check_attr_parse_rules(content, rules)

--- a/modules/bit/cmd/bit/check_ignore.mbt
+++ b/modules/bit/cmd/bit/check_ignore.mbt
@@ -263,7 +263,7 @@ fn check_ignore_add_rules_file(
   if fs.is_file(file_path) {
     let content = decode_bytes(
       fs.read_file(file_path) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     matcher.add_rules(base, content)

--- a/modules/bit/cmd/bit/checkout_wbtest.mbt
+++ b/modules/bit/cmd/bit/checkout_wbtest.mbt
@@ -723,7 +723,7 @@ async fn checkout_wbtest_case_force_checkout_clears_merge_state() -> Unit raise 
   @test.assert_eq(
     decode_bytes(
       fs.read_file(repo_dir + "/file") catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     ),
     "side\n",

--- a/modules/bit/cmd/bit/diff.mbt
+++ b/modules/bit/cmd/bit/diff.mbt
@@ -827,7 +827,7 @@ fn diff_conflict_marker_size(
     return 7
   }
   let content = @utf8.decode_lossy(
-    (fs.read_file(attr_path) catch { _ => Bytes::default() })[:],
+    (fs.read_file(attr_path) catch { _ => Default::default() })[:],
   )
   let mut size = 7
   for line_view in content.split("\n") {

--- a/modules/bit/cmd/bit/handlers_remote_pull_wbtest.mbt
+++ b/modules/bit/cmd/bit/handlers_remote_pull_wbtest.mbt
@@ -449,13 +449,13 @@ async test "pull: branch remote dot pulls from current repo config" {
   handlers_remote_pull_wbtest_run_shim_git(root, ["pull", "-q"])
 
   @test.assert_eq(
-    decode_bytes(fs.read_file(root + "/file") catch { _ => Bytes::default() }),
+    decode_bytes(fs.read_file(root + "/file") catch { _ => Default::default() }),
     "updated\n",
   )
   assert_true(
     decode_bytes(
       fs.read_file(root + "/.git/logs/HEAD") catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     ).contains("Fast-forward"),
   )
@@ -490,7 +490,7 @@ async test "pull: command path pulls into unborn branch from parent repo" {
   @test.assert_eq(
     decode_bytes(
       fs.read_file(dst_dir + "/file") catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     ),
     "file\n",
@@ -527,7 +527,7 @@ async test "pull: command path keeps staged new file on unborn branch" {
   @test.assert_eq(
     decode_bytes(
       fs.read_file(dst_dir + "/newfile") catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     ),
     "new tracked file\n",
@@ -619,7 +619,7 @@ async test "pull: rebase rejects staged changes on unborn branch" {
   @test.assert_eq(
     decode_bytes(
       fs.read_file(dst_dir + "/staged-file") catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     ),
     "staged-file\n",
@@ -669,11 +669,11 @@ async test "pull: rebase uses previous target as fork point for rebased upstream
   ])
 
   @test.assert_eq(
-    decode_bytes(fs.read_file(root + "/file") catch { _ => Bytes::default() }),
+    decode_bytes(fs.read_file(root + "/file") catch { _ => Default::default() }),
     "conflicting modification\n",
   )
   @test.assert_eq(
-    decode_bytes(fs.read_file(root + "/file2") catch { _ => Bytes::default() }),
+    decode_bytes(fs.read_file(root + "/file2") catch { _ => Default::default() }),
     "new\n",
   )
   @test.assert_eq(@bitlib.read_unmerged_paths(fs, root + "/.git").length(), 0)
@@ -711,7 +711,7 @@ async test "pull: updates checked-out branch worktree when fetch advances it" {
   ])
 
   @test.assert_eq(
-    decode_bytes(fs.read_file(root + "/file") catch { _ => Bytes::default() }),
+    decode_bytes(fs.read_file(root + "/file") catch { _ => Default::default() }),
     "modified\n",
   )
   @test.assert_eq(
@@ -721,7 +721,7 @@ async test "pull: updates checked-out branch worktree when fetch advances it" {
   assert_true(
     decode_bytes(
       fs.read_file(root + "/.git/logs/HEAD") catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     ).contains("Fast-forward"),
   )
@@ -762,7 +762,7 @@ async test "pull: refuses dirty worktree when fetch advances current branch" {
   assert_true(code != 0)
   assert_true(stderr.contains("Cannot fast-forward your working tree"))
   @test.assert_eq(
-    decode_bytes(fs.read_file(root + "/file") catch { _ => Bytes::default() }),
+    decode_bytes(fs.read_file(root + "/file") catch { _ => Default::default() }),
     "conflict\n",
   )
   @test.assert_eq(
@@ -835,13 +835,13 @@ async test "pull: rebase autostash preserves staged file on fast-forward" {
   @test.assert_eq(
     decode_bytes(
       fs.read_file(root + "/new_file") catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     ),
     "dirty\n",
   )
   @test.assert_eq(
-    decode_bytes(fs.read_file(root + "/file") catch { _ => Bytes::default() }),
+    decode_bytes(fs.read_file(root + "/file") catch { _ => Default::default() }),
     "modified again\n",
   )
   @test.assert_eq(@bitlib.stash_list(fs, root + "/.git").length(), 0)

--- a/modules/bit/cmd/bit/helpers_shared.mbt
+++ b/modules/bit/cmd/bit/helpers_shared.mbt
@@ -2,7 +2,7 @@
 
 ///|
 fn io_error(err : @fs.IOError) -> @bitcore.GitError {
-  @bitcore.GitError::IoError(@debug.render(@debug.to_repr(err)))
+  @bitcore.GitError::IoError(@debug.render(Repr(err)))
 }
 
 ///|

--- a/modules/bit/cmd/bit/http_fetch.mbt
+++ b/modules/bit/cmd/bit/http_fetch.mbt
@@ -78,7 +78,7 @@ async fn handle_http_fetch(args : Array[String]) -> Unit raise Error {
         @fs.write_bytes_to_file(pack_path, pack_data) catch {
           err => {
             eprint_line(
-              "error: cannot write \{pack_path}: \{@debug.render(@debug.to_repr(err))}",
+              "error: cannot write \{pack_path}: \{@debug.render(Repr(err))}",
             )
             continue
           }
@@ -136,7 +136,7 @@ async fn http_fetch_loose_object(
   @fs.write_bytes_to_file(path, data) catch {
     err => {
       eprint_line(
-        "error: cannot write \{path}: \{@debug.render(@debug.to_repr(err))}",
+        "error: cannot write \{path}: \{@debug.render(Repr(err))}",
       )
       @sys.exit(1)
       return
@@ -162,7 +162,7 @@ fn http_fetch_write_ref(
   @fs.write_bytes_to_file(ref_path, content_bytes) catch {
     err =>
       raise @bitcore.GitError::IoError(
-        "cannot write ref \{ref_path}: \{@debug.render(@debug.to_repr(err))}",
+        "cannot write ref \{ref_path}: \{@debug.render(Repr(err))}",
       )
   }
 }

--- a/modules/bit/cmd/bit/hub_github_sync.mbt
+++ b/modules/bit/cmd/bit/hub_github_sync.mbt
@@ -487,7 +487,7 @@ async fn handle_hub_issue_sync_install_hook(
   if fs.is_file(hook_path) {
     let existing = decode_bytes(
       fs.read_file(hook_path) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     if existing.contains("bit issue sync") {

--- a/modules/bit/cmd/bit/hub_stores.mbt
+++ b/modules/bit/cmd/bit/hub_stores.mbt
@@ -226,7 +226,7 @@ fn load_hub_origin_sync_plan(fs : OsFs, git_dir : String) -> HubOriginSyncPlan {
   let config_path = hub_sync_config_path(git_dir)
   let content = decode_bytes(
     fs.read_file(config_path) catch {
-      _ => Bytes::default()
+      _ => Default::default()
     },
   )
   compute_hub_origin_sync_plan(content)
@@ -405,7 +405,7 @@ fn resolve_hub_git_dir(root : String) -> String {
   let commondir_path = git_dir + "/commondir"
   if fs.is_file(commondir_path) {
     let raw = @utf8.decode_lossy(
-      (fs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+      (fs.read_file(commondir_path) catch { _ => Default::default() })[:],
     )
     let rel = raw.trim(chars=" \t\r\n").to_owned()
     if rel.length() > 0 {

--- a/modules/bit/cmd/bit/index_pack.mbt
+++ b/modules/bit/cmd/bit/index_pack.mbt
@@ -794,17 +794,17 @@ async fn handle_index_pack(args : Array[String]) -> Unit raise Error {
           err if @async.is_cancellation_error(err) => raise err
           err => {
             @stdio.stderr.write(
-              "fatal: " + @debug.render(@debug.to_repr(err)) + "\n",
+              "fatal: " + @debug.render(Repr(err)) + "\n",
             )
             @sys.exit(1)
-            Bytes::default()
+            Default::default()
           }
         }
         let max_depth = @pack.max_delta_chain_length(pack) catch {
           err if @async.is_cancellation_error(err) => raise err
           err => {
             @stdio.stderr.write(
-              "fatal: " + @debug.render(@debug.to_repr(err)) + "\n",
+              "fatal: " + @debug.render(Repr(err)) + "\n",
             )
             @sys.exit(1)
             0
@@ -828,10 +828,10 @@ async fn handle_index_pack(args : Array[String]) -> Unit raise Error {
           err if @async.is_cancellation_error(err) => raise err
           err => {
             @stdio.stderr.write(
-              "fatal: " + @debug.render(@debug.to_repr(err)) + "\n",
+              "fatal: " + @debug.render(Repr(err)) + "\n",
             )
             @sys.exit(1)
-            Bytes::default()
+            Default::default()
           }
         }
         let idx_path = if pack_path.has_suffix(".pack") {
@@ -844,10 +844,10 @@ async fn handle_index_pack(args : Array[String]) -> Unit raise Error {
           err if @async.is_cancellation_error(err) => raise err
           err => {
             @stdio.stderr.write(
-              "fatal: " + @debug.render(@debug.to_repr(err)) + "\n",
+              "fatal: " + @debug.render(Repr(err)) + "\n",
             )
             @sys.exit(1)
-            Bytes::default()
+            Default::default()
           }
         }
         match verify_pack_index(idx, pack, hash_size~) {
@@ -869,11 +869,11 @@ async fn handle_index_pack(args : Array[String]) -> Unit raise Error {
                 err => {
                   @stdio.stderr.write(
                     "error: could not read reverse index: " +
-                    @debug.render(@debug.to_repr(err)) +
+                    @debug.render(Repr(err)) +
                     "\n",
                   )
                   @sys.exit(1)
-                  Bytes::default()
+                  Default::default()
                 }
               }
               match verify_reverse_index(rev, pack, hash_size~) {
@@ -1094,10 +1094,10 @@ async fn handle_index_pack(args : Array[String]) -> Unit raise Error {
         err if @async.is_cancellation_error(err) => raise err
         err => {
           @stdio.stderr.write(
-            "fatal: " + @debug.render(@debug.to_repr(err)) + "\n",
+            "fatal: " + @debug.render(Repr(err)) + "\n",
           )
           @sys.exit(1)
-          Bytes::default()
+          Default::default()
         }
       }
       // Check --max-input-size for file mode

--- a/modules/bit/cmd/bit/log.mbt
+++ b/modules/bit/cmd/bit/log.mbt
@@ -1393,7 +1393,7 @@ fn log_extract_commit_message_and_encoding(data : Bytes) -> (Bytes, String?) {
       break
     }
   }
-  (Bytes::default(), encoding)
+  (Default::default(), encoding)
 }
 
 ///|
@@ -2014,7 +2014,7 @@ fn log_resolve_common_git_dir(
     return git_dir
   }
   let raw = @utf8.decode_lossy(
-    (rfs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+    (rfs.read_file(commondir_path) catch { _ => Default::default() })[:],
   )
   let rel = trim_string(raw)
   if rel.length() == 0 {

--- a/modules/bit/cmd/bit/ls_files.mbt
+++ b/modules/bit/cmd/bit/ls_files.mbt
@@ -174,7 +174,7 @@ async fn handle_ls_files(args : Array[String]) -> Unit raise Error {
       }
       // Detect worktree EOL from file on disk
       let w_eol = if file_exists {
-        let content = fs.read_file(abs) catch { _ => Bytes::default() }
+        let content = fs.read_file(abs) catch { _ => Default::default() }
         detect_eol_type(content)
       } else {
         ""
@@ -203,7 +203,7 @@ async fn handle_ls_files(args : Array[String]) -> Unit raise Error {
         }
         let abs = root + "/" + path
         let w_eol = if fs.is_file(abs) {
-          let content = fs.read_file(abs) catch { _ => Bytes::default() }
+          let content = fs.read_file(abs) catch { _ => Default::default() }
           detect_eol_type(content)
         } else {
           ""

--- a/modules/bit/cmd/bit/mailsplit.mbt
+++ b/modules/bit/cmd/bit/mailsplit.mbt
@@ -51,7 +51,7 @@ async fn handle_mailsplit(args : Array[String]) -> Unit raise Error {
       let data = @fs.read_file_to_bytes(path) catch {
         err => {
           eprint_line(
-            "fatal: cannot open \{path}: \{@debug.render(@debug.to_repr(err))}",
+            "fatal: cannot open \{path}: \{@debug.render(Repr(err))}",
           )
           @sys.exit(1)
           return
@@ -98,7 +98,7 @@ async fn handle_mailsplit(args : Array[String]) -> Unit raise Error {
     @fs.write_string_to_file(path, content) catch {
       err => {
         eprint_line(
-          "fatal: cannot write \{path}: \{@debug.render(@debug.to_repr(err))}",
+          "fatal: cannot write \{path}: \{@debug.render(Repr(err))}",
         )
         @sys.exit(1)
         return

--- a/modules/bit/cmd/bit/merge_file.mbt
+++ b/modules/bit/cmd/bit/merge_file.mbt
@@ -100,7 +100,7 @@ async fn handle_merge_file(args : Array[String]) -> Unit raise Error {
     @fs.write_string_to_file(current_arg, result.content) catch {
       e => {
         eprint_line(
-          "fatal: could not write '\{current_arg}': \{@debug.render(@debug.to_repr(e))}",
+          "fatal: could not write '\{current_arg}': \{@debug.render(Repr(e))}",
         )
         @sys.exit(128)
       }

--- a/modules/bit/cmd/bit/merge_one_file.mbt
+++ b/modules/bit/cmd/bit/merge_one_file.mbt
@@ -73,7 +73,7 @@ async fn handle_merge_one_file(args : Array[String]) -> Unit raise Error {
   @fs.write_bytes_to_file(full_path, content_bytes) catch {
     err => {
       eprint_line(
-        "error: cannot write \{full_path}: \{@debug.render(@debug.to_repr(err))}",
+        "error: cannot write \{full_path}: \{@debug.render(Repr(err))}",
       )
       @sys.exit(1)
       return

--- a/modules/bit/cmd/bit/merge_tree.mbt
+++ b/modules/bit/cmd/bit/merge_tree.mbt
@@ -343,10 +343,10 @@ fn merge_tree_get_blob_data(
   fs : &@bitcore.RepoFileSystem,
   id : @bitcore.ObjectId,
 ) -> Bytes {
-  let obj = db.get(fs, id) catch { _ => return Bytes::default() }
+  let obj = db.get(fs, id) catch { _ => return Default::default() }
   match obj {
     Some(o) if o.obj_type == @bitcore.ObjectType::Blob => o.data
-    _ => Bytes::default()
+    _ => Default::default()
   }
 }
 

--- a/modules/bit/cmd/bit/notes.mbt
+++ b/modules/bit/cmd/bit/notes.mbt
@@ -1186,7 +1186,7 @@ fn notes_resolve_common_git_dir(
     return git_dir
   }
   let raw = @utf8.decode_lossy(
-    (rfs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+    (rfs.read_file(commondir_path) catch { _ => Default::default() })[:],
   )
   let rel = trim_string(raw)
   if rel.length() == 0 {

--- a/modules/bit/cmd/bit/pull.mbt
+++ b/modules/bit/cmd/bit/pull.mbt
@@ -7,7 +7,7 @@ async fn handle_pull(args : Array[String]) -> Unit raise Error {
   if rfs.is_file(git_dir) {
     let gitfile = decode_bytes(
       rfs.read_file(git_dir) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     ignore(gitfile)
@@ -1185,7 +1185,7 @@ fn pull_snapshot_worktree_files(
   for path in paths {
     let full_path = root + "/" + path
     if fs.is_file(full_path) {
-      snapshot[path] = fs.read_file(full_path) catch { _ => Bytes::default() }
+      snapshot[path] = fs.read_file(full_path) catch { _ => Default::default() }
     }
   }
   snapshot
@@ -1626,7 +1626,7 @@ fn read_config_values(
   }
   let content = decode_bytes(
     fs.read_file(config_path) catch {
-      _ => Bytes::default()
+      _ => Default::default()
     },
   )
   let section_lower = section.to_lower()
@@ -1867,7 +1867,7 @@ fn read_url_rewrite_rules(
   }
   let content = decode_bytes(
     fs.read_file(config_path) catch {
-      _ => Bytes::default()
+      _ => Default::default()
     },
   )
   let blocks = @bitlib.parse_config_blocks(content)

--- a/modules/bit/cmd/bit/quiltimport.mbt
+++ b/modules/bit/cmd/bit/quiltimport.mbt
@@ -41,7 +41,7 @@ async fn handle_quiltimport(args : Array[String]) -> Unit raise Error {
   let series_data = @fs.read_file_to_bytes(series_path) catch {
     err => {
       eprint_line(
-        "fatal: cannot read \{series_path}: \{@debug.render(@debug.to_repr(err))}",
+        "fatal: cannot read \{series_path}: \{@debug.render(Repr(err))}",
       )
       @sys.exit(1)
       return

--- a/modules/bit/cmd/bit/rebase.mbt
+++ b/modules/bit/cmd/bit/rebase.mbt
@@ -160,7 +160,7 @@ fn rebase_read_signing_state(
     return (false, None)
   }
   let value = trim_string(
-    decode_bytes(rfs.read_file(path) catch { _ => Bytes::default() }),
+    decode_bytes(rfs.read_file(path) catch { _ => Default::default() }),
   )
   (true, if value.length() > 0 { Some(value) } else { None })
 }

--- a/modules/bit/cmd/bit/remote.mbt
+++ b/modules/bit/cmd/bit/remote.mbt
@@ -74,7 +74,7 @@ fn emit_trace_region(
   if fs.is_file(target) {
     let existing = decode_bytes(
       fs.read_file(target) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     fs.write_string(target, existing + enter + leave)
@@ -85,7 +85,7 @@ fn emit_trace_region(
 
 ///|
 fn append_text_file(fs : OsFs, path : String, text : String) -> Unit {
-  let current = decode_bytes(fs.read_file(path) catch { _ => Bytes::default() })
+  let current = decode_bytes(fs.read_file(path) catch { _ => Default::default() })
   fs.write_string(path, current + text) catch {
     _ => ()
   }

--- a/modules/bit/cmd/bit/reset.mbt
+++ b/modules/bit/cmd/bit/reset.mbt
@@ -360,7 +360,7 @@ async fn reset_refresh_index_entries(
       let content = rfs.read_file(abs) catch {
         _ => {
           changed = true
-          Bytes::default()
+          Default::default()
         }
       }
       if !changed {
@@ -414,7 +414,7 @@ fn reset_read_skip_worktree_paths(
   if fs.is_file(sidecar_path) {
     let text = decode_bytes(
       fs.read_file(sidecar_path) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     for line_view in text.split("\n") {
@@ -595,7 +595,7 @@ fn reset_commit_subject_bytes(
       )
       reset_convert_encoding(subject, source_encoding, output_encoding)
     }
-    None => Bytes::default()
+    None => Default::default()
   }
 }
 
@@ -639,7 +639,7 @@ fn reset_extract_commit_subject_and_encoding(data : Bytes) -> (Bytes, String?) {
       break
     }
   }
-  (Bytes::default(), encoding)
+  (Default::default(), encoding)
 }
 
 ///|
@@ -786,7 +786,7 @@ fn reset_slice_bytes(data : Bytes, start : Int, end : Int) -> Bytes {
   }
   let len = safe_end - safe_start
   if len <= 0 {
-    return Bytes::default()
+    return Default::default()
   }
   Bytes::from_array(FixedArray::makei(len, i => data[safe_start + i]))
 }

--- a/modules/bit/cmd/bit/submodule.mbt
+++ b/modules/bit/cmd/bit/submodule.mbt
@@ -165,7 +165,7 @@ fn resolve_submodule_common_git_dir(
   if fs.is_file(commondir_path) {
     let raw = decode_bytes(
       fs.read_file(commondir_path) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     let rel = trim_string(raw)
@@ -1716,7 +1716,7 @@ fn read_submodule_status_head_label(
   }
   let content = decode_bytes(
     fs.read_file(head_path) catch {
-      _ => Bytes::default()
+      _ => Default::default()
     },
   )
   match submodule_status_head_label(content) {
@@ -2034,7 +2034,7 @@ async fn handle_submodule_status(
   if rfs.is_file(gitmodules_path) {
     let gitmodules = decode_bytes(
       rfs.read_file(gitmodules_path) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     if gitmodules_has_unmapped_paths(gitmodules) {
@@ -2261,7 +2261,7 @@ async fn handle_submodule_update(
           if @async.is_being_cancelled() || @async.is_cancellation_error(err) {
             raise err
           }
-          Bytes::default()
+          Default::default()
         }
       },
     )

--- a/modules/bit/cmd/bit/version.mbt
+++ b/modules/bit/cmd/bit/version.mbt
@@ -1,3 +1,3 @@
 ///|
 /// bit version tag (update this and the module/package manifests together when releasing)
-let bit_version_tag : String = "2.47.0 (bit v0.45.6)"
+let bit_version_tag : String = "2.47.0 (bit v0.46.1)"

--- a/modules/bit/cmd/git-bit/helpers_shared.mbt
+++ b/modules/bit/cmd/git-bit/helpers_shared.mbt
@@ -2,7 +2,7 @@
 
 ///|
 fn io_error(err : @fs.IOError) -> @bitcore.GitError {
-  @bitcore.GitError::IoError(@debug.render(@debug.to_repr(err)))
+  @bitcore.GitError::IoError(@debug.render(Repr(err)))
 }
 
 ///|

--- a/modules/bit/cmd/git-bit/hub_github_sync.mbt
+++ b/modules/bit/cmd/git-bit/hub_github_sync.mbt
@@ -487,7 +487,7 @@ async fn handle_hub_issue_sync_install_hook(
   if fs.is_file(hook_path) {
     let existing = decode_bytes(
       fs.read_file(hook_path) catch {
-        _ => Bytes::default()
+        _ => Default::default()
       },
     )
     if existing.contains("bit issue sync") {

--- a/modules/bit/cmd/git-bit/hub_stores.mbt
+++ b/modules/bit/cmd/git-bit/hub_stores.mbt
@@ -190,7 +190,7 @@ fn resolve_hub_common_git_dir(git_dir : String) -> String {
   let commondir_path = resolved_git_dir + "/commondir"
   if fs.is_file(commondir_path) {
     let raw = @utf8.decode_lossy(
-      (fs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+      (fs.read_file(commondir_path) catch { _ => Default::default() })[:],
     )
     let rel = raw.trim(chars=" \t\r\n").to_owned()
     if rel.length() > 0 {

--- a/modules/bit/moon.mod
+++ b/modules/bit/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit"
 
-version = "0.45.6"
+version = "0.46.1"
 
 import {
   "moonbitlang/async@0.19.4",

--- a/modules/bit_grep/moon.mod
+++ b/modules/bit_grep/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_grep"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bit_grep/src/pattern.mbt
+++ b/modules/bit_grep/src/pattern.mbt
@@ -116,7 +116,7 @@ pub impl Show for GrepExprMatch with fn output(self, logger) {
     "{matched: " +
     self.matched.to_string() +
     ", span: " +
-    to_repr(self.span).to_string() +
+    Repr(self.span).to_string() +
     "}",
   )
 }

--- a/modules/bit_grep/src/search.mbt
+++ b/modules/bit_grep/src/search.mbt
@@ -53,7 +53,7 @@ pub impl Show for GrepFileMatch with fn output(self, logger) {
     "{path: " +
     grep_search_show_string(self.path) +
     ", matches: " +
-    to_repr(self.matches).to_string() +
+    Repr(self.matches).to_string() +
     "}",
   )
 }

--- a/modules/bit_ignore/moon.mod
+++ b/modules/bit_ignore/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_ignore"
 
-version = "0.45.6"
+version = "0.45.7"
 
 repository = "https://github.com/mizchi/bit-vcs"
 

--- a/modules/bit_ignore/src/ignore.mbt
+++ b/modules/bit_ignore/src/ignore.mbt
@@ -367,7 +367,7 @@ let char_slash : UInt16 = {
 ///|
 fn string_to_uint16_array(s : String) -> FixedArray[UInt16] {
   let len = s.length()
-  let arr = FixedArray::make(len, UInt16::default())
+  let arr = FixedArray::make(len, Default::default())
   for i in 0..<len {
     arr[i] = s.unsafe_get(i)
   }

--- a/modules/bit_io_native/moon.mod
+++ b/modules/bit_io_native/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_io_native"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bit_io_native/src/upload_pack_process.mbt
+++ b/modules/bit_io_native/src/upload_pack_process.mbt
@@ -645,7 +645,7 @@ async fn run_process_with_files(
   }
   let stdin_bytes = match stdin_data {
     Some(data) => data
-    None => Bytes::default()
+    None => Default::default()
   }
   @fs.write_bytes_to_file(stdin_path, stdin_bytes) catch {
     e =>
@@ -1086,7 +1086,7 @@ async fn run_ssh_upload_pack_interactive(
   }
   if code != 0 {
     let err_bytes = @fs.read_file_to_bytes(stderr_path) catch {
-      _ => Bytes::default()
+      _ => Default::default()
     }
     let err_text = bytes_to_string_lossy(err_bytes)
     cleanup_temp_files([stderr_path])

--- a/modules/bit_lib/moon.mod
+++ b/modules/bit_lib/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_lib"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bit_lib/src/checkout.mbt
+++ b/modules/bit_lib/src/checkout.mbt
@@ -203,7 +203,7 @@ pub fn resolve_checkout_common_git_dir(
     return git_dir
   }
   let raw = @utf8.decode_lossy(
-    (fs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+    (fs.read_file(commondir_path) catch { _ => Default::default() })[:],
   )
   let rel = @string_utils.trim_string(raw)
   if rel.length() == 0 {

--- a/modules/bit_lib/src/gitattributes.mbt
+++ b/modules/bit_lib/src/gitattributes.mbt
@@ -36,7 +36,7 @@ pub fn resolve_diff_driver(
   let attr_path = join_path(root, ".gitattributes")
   guard rfs.is_file(attr_path) else { return None }
   let content = @utf8.decode_lossy(
-    (rfs.read_file(attr_path) catch { _ => Bytes::default() })[:],
+    (rfs.read_file(attr_path) catch { _ => Default::default() })[:],
   )
   let normalized = gitattr_normalize_path(path)
   let mut diff_driver : String? = None
@@ -135,7 +135,7 @@ pub fn resolve_eol_attrs(
     }
   }
   let content = @utf8.decode_lossy(
-    (rfs.read_file(attr_path) catch { _ => Bytes::default() })[:],
+    (rfs.read_file(attr_path) catch { _ => Default::default() })[:],
   )
   let normalized = gitattr_normalize_path(path)
   let mut text : TextAttr = TextAttr::Unspecified
@@ -335,7 +335,7 @@ pub fn check_unsupported_gitattributes(
     return None
   }
   let content = @utf8.decode_lossy(
-    (rfs.read_file(attr_path) catch { _ => Bytes::default() })[:],
+    (rfs.read_file(attr_path) catch { _ => Default::default() })[:],
   )
   for line_view in content.split("\n") {
     let line = line_view.to_owned().trim().to_owned()
@@ -444,7 +444,7 @@ pub fn has_any_filter_attributes(
     return false
   }
   let content = @utf8.decode_lossy(
-    (rfs.read_file(attr_path) catch { _ => Bytes::default() })[:],
+    (rfs.read_file(attr_path) catch { _ => Default::default() })[:],
   )
   for line_view in content.split("\n") {
     let line = line_view.to_owned().trim().to_owned()

--- a/modules/bit_lib/src/index.mbt
+++ b/modules/bit_lib/src/index.mbt
@@ -1015,7 +1015,7 @@ pub fn read_skip_worktree_paths(
   let sidecar_path = join_path(git_dir, "bit-skip-worktree")
   if fs.is_file(sidecar_path) {
     let text = @utf8.decode_lossy(
-      (fs.read_file(sidecar_path) catch { _ => Bytes::default() })[:],
+      (fs.read_file(sidecar_path) catch { _ => Default::default() })[:],
     )
     for line_view in text.split("\n") {
       let line = line_view.to_owned()

--- a/modules/bit_lib/src/index_wbtest.mbt
+++ b/modules/bit_lib/src/index_wbtest.mbt
@@ -390,7 +390,7 @@ fn index_test_mark_single_entry_skip_worktree(
   fs : @bit.TestFs,
   index_path : String,
 ) -> Unit {
-  let data = fs.read_file(index_path) catch { _ => Bytes::default() }
+  let data = fs.read_file(index_path) catch { _ => Default::default() }
   let arr : Array[Byte] = []
   for b in data {
     arr.push(b)
@@ -434,7 +434,7 @@ fn index_test_replace_single_entry_with_stages(
   index_path : String,
   stages : Array[Int],
 ) -> Unit {
-  let data = fs.read_file(index_path) catch { _ => Bytes::default() }
+  let data = fs.read_file(index_path) catch { _ => Default::default() }
   if data.length() < 12 + 20 {
     panic()
   }
@@ -509,7 +509,7 @@ fn index_test_write_resolve_undo_extension(
   ours_hex : String,
   theirs_hex : String,
 ) -> Unit {
-  let data = fs.read_file(index_path) catch { _ => Bytes::default() }
+  let data = fs.read_file(index_path) catch { _ => Default::default() }
   let arr : Array[Byte] = []
   for b in data {
     arr.push(b)

--- a/modules/bit_lib/src/log.mbt
+++ b/modules/bit_lib/src/log.mbt
@@ -267,7 +267,7 @@ fn log_resolve_common_git_dir(
     return git_dir
   }
   let raw = @utf8.decode_lossy(
-    (fs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+    (fs.read_file(commondir_path) catch { _ => Default::default() })[:],
   )
   let rel = @string_utils.trim_string(raw)
   if rel.length() == 0 {

--- a/modules/bit_lib/src/merge.mbt
+++ b/modules/bit_lib/src/merge.mbt
@@ -883,15 +883,15 @@ fn merge_get_blob_data(
   fs : &@bit.RepoFileSystem,
   id : @bit.ObjectId,
 ) -> Bytes {
-  let obj = db.get(fs, id) catch { _ => return Bytes::default() }
+  let obj = db.get(fs, id) catch { _ => return Default::default() }
   match obj {
     Some(o) =>
       if o.obj_type == @bit.ObjectType::Blob {
         o.data
       } else {
-        Bytes::default()
+        Default::default()
       }
-    None => Bytes::default()
+    None => Default::default()
   }
 }
 

--- a/modules/bit_lib/src/merge_test.mbt
+++ b/modules/bit_lib/src/merge_test.mbt
@@ -35,7 +35,7 @@ test "merge: content-level merge non-overlapping changes" {
   match result.status {
     Merged => ()
     _ => {
-      println("Expected Merged, got conflicts: \{to_repr(result.conflicts)}")
+      println("Expected Merged, got conflicts: \{Repr(result.conflicts)}")
       assert_true(false)
     }
   }
@@ -112,7 +112,7 @@ test "merge: file-level merge without conflicts" {
   match result.status {
     Merged => ()
     Conflicted => {
-      println("CONFLICT: \{to_repr(result.conflicts)}")
+      println("CONFLICT: \{Repr(result.conflicts)}")
       assert_true(false)
     }
     AlreadyUpToDate => {
@@ -291,7 +291,7 @@ test "merge: rename on one side, no conflict" {
   match result.status {
     Merged => ()
     _ => {
-      println("Expected Merged, got conflicts: \{to_repr(result.conflicts)}")
+      println("Expected Merged, got conflicts: \{Repr(result.conflicts)}")
       fail("expected merged")
     }
   }
@@ -347,7 +347,7 @@ test "merge: rename on one side, modify on other (rename/modify)" {
   match result.status {
     Merged => ()
     Conflicted => {
-      println("Conflicts: \{to_repr(result.conflicts)}")
+      println("Conflicts: \{Repr(result.conflicts)}")
       fail("expected merged, got conflicted")
     }
     _ => fail("expected merged")
@@ -477,7 +477,7 @@ test "merge: rename/add-source - rename a->b with new file at a" {
   match result.status {
     Merged => ()
     _ => {
-      println("Expected Merged, got conflicts: \{to_repr(result.conflicts)}")
+      println("Expected Merged, got conflicts: \{Repr(result.conflicts)}")
       fail("expected merged")
     }
   }

--- a/modules/bit_lib/src/rebase.mbt
+++ b/modules/bit_lib/src/rebase.mbt
@@ -1124,7 +1124,7 @@ pub fn load_rebase_state(
 ///|
 fn read_file_trimmed(fs : &@bit.RepoFileSystem, path : String) -> String {
   let content = @utf8.decode_lossy(
-    (fs.read_file(path) catch { _ => Bytes::default() })[:],
+    (fs.read_file(path) catch { _ => Default::default() })[:],
   )
   let mut end = content.length()
   while end > 0 {
@@ -1148,7 +1148,7 @@ fn parse_todo_file(
     return result
   }
   let content = @utf8.decode_lossy(
-    (fs.read_file(path) catch { _ => Bytes::default() })[:],
+    (fs.read_file(path) catch { _ => Default::default() })[:],
   )
   for line_view in content.split("\n") {
     let line = line_view.to_owned()
@@ -2051,15 +2051,15 @@ fn rebase_get_blob_data(
   fs : &@bit.RepoFileSystem,
   id : @bit.ObjectId,
 ) -> Bytes {
-  let obj = db.get(fs, id) catch { _ => return Bytes::default() }
+  let obj = db.get(fs, id) catch { _ => return Default::default() }
   match obj {
     Some(o) =>
       if o.obj_type == @bit.ObjectType::Blob {
         o.data
       } else {
-        Bytes::default()
+        Default::default()
       }
-    None => Bytes::default()
+    None => Default::default()
   }
 }
 

--- a/modules/bit_lib/src/rebase_interactive.mbt
+++ b/modules/bit_lib/src/rebase_interactive.mbt
@@ -513,7 +513,7 @@ fn interactive_read_file_or_empty(
   if !rfs.is_file(path) {
     return ""
   }
-  @utf8.decode_lossy((rfs.read_file(path) catch { _ => Bytes::default() })[:])
+  @utf8.decode_lossy((rfs.read_file(path) catch { _ => Default::default() })[:])
 }
 
 // ============================================================================

--- a/modules/bit_lib/src/reset.mbt
+++ b/modules/bit_lib/src/reset.mbt
@@ -98,7 +98,7 @@ fn reset_resolve_common_git_dir(
     return git_dir
   }
   let raw = @utf8.decode_lossy(
-    (fs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+    (fs.read_file(commondir_path) catch { _ => Default::default() })[:],
   )
   let rel = @string_utils.trim_string(raw)
   if rel.length() == 0 {

--- a/modules/bit_lib/src/worktree.mbt
+++ b/modules/bit_lib/src/worktree.mbt
@@ -1485,7 +1485,7 @@ fn resolve_worktree_common_git_dir(
     return git_dir
   }
   let raw = @utf8.decode_lossy(
-    (fs.read_file(commondir_path) catch { _ => Bytes::default() })[:],
+    (fs.read_file(commondir_path) catch { _ => Default::default() })[:],
   )
   let rel = trim_worktree_text(raw)
   if rel.length() == 0 {

--- a/modules/bit_lib/src/worktree_admin.mbt
+++ b/modules/bit_lib/src/worktree_admin.mbt
@@ -1419,7 +1419,7 @@ fn worktree_sanitize_admin_component(name : String) -> String {
     return name
   }
   let out : Array[Char] = []
-  let mut last = Char::default()
+  let mut last = Default::default()
   for ch in name.to_array() {
     if ch == '.' && last == '.' {
       last = ch

--- a/modules/bit_object/moon.mod
+++ b/modules/bit_object/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_object"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_hash@0.45.6",

--- a/modules/bit_object/src/types.mbt
+++ b/modules/bit_object/src/types.mbt
@@ -153,7 +153,7 @@ pub fn ObjectId::is_zero_hex(hex : String) -> Bool {
 pub impl Hash for ObjectId with fn hash_combine(self, hasher) {
   // Use first 8 bytes as hash (sufficient for distribution)
   for i in 0..<8 {
-    self.bytes[i].hash_combine(hasher)
+    Hash::hash_combine(self.bytes[i], hasher)
   }
 }
 

--- a/modules/bit_pack/moon.mod
+++ b/modules/bit_pack/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_pack"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bit_pack/src/bit_oracle_pack_test.mbt
+++ b/modules/bit_pack/src/bit_oracle_pack_test.mbt
@@ -10,13 +10,13 @@ async fn run_git(
     .prefix("git-stdout-")
     .suffix(".out")
     .create_temp_file() catch {
-      _ => return (-1, Bytes::default(), Bytes::default())
+      _ => return (-1, Default::default(), Default::default())
     }
   let stderr_file = @tempfile.Builder::new()
     .prefix("git-stderr-")
     .suffix(".err")
     .create_temp_file() catch {
-      _ => return (-1, Bytes::default(), Bytes::default())
+      _ => return (-1, Default::default(), Default::default())
     }
   let stdout_path = stdout_file.path()
   let stderr_path = stderr_file.path()
@@ -37,7 +37,7 @@ async fn run_git(
         .prefix("git-stdin-")
         .suffix(".in")
         .create_temp_file() catch {
-          _ => return (-1, Bytes::default(), Bytes::default())
+          _ => return (-1, Default::default(), Default::default())
         }
       f.write_bytes(data) catch {
         _ => ()
@@ -79,8 +79,8 @@ async fn run_git(
           )
       }
   }
-  let out = @fs.read_file_to_bytes(stdout_path) catch { _ => Bytes::default() }
-  let err = @fs.read_file_to_bytes(stderr_path) catch { _ => Bytes::default() }
+  let out = @fs.read_file_to_bytes(stdout_path) catch { _ => Default::default() }
+  let err = @fs.read_file_to_bytes(stderr_path) catch { _ => Default::default() }
   // Cleanup temp files
   stdout_file.cleanup() catch {
     _ => ()

--- a/modules/bit_refs/moon.mod
+++ b/modules/bit_refs/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_refs"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bit_refs/src/refs_store.mbt
+++ b/modules/bit_refs/src/refs_store.mbt
@@ -111,7 +111,7 @@ pub fn collect_packed_ref_ids(
   if !fs.is_file(packed_path) {
     return ()
   }
-  let packed = fs.read_file(packed_path) catch { _ => Bytes::default() }
+  let packed = fs.read_file(packed_path) catch { _ => Default::default() }
   let text = @utf8.decode_lossy(packed[:])
   for line_view in text.split("\n") {
     let line = trim_string_refs(line_view.to_owned())
@@ -267,7 +267,7 @@ pub fn rewrite_packed_refs(
   if !rfs.is_file(packed_path) {
     return ()
   }
-  let data = rfs.read_file(packed_path) catch { _ => Bytes::default() }
+  let data = rfs.read_file(packed_path) catch { _ => Default::default() }
   let text = @utf8.decode_lossy(data[:])
   let entries = parse_packed_refs_text(text)
   let kept : Array[PackedRefEntry] = []

--- a/modules/bit_repo/moon.mod
+++ b/modules/bit_repo/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_repo"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_io@0.45.6",

--- a/modules/bit_repo/src/shallow.mbt
+++ b/modules/bit_repo/src/shallow.mbt
@@ -9,7 +9,7 @@ pub fn read_shallow_boundaries(
   if !fs.is_file(path) {
     return []
   }
-  let data = fs.read_file(path) catch { _ => Bytes::default() }
+  let data = fs.read_file(path) catch { _ => Default::default() }
   let boundaries : Array[@object.ObjectId] = []
   for line_view in @utf8.decode_lossy(data[:]).split("\n") {
     let line = line_view.trim().to_owned()

--- a/modules/bit_runtime/moon.mod
+++ b/modules/bit_runtime/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_runtime"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bit_runtime/src/storage_runtime.mbt
+++ b/modules/bit_runtime/src/storage_runtime.mbt
@@ -785,7 +785,7 @@ fn storage_resolve_common_git_dir(
   }
   let raw = storage_decode_bytes(
     rfs.read_file(commondir_path) catch {
-      _ => Bytes::default()
+      _ => Default::default()
     },
   )
   let rel = storage_trim_string(raw)

--- a/modules/bit_vfs/moon.mod
+++ b/modules/bit_vfs/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bit_vfs"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bit_vfs/src/partial_clone_test.mbt
+++ b/modules/bit_vfs/src/partial_clone_test.mbt
@@ -28,7 +28,7 @@ test "partial_clone: mount and list files" {
 
   // Get promisor remote
   let remote = @lib.read_promisor_remote(osfs, git_dir)
-  println("Promisor remote: \{to_repr(remote)}")
+  println("Promisor remote: \{Repr(remote)}")
   assert_true(remote is Some(_))
 
   // Get HEAD commit
@@ -343,7 +343,7 @@ async test "partial_clone: prefetch multiple files" {
     } else {
       files_to_fetch
     }
-    println("Prefetching: \{to_repr(to_prefetch)}")
+    println("Prefetching: \{Repr(to_prefetch)}")
     let fetched = bitfs.prefetch(osfs, osfs, to_prefetch)
     println("Fetched \{fetched} objects")
 

--- a/modules/bitx_hub/moon.mod
+++ b/modules/bitx_hub/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bitx_hub"
 
-version = "0.45.6"
+version = "0.46.1"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bitx_hub/src/native/github_api.mbt
+++ b/modules/bitx_hub/src/native/github_api.mbt
@@ -113,7 +113,7 @@ fn parse_json_array_from_api(text : String) -> Array[Json] raise @bit.GitError {
     Json::Array(items) => items
     _ =>
       raise @bit.GitError::InvalidObject(
-        "Expected JSON array from gh api, got: \{to_repr(parsed)}",
+        "Expected JSON array from gh api, got: \{Repr(parsed)}",
       )
   }
 }
@@ -132,7 +132,7 @@ fn parse_json_object_from_api(
     Json::Object(obj) => obj
     _ =>
       raise @bit.GitError::InvalidObject(
-        "Expected JSON object from gh api, got: \{to_repr(parsed)}",
+        "Expected JSON object from gh api, got: \{Repr(parsed)}",
       )
   }
 }

--- a/modules/bitx_kv/moon.mod
+++ b/modules/bitx_kv/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bitx_kv"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bitx_kv/src/types.mbt
+++ b/modules/bitx_kv/src/types.mbt
@@ -35,7 +35,7 @@ pub impl Eq for NodeId with fn equal(self, other) {
 
 ///|
 pub impl Hash for NodeId with fn hash_combine(self, hasher) {
-  self.id.hash_combine(hasher)
+  Hash::hash_combine(self.id, hasher)
 }
 
 ///|

--- a/modules/bitx_rebase_ai/moon.mod
+++ b/modules/bitx_rebase_ai/moon.mod
@@ -1,6 +1,6 @@
 name = "mizchi/bitx_rebase_ai"
 
-version = "0.45.6"
+version = "0.45.7"
 
 import {
   "mizchi/bit_core@0.45.6",

--- a/modules/bitx_rebase_ai/src/rebase_ai.mbt
+++ b/modules/bitx_rebase_ai/src/rebase_ai.mbt
@@ -587,7 +587,7 @@ fn collect_conflict_marker_paths_recursive(
     if rfs.is_dir(child_path) {
       collect_conflict_marker_paths_recursive(rfs, root, child_rel, out)
     } else if rfs.is_file(child_path) {
-      let data = rfs.read_file(child_path) catch { _ => Bytes::default() }
+      let data = rfs.read_file(child_path) catch { _ => Default::default() }
       let text = decode_bytes(data)
       if has_conflict_markers(text) {
         out.push(child_rel)

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mizchi/bit",
-  "version": "0.45.6",
+  "version": "0.46.1",
   "description": "Pure MoonBit Git implementation (JS target)",
   "type": "module",
   "sideEffects": false,

--- a/tools/module-publish-graph.test.mjs
+++ b/tools/module-publish-graph.test.mjs
@@ -8,7 +8,7 @@ import {
   topologicalPublishOrder,
 } from "./module-publish-graph.mjs";
 
-test("workspace modules form a publish DAG with resolvable internal versions", () => {
+test("workspace modules form a publish DAG with valid internal dependency versions", () => {
   const modules = loadWorkspaceModules();
   const byName = new Map(modules.map((module) => [module.name, module]));
 
@@ -18,10 +18,10 @@ test("workspace modules form a publish DAG with resolvable internal versions", (
   for (const module of modules) {
     for (const [dependency, version] of Object.entries(module.deps ?? {})) {
       if (byName.has(dependency)) {
-        assert.equal(
+        assert.match(
           version,
-          byName.get(dependency).version,
-          `${module.name} must use ${dependency}'s workspace version`,
+          /^\d+\.\d+\.\d+$/,
+          `${module.name} must pin ${dependency} to a semantic version`,
         );
       }
     }

--- a/tools/publish-changed.mbtx
+++ b/tools/publish-changed.mbtx
@@ -1,5 +1,5 @@
 // Lerna-style selective publish for the bit workspace's many `modules/*`
-// packages: diff each package's directory against the last "Release vX.Y.Z"
+// packages: diff each package's directory against the last "Release" marker
 // commit and only `moon publish` the ones that actually changed, in
 // dependency order.
 //
@@ -9,7 +9,14 @@
 //   moon run --target native tools/publish-changed.mbtx -- --apply
 //     -- actually run `moon publish` for the changed modules
 //   moon run --target native tools/publish-changed.mbtx -- --since <git-ref> [--apply]
-//     -- compare against an explicit ref instead of the last Release commit
+//     -- compare against an explicit ref instead of the last Release marker
+//   moon run --target native tools/publish-changed.mbtx -- patch
+//   moon run --target native tools/publish-changed.mbtx -- minor
+//     -- prepare independent releases by updating only packages with changes
+//        since the last release. npm and the CLI version update only when the
+//        installable `mizchi/bit` package itself changed. Commit the resulting
+//        metadata with a subject beginning `Release`, then tag/push it and run
+//        the script again with `--apply` to publish the changed packages.
 
 import {
   "moonbitlang/async@0.19.4",
@@ -38,6 +45,27 @@ struct ModuleInfo {
   dir : String
   dir_basename : String
   deps : Array[String]
+}
+
+///|
+enum ReleaseBump {
+  Patch
+  Minor
+}
+
+///|
+struct AnchorInfo {
+  sha : String
+  subject : String
+}
+
+///|
+struct VersionUpdate {
+  name : String
+  current : String
+  next : String
+  manifest_path : String
+  manifest_content : String
 }
 
 // -- tiny moon.mod parsing -------------------------------------------------
@@ -162,13 +190,146 @@ fn load_workspace_modules(root : String) -> Array[ModuleInfo] raise ScriptError 
   result
 }
 
+// -- version updates -------------------------------------------------------
+
+///|
+fn parse_decimal_component(value : String) -> Int? {
+  if value.length() == 0 {
+    return None
+  }
+  let mut result = 0
+  for c in value {
+    if c < '0' || c > '9' {
+      return None
+    }
+    result = result * 10 + c.to_int() - '0'.to_int()
+  }
+  Some(result)
+}
+
+///|
+fn next_version(current : String, bump : ReleaseBump) -> String raise ScriptError {
+  let parts : Array[String] = []
+  for part in current.split(".") {
+    parts.push(part.to_owned())
+  }
+  if parts.length() != 3 {
+    raise ScriptError::Fail("expected MAJOR.MINOR.PATCH version, got \{current}")
+  }
+  let major = match parse_decimal_component(parts[0]) {
+    Some(value) => value
+    None => raise ScriptError::Fail("invalid major version in \{current}")
+  }
+  let minor = match parse_decimal_component(parts[1]) {
+    Some(value) => value
+    None => raise ScriptError::Fail("invalid minor version in \{current}")
+  }
+  let patch = match parse_decimal_component(parts[2]) {
+    Some(value) => value
+    None => raise ScriptError::Fail("invalid patch version in \{current}")
+  }
+  match bump {
+    Patch => "\{major}.\{minor}.\{patch + 1}"
+    Minor => "\{major}.\{minor + 1}.0"
+  }
+}
+
+///|
+fn replace_required(
+  content : String,
+  old : String,
+  new : String,
+  path : String,
+) -> String raise ScriptError {
+  match content.find(old) {
+    Some(_) => content.replace(old=old, new=new)
+    None => raise ScriptError::Fail("\{path}: expected to find \{old}")
+  }
+}
+
+///|
+fn read_text(path : String) -> String raise ScriptError {
+  try @fs.read_file_to_string(path) catch {
+    err => raise ScriptError::Fail("cannot read \{path}: \{err}")
+  }
+}
+
+///|
+fn write_text(path : String, content : String) -> Unit raise ScriptError {
+  try @fs.write_string_to_file(path, content) catch {
+    err => raise ScriptError::Fail("cannot write \{path}: \{err}")
+  }
+}
+
+///|
+fn prepare_release_versions(
+  root : String,
+  modules : Array[ModuleInfo],
+  changed_dirs : Array[String],
+  bump : ReleaseBump,
+) -> Array[VersionUpdate] raise ScriptError {
+  // Build and validate every change before writing any file.
+  let updates : Array[VersionUpdate] = []
+  let mut npm_updated : String? = None
+  let mut cli_version_updated : String? = None
+  for m in modules {
+    if !changed_dirs.contains(m.dir_basename) {
+      continue
+    }
+    let current = m.version
+    let next = next_version(current, bump)
+    let manifest_path = m.dir + "/moon.mod"
+    let manifest_content = replace_required(
+      read_text(manifest_path),
+      "version = \"\{current}\"",
+      "version = \"\{next}\"",
+      manifest_path,
+    )
+    updates.push({
+      name: m.name,
+      current,
+      next,
+      manifest_path,
+      manifest_content,
+    })
+    if m.dir_basename == "bit" {
+      let npm_path = root + "/npm/package.json"
+      npm_updated = Some(replace_required(
+        read_text(npm_path),
+        "\"version\": \"\{current}\"",
+        "\"version\": \"\{next}\"",
+        npm_path,
+      ))
+      let cli_version_path = root + "/modules/bit/cmd/bit/version.mbt"
+      cli_version_updated = Some(replace_required(
+        read_text(cli_version_path),
+        "bit v\{current}",
+        "bit v\{next}",
+        cli_version_path,
+      ))
+    }
+  }
+  for update in updates {
+    write_text(update.manifest_path, update.manifest_content)
+  }
+  match npm_updated {
+    Some(content) => write_text(root + "/npm/package.json", content)
+    None => ()
+  }
+  match cli_version_updated {
+    Some(content) => write_text(root + "/modules/bit/cmd/bit/version.mbt", content)
+    None => ()
+  }
+  updates
+}
+
 // -- dependency ordering ----------------------------------------------------
 
 ///|
 fn topological_layers(
   modules : Array[ModuleInfo],
 ) -> Array[Array[ModuleInfo]] raise ScriptError {
-  let by_name : Map[String, ModuleInfo] = Map::new()
+  let by_name : Map[String, ModuleInfo] = Map([], capacity=modules.length())
   for m in modules {
     by_name.set(m.name, m)
   }
@@ -196,7 +357,7 @@ fn topological_layers(
       for m in remaining {
         names.push(m.name)
       }
-      raise ScriptError::Fail("workspace module dependency cycle: \{names}")
+      raise ScriptError::Fail("workspace module dependency cycle: \{Repr(names)}")
     }
     ready.sort_by(fn(a, b) { String::compare(a.name, b.name) })
     for m in ready {
@@ -213,13 +374,13 @@ fn topological_layers(
 ///|
 async fn git_output(args : Array[String]) -> String raise ScriptError {
   let (code, stdout, stderr) = try @process.collect_output("git", args) catch {
-    err => raise ScriptError::Fail("failed to spawn git \{args}: \{err}")
+    err => raise ScriptError::Fail("failed to spawn git \{Repr(args)}: \{err}")
   }
   let out = try stdout.text() catch { _ => "" }
   if code != 0 {
     let err_text = try stderr.text() catch { _ => "" }
     raise ScriptError::Fail(
-      "git \{args} failed (\{code}): \{err_text.trim().to_owned()}",
+      "git \{Repr(args)} failed (\{code}): \{err_text.trim().to_owned()}",
     )
   }
   out
@@ -234,33 +395,63 @@ fn first_line(s : String) -> String {
 }
 
 ///|
-/// Returns (sha, subject) of the last commit that looks like a release, or
-/// the repo's root commit if no such commit exists yet.
-async fn find_anchor_commit() -> (String, String) raise ScriptError {
-  let out = git_output([
-    "log", "-n", "1", "--format=%H\t%s", "--grep=^Release v", "-i", "HEAD",
-  ])
-  let trimmed = out.trim().to_owned()
-  if trimmed.length() > 0 {
-    match trimmed.find("\t") {
-      Some(i) =>
-        return (
-          String::unsafe_substring(trimmed, start=0, end=i),
-          String::unsafe_substring(trimmed, start=i + 1, end=trimmed.length()),
-        )
-      None => return (trimmed, "")
-    }
+fn parse_release_log_line(output : String) -> (String, String)? {
+  let trimmed = output.trim().to_owned()
+  if trimmed.length() == 0 {
+    return None
   }
-  let root_out = git_output(["rev-list", "--max-parents=0", "HEAD"])
-  let root_sha = first_line(root_out.trim().to_owned())
-  (root_sha, "(root commit, no prior release found)")
+  match trimmed.find("\t") {
+    Some(i) =>
+      Some((
+        String::unsafe_substring(trimmed, start=0, end=i),
+        String::unsafe_substring(trimmed, start=i + 1, end=trimmed.length()),
+      ))
+    None => Some((trimmed, ""))
+  }
 }
 
 ///|
-/// Names of `modules/*` directories with content changes (excluding the
-/// `moon.mod` file itself, since a release commit bumps every module's
-/// `moon.mod` in lockstep regardless of whether that module's own code
-/// changed).
+/// Returns the release anchor. When HEAD itself is a Release commit, use its
+/// predecessor so `--apply` sees the feature diff contained by that release.
+async fn find_anchor_commit() -> AnchorInfo raise ScriptError {
+  let out = git_output([
+    "log", "-n", "1", "--format=%H\t%s", "--grep=^Release", "-i", "HEAD",
+  ])
+  match parse_release_log_line(out) {
+    Some((latest_sha, latest_subject)) => {
+      let head_sha = first_line(git_output(["rev-parse", "HEAD"]).trim().to_owned())
+      if latest_sha != head_sha {
+        return {
+          sha: latest_sha,
+          subject: latest_subject,
+        }
+      }
+      let previous = git_output([
+        "log", "-n", "1", "--skip=1", "--format=%H\t%s", "--grep=^Release", "-i", "HEAD",
+      ])
+      match parse_release_log_line(previous) {
+        Some((sha, subject)) =>
+          return {
+            sha,
+            subject: "\{subject} (previous release for current HEAD)",
+          }
+        None => ()
+      }
+    }
+    None => ()
+  }
+  let root_out = git_output(["rev-list", "--max-parents=0", "HEAD"])
+  let root_sha = first_line(root_out.trim().to_owned())
+  {
+    sha: root_sha,
+    subject: "(root commit, no prior release found)",
+  }
+}
+
+///|
+/// Names of `modules/*` directories with changes. A `moon.mod` dependency
+/// update is a package change too, while independently versioned release
+/// metadata only touches the modules selected for that release.
 async fn changed_module_dirs(anchor : String) -> Array[String] raise ScriptError {
   let out = git_output(["diff", "--name-only", anchor, "HEAD", "--", "modules"])
   let changed : Array[String] = []
@@ -274,8 +465,7 @@ async fn changed_module_dirs(anchor : String) -> Array[String] raise ScriptError
       None => continue
       Some(si) => {
         let mod_dir = String::unsafe_substring(rest, start=0, end=si)
-        let sub = String::unsafe_substring(rest, start=si + 1, end=rest.length())
-        if sub != "moon.mod" && !changed.contains(mod_dir) {
+        if !changed.contains(mod_dir) {
           changed.push(mod_dir)
         }
       }
@@ -359,7 +549,7 @@ async fn wait_for_layer(layer : Array[ModuleInfo]) -> Unit raise ScriptError {
     }
   }
   raise ScriptError::Fail(
-    "published modules did not reach the registry index: \{missing}",
+    "published modules did not reach the registry index: \{Repr(missing)}",
   )
 }
 
@@ -378,9 +568,55 @@ fn arg_value_after(args : Array[String], flag : String) -> String? {
 }
 
 ///|
+fn release_bump_from_args(args : Array[String]) -> ReleaseBump? raise ScriptError {
+  let mut bump : ReleaseBump? = None
+  // get_cli_args includes the executable path at index zero.
+  let mut i = 1
+  while i < args.length() {
+    let arg = args[i]
+    if arg == "--apply" {
+      i += 1
+      continue
+    }
+    if arg == "--since" {
+      if i + 1 >= args.length() {
+        raise ScriptError::Fail("--since requires a git ref")
+      }
+      i += 2
+      continue
+    }
+    let requested = match arg {
+      "patch" => Patch
+      "minor" => Minor
+      _ => raise ScriptError::Fail(
+        "unknown argument `\{arg}`; expected `patch` or `minor`",
+      )
+    }
+    match bump {
+      Some(_) => raise ScriptError::Fail("only one of `patch` or `minor` may be given")
+      None => bump = Some(requested)
+    }
+    i += 1
+  }
+  bump
+}
+
+///|
 async fn main_async() -> Unit {
   let args = @sys.get_cli_args()
   let apply = args.contains("--apply")
+  let bump = try release_bump_from_args(args) catch {
+    err => {
+      println("error: \{err}")
+      @sys.exit(1)
+      return
+    }
+  }
+  if apply && bump is Some(_) {
+    println("error: `patch`/`minor` prepares release metadata; commit and tag it before --apply")
+    @sys.exit(1)
+    return
+  }
   let root = "."
   let modules = try load_workspace_modules(root) catch {
     err => {
@@ -389,9 +625,12 @@ async fn main_async() -> Unit {
       return
     }
   }
-  let (anchor_sha, anchor_subject) = try (
+  let anchor = try (
     match arg_value_after(args, "--since") {
-      Some(refname) => (refname, "(explicit --since ref)")
+      Some(refname) => {
+        sha: refname,
+        subject: "(explicit --since ref)",
+      }
       None => find_anchor_commit()
     }
   ) catch {
@@ -401,15 +640,52 @@ async fn main_async() -> Unit {
       return
     }
   }
-  let changed_dirs = try changed_module_dirs(anchor_sha) catch {
+  let changed_dirs = try changed_module_dirs(anchor.sha) catch {
     err => {
       println("error: \{err}")
       @sys.exit(1)
       return
     }
   }
-  println("comparing against \{anchor_sha} \{anchor_subject}")
+  println("comparing against \{anchor.sha} \{anchor.subject}")
   println("")
+  if bump is Some(_) {
+    if changed_dirs.length() == 0 {
+      println("no modules changed since \{anchor.sha} — release metadata was not updated")
+      return
+    }
+    let dirty = try git_output(["status", "--porcelain"]) catch {
+      err => {
+        println("error: \{err}")
+        @sys.exit(1)
+        return
+      }
+    }
+    if dirty.trim().to_owned().length() > 0 {
+      println("error: refusing to bump a dirty worktree; commit source changes first")
+      @sys.exit(1)
+      return
+    }
+    let updates = try (
+      match bump {
+        Some(kind) => prepare_release_versions(root, modules, changed_dirs, kind)
+        None => raise ScriptError::Fail("unreachable: missing release bump")
+      }
+    ) catch {
+      err => {
+        println("error: \{err}")
+        @sys.exit(1)
+        return
+      }
+    }
+    println("prepared \{updates.length()} independent release(s):")
+    for update in updates {
+      println("  \{update.name}: v\{update.current} -> v\{update.next}")
+    }
+    println("updated only changed module manifests (and npm/CLI if mizchi/bit changed)")
+    println("next: commit the release metadata, tag/push it, then run with --apply")
+    return
+  }
   let layers = try topological_layers(modules) catch {
     err => {
       println("error: \{err}")
@@ -435,7 +711,7 @@ async fn main_async() -> Unit {
   println("")
   let total_changed = changed_dirs.length()
   if total_changed == 0 {
-    println("no modules changed since \{anchor_sha} — nothing to publish")
+    println("no modules changed since \{anchor.sha} — nothing to publish")
     return
   }
   println("\{total_changed} module(s) changed; publish order:")

--- a/tools/publish-changed.test.mjs
+++ b/tools/publish-changed.test.mjs
@@ -26,3 +26,58 @@ test("reports no changes when compared against HEAD itself", () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /no modules changed since HEAD — nothing to publish/);
 });
+
+test("rejects an unknown release bump argument", () => {
+  const result = runScript(["major", "--since", "HEAD"]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /unknown argument `major`; expected `patch` or `minor`/);
+});
+
+test("patch leaves release metadata untouched when its diff is empty", () => {
+  const result = runScript(["patch", "--since", "HEAD"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /no modules changed since HEAD — release metadata was not updated/,
+  );
+});
+
+test("minor leaves release metadata untouched when its diff is empty", () => {
+  const result = runScript(["minor", "--since", "HEAD"]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /no modules changed since HEAD — release metadata was not updated/,
+  );
+});
+
+test("release preparation cannot publish from its dirty prepared worktree", () => {
+  const result = runScript(["patch", "--apply", "--since", "HEAD"]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stdout,
+    /prepares release metadata; commit and tag it before --apply/,
+  );
+});
+
+test("release preparation updates only modules changed since its anchor", () => {
+  const source = readFileSync(
+    new URL("./publish-changed.mbtx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /"patch" => Patch/);
+  assert.match(source, /"minor" => Minor/);
+  assert.match(source, /prepare_release_versions\(root, modules, changed_dirs, kind\)/);
+  assert.match(source, /if !changed_dirs\.contains\(m\.dir_basename\)/);
+  assert.match(source, /if m\.dir_basename == "bit"/);
+  assert.doesNotMatch(source, /workspace versions must match/);
+  assert.doesNotMatch(source, /sub != "moon\.mod"/);
+  assert.match(source, /"--grep=\^Release"/);
+  assert.match(source, /"--skip=1"/);
+  assert.doesNotMatch(source, /publishing the full workspace version/);
+});


### PR DESCRIPTION
## Summary

- add independent `patch` / `minor` release preparation for modules changed since the previous release
- keep publish ordering and the `--apply` safety gate while syncing npm and CLI metadata only when `mizchi/bit` changes
- migrate deprecated MoonBit default, debug representation, hash, and map APIs
- prepare patch versions for the 14 touched modules (`mizchi/bit` and `mizchi/bitx_hub` at `0.46.1`; the other affected modules at `0.45.7`)

## Why

The workspace release helper previously assumed lockstep versions and the current MoonBit toolchain emitted 121 source deprecation warnings plus four warnings from the release helper. Independent version preparation avoids republishing unchanged modules, while the API migrations keep all supported targets warning-free.

## Impact

Release preparation now updates only changed package manifests, preserves topological publishing, refuses unsafe dirty-worktree publishing, and keeps the installable npm/CLI version synchronized with `mizchi/bit`.

## Validation

- `moon check --target native`
- `moon check --target js`
- `moon check --target wasm`
- `node --test tools/module-publish-graph.test.mjs tools/publish-changed.test.mjs` (9 passed)
- affected native package tests (682 passed)
- `mizchi/bit/cmd/git-bit` native tests (4 passed)
- `mizchi/bit/cmd/bit` release native tests (869 passed)
- `node tools/check-layers.mjs`
- `moon build --target native --release modules/bit`
- `git diff --check`
