### PR TITLE
Pin MoonBit toolchain in CI

### DIFF
--- a/.github/actions/setup-moonbit/action.yaml
+++ b/.github/actions/setup-moonbit/action.yaml
@@ -1,0 +1,44 @@
+name: Setup MoonBit
+description: Install the repository's pinned MoonBit toolchain
+
+inputs:
+  version:
+    description: MoonBit toolchain version
+    required: false
+    # v0.10.7 ICEs while compiling moonbitlang/x@0.4.43. Keep CI on the
+    # last verified compiler until an upstream release fixes that regression.
+    default: "0.10.6+80dc50f24"
+
+runs:
+  using: composite
+  steps:
+    - name: Install MoonBit CLI (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        MOONBIT_INSTALL_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+        echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+    - name: Install MoonBit CLI (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        MOONBIT_INSTALL_VERSION: ${{ inputs.version }}
+      run: |
+        Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+        irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
+        echo "$env:USERPROFILE\.moon\bin" |
+          Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Report MoonBit version (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: moon version --all
+
+    - name: Report MoonBit version (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: moon version --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,7 @@ jobs:
           version: 0.4.1
           pkl-version: none
       - name: Install MoonBit CLI
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-moonbit
       - name: Moon update
         run: moon update
       - name: pkf run check
@@ -182,9 +180,7 @@ jobs:
           version: 0.4.1
           pkl-version: none
       - name: Install MoonBit CLI
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-moonbit
       - name: Moon update
         run: moon update
       - name: Build native binary for wbtests
@@ -236,9 +232,7 @@ jobs:
         with:
           submodules: true
       - name: Install MoonBit CLI
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-moonbit
       - name: Moon update
         run: moon update
       - name: Distributed tests
@@ -312,9 +306,7 @@ jobs:
 
       - name: Install MoonBit CLI
         if: steps.shardtests.outputs.count != '0'
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-moonbit
 
       - name: Moon update
         if: steps.shardtests.outputs.count != '0'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,9 +30,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up MoonBit
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+        uses: ./.github/actions/setup-moonbit
 
       - name: Update MoonBit dependencies
         run: |

--- a/.github/workflows/git-compat-random.yml
+++ b/.github/workflows/git-compat-random.yml
@@ -78,9 +78,7 @@ jobs:
 
       - name: Install MoonBit CLI
         if: ${{ steps.shard_guard.outputs.should_run == 'true' }}
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-moonbit
 
       - name: Build git from source
         if: ${{ steps.shard_guard.outputs.should_run == 'true' }}

--- a/.github/workflows/js-build.yml
+++ b/.github/workflows/js-build.yml
@@ -38,9 +38,7 @@ jobs:
           bun-version: 1.3.5
 
       - name: Install MoonBit CLI
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-moonbit
 
       - name: Moon update
         run: moon update

--- a/.github/workflows/pages-demo.yml
+++ b/.github/workflows/pages-demo.yml
@@ -59,9 +59,7 @@ jobs:
           bun-version: 1.3.5
 
       - name: Install MoonBit CLI
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/setup-moonbit
 
       - name: Moon update
         run: moon update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Install MoonBit CLI (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
-          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
-
-      - name: Install MoonBit CLI (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-          irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
-          echo "$env:USERPROFILE\.moon\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install MoonBit CLI
+        uses: ./.github/actions/setup-moonbit
 
       - name: Moon update
         run: moon update


### PR DESCRIPTION
## Summary

- add a reusable local action for installing the repository's MoonBit toolchain
- pin CI to `moonbit v0.10.6+80dc50f24`
- use the same setup from CI, JS build, randomized compatibility, Pages, release, and Copilot workflows
- report the installed compiler version in every job

## Root cause

The official `latest` channel currently installs `moon 0.1.20260807 / moonc v0.10.7+bc794d341`. That compiler crashes with `Moonc.Hashed_type.Unresolved_type_variable` while compiling `moonbitlang/x@0.4.43`, then emits 242 cascading parse/type errors before the repository code is tested.

## Validation

- reproduced the failure with an isolated download of the current `latest` toolchain
- downloaded the immutable `0.10.6+80dc50f24` archive into a separate isolated directory and passed `moon check --target js modules/bit`
- `pkf run test-js-build`: 41/41 passed
- `pkf run check`
- `actionlint -shellcheck= .github/workflows/*.yml`
- parsed all workflow and composite-action YAML files
- `git diff --check`
