### PR TITLE
Fix HTTP push pack negotiation memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,10 +251,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: ./.github/actions/setup-nix
       - name: Build
-        run: >
-          nix build
-          --override-input moon-registry git+https://mooncakes.io/git/index
-          --override-input moonbit-overlay github:moonbit-community/moonbit-overlay
+        run: nix build
       - name: Smoke test
         run: test -x ./result/bin/bit
 

--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
     "moon-registry": {
       "flake": false,
       "locked": {
-        "lastModified": 1779690452,
-        "narHash": "sha256-btQ0I/ousUQMGc+ttplUvl02u9BX5S17whyxMDd2iS8=",
+        "lastModified": 1786520418,
+        "narHash": "sha256-SQXdiy5uRgFikTrhOBViG/dJaPsVPNCEaaoBH53Toh4=",
         "ref": "refs/heads/main",
-        "rev": "bbd38c835b32fab52354e1721fb748c8dea8ab4c",
-        "revCount": 8995,
+        "rev": "d5bb6b1c91c629d4de1380e1e3df336d2646b840",
+        "revCount": 12412,
         "type": "git",
         "url": "https://mooncakes.io/git/index"
       },
@@ -94,11 +94,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1782454513,
-        "narHash": "sha256-w7LuB7t/qfHYQpfxzozCuZwxdDT8NwNVT3SLTHFOV+o=",
+        "lastModified": 1786420125,
+        "narHash": "sha256-0R0o7stSsajTxBZAofhAKP19jVwN3vGTAwXHyuE2xNU=",
         "owner": "moonbit-community",
         "repo": "moonbit-overlay",
-        "rev": "5b9c0b328dcdd238ad8e3acff72dad0892ca507e",
+        "rev": "373a7d7e793063da0feaf6ff7942852fbc9732f3",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781607440,
-        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "lastModified": 1785975029,
+        "narHash": "sha256-X44cn5rzytELc3NNoQsh0aLkjWA/QzPfc6HPQmsG3sU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "rev": "70ce234312134a463ba7728e94da2486a1d237ac",
         "type": "github"
       },
       "original": {
@@ -296,11 +296,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
         "type": "github"
       },
       "original": {

--- a/modules/bit_lib/src/native/sync_http.mbt
+++ b/modules/bit_lib/src/native/sync_http.mbt
@@ -137,8 +137,30 @@ pub async fn push_http(
   match head {
     None => raise @bit.GitError::InvalidObject("HEAD not found")
     Some(head_id) => {
+      // Discover first so object collection can exclude everything the
+      // receiver already advertises. Building a full-history pack before
+      // negotiation can retain many gigabytes for a one-commit push.
+      let remote = @protocol.Remote::new(remote_url)
+      let refs = @bitnative.discover_receive_refs_http(remote)
+      let old_id = sync_find_ref(refs, refname)
+      if old_id == head_id {
+        return "Everything up-to-date"
+      }
+      // Check fast-forward unless force
+      if !force && old_id != @bit.ObjectId::zero() {
+        if !sync_is_ancestor(rfs, actual_git_dir, old_id, head_id) {
+          raise @bit.GitError::InvalidObject(
+            "Updates were rejected because the tip of your current branch is behind\nits remote counterpart. If you want to force the update, use 'git push --force'.",
+          )
+        }
+      }
       let db = @bitlib.ObjectDb::load(rfs, actual_git_dir)
-      let objects = @bitlib.collect_reachable_objects(db, rfs, head_id)
+      let objects = @bitlib.collect_reachable_objects_excluding_commits(
+        db,
+        rfs,
+        [head_id],
+        sync_remote_have_ids(refs),
+      )
       let pack = @pack.create_packfile(objects)
       sync_raise_lfs_upload_errors(
         lfs_upload_pack_objects(
@@ -149,17 +171,6 @@ pub async fn push_http(
           remote_name~,
         ),
       )
-      let remote = @protocol.Remote::new(remote_url)
-      let refs = @bitnative.discover_receive_refs_http(remote)
-      let old_id = sync_find_ref(refs, refname)
-      // Check fast-forward unless force
-      if !force && old_id != @bit.ObjectId::zero() {
-        if !sync_is_ancestor(rfs, actual_git_dir, old_id, head_id) {
-          raise @bit.GitError::InvalidObject(
-            "Updates were rejected because the tip of your current branch is behind\nits remote counterpart. If you want to force the update, use 'git push --force'.",
-          )
-        }
-      }
       let req = @protocol.PushRequest::new(old_id, head_id, refname, pack)
       @bitnative.push(remote, req)
     }
@@ -181,15 +192,23 @@ pub async fn push_http_from_commit(
   } else {
     git_dir
   }
+  let remote = @protocol.Remote::new(remote_url)
+  let refs = @bitnative.discover_receive_refs_http(remote)
+  let old_id = sync_find_ref(refs, refname)
+  if old_id == commit_id {
+    return "Everything up-to-date"
+  }
   let db = @bitlib.ObjectDb::load(rfs, actual_git_dir)
-  let objects = @bitlib.collect_reachable_objects(db, rfs, commit_id)
+  let objects = @bitlib.collect_reachable_objects_excluding_commits(
+    db,
+    rfs,
+    [commit_id],
+    sync_remote_have_ids(refs),
+  )
   let pack = @pack.create_packfile(objects)
   sync_raise_lfs_upload_errors(
     lfs_upload_pack_objects(rfs, actual_git_dir, remote_url, objects),
   )
-  let remote = @protocol.Remote::new(remote_url)
-  let refs = @bitnative.discover_receive_refs_http(remote)
-  let old_id = sync_find_ref(refs, refname)
   let req = @protocol.PushRequest::new(old_id, commit_id, refname, pack)
   @bitnative.push(remote, req)
 }
@@ -249,6 +268,41 @@ fn sync_find_ref(
     }
   }
   @bit.ObjectId::zero()
+}
+
+///|
+fn sync_remote_have_ids(
+  refs : Array[(@bit.ObjectId, String)],
+) -> Array[@bit.ObjectId] {
+  let zero = @bit.ObjectId::zero()
+  let seen : Map[String, Bool] = Map([])
+  let haves : Array[@bit.ObjectId] = []
+  for item in refs {
+    let (id, _) = item
+    let hex = id.to_hex()
+    if id != zero && !seen.contains(hex) {
+      seen[hex] = true
+      haves.push(id)
+    }
+  }
+  haves
+}
+
+///|
+test "sync_remote_have_ids removes zero and duplicate refs" {
+  let first = @bit.ObjectId::from_hex(
+    "1111111111111111111111111111111111111111",
+  )
+  let second = @bit.ObjectId::from_hex(
+    "2222222222222222222222222222222222222222",
+  )
+  let haves = sync_remote_have_ids([
+    (first, "HEAD"),
+    (first, "refs/heads/main"),
+    (@bit.ObjectId::zero(), "refs/heads/unborn"),
+    (second, "refs/heads/topic"),
+  ])
+  assert_eq(haves, [first, second])
 }
 
 ///|

--- a/modules/bit_lib/src/pack_collect.mbt
+++ b/modules/bit_lib/src/pack_collect.mbt
@@ -96,10 +96,10 @@ fn collect_tree_ids_only(
           if collect_is_gitlink_mode(entry.mode) {
             continue // Skip submodule entries
           }
-          let entry_hex = entry.id.to_hex()
-          seen[entry_hex] = true
           if collect_is_tree_mode(entry.mode) {
             collect_tree_ids_only(db, fs, entry.id, seen)
+          } else {
+            seen[entry.id.to_hex()] = true
           }
         }
       }
@@ -235,51 +235,18 @@ pub fn collect_reachable_objects_excluding_commits(
   commits : Array[@bit.ObjectId],
   excluded_commits : Array[@bit.ObjectId],
 ) -> Array[@bit.PackObject] raise @bit.GitError {
-  let excluded : Map[String, Bool] = Map([])
-  for id in excluded_commits {
-    excluded[id.to_hex()] = true
-  }
+  // Mark the complete object closure already owned by the receiver. Merely
+  // stopping the commit walk at a have commit is insufficient: the wanted
+  // commit's new tree can still reference unchanged blobs from that commit.
   let seen : Map[String, Bool] = Map([])
+  for id in excluded_commits {
+    collect_object_ids_only(db, fs, id, seen)
+  }
   let out : Array[@bit.PackObject] = []
   for commit_id in commits {
-    collect_commit_objects_until_excluded(
-      db, fs, commit_id, excluded, seen, out,
-    )
+    collect_commit_objects(db, fs, commit_id, seen, out)
   }
   out
-}
-
-///|
-fn collect_commit_objects_until_excluded(
-  db : ObjectDb,
-  fs : &@bit.RepoFileSystem,
-  commit_id : @bit.ObjectId,
-  excluded : Map[String, Bool],
-  seen : Map[String, Bool],
-  out : Array[@bit.PackObject],
-) -> Unit raise @bit.GitError {
-  let hex = commit_id.to_hex()
-  if excluded.contains(hex) || seen.contains(hex) {
-    return
-  }
-  seen[hex] = true
-  let obj = db.get(fs, commit_id)
-  match obj {
-    None => raise @bit.GitError::InvalidObject("Missing commit object")
-    Some(o) => {
-      if o.obj_type != @bit.ObjectType::Commit {
-        raise @bit.GitError::InvalidObject("Object is not a commit")
-      }
-      out.push(o)
-      let info = @bit.parse_commit(o.data)
-      collect_tree_objects(db, fs, info.tree, seen, out)
-      for parent in info.parents {
-        collect_commit_objects_until_excluded(
-          db, fs, parent, excluded, seen, out,
-        )
-      }
-    }
-  }
 }
 
 ///|

--- a/modules/bit_lib/src/pack_collect_test.mbt
+++ b/modules/bit_lib/src/pack_collect_test.mbt
@@ -358,24 +358,42 @@ test "collect_reachable_objects_excluding_commits: stops at have commits" {
     _ => ()
   }
   fs.write_file("/repo/shared.txt", b"shared")
-  let base = commit(fs, fs, "/repo", "base", "test <test@test.com>", 1000L) catch {
-    _ => return ()
-  }
+  fs.mkdir_p("/repo/nested")
+  fs.write_file("/repo/nested/shared.txt", b"nested shared")
+  add_paths(fs, fs, "/repo", ["."])
+  let base = commit(fs, fs, "/repo", "base", "test <test@test.com>", 1000L)
   fs.write_file("/repo/new.txt", b"new")
-  let tip = commit(fs, fs, "/repo", "tip", "test <test@test.com>", 2000L) catch {
-    _ => return ()
-  }
-  let db = ObjectDb::load(fs, "/repo/.git") catch { _ => return () }
+  add_paths(fs, fs, "/repo", ["new.txt"])
+  let tip = commit(fs, fs, "/repo", "tip", "test <test@test.com>", 2000L)
+  let db = ObjectDb::load(fs, "/repo/.git")
 
   let objects = collect_reachable_objects_excluding_commits(db, fs, [tip], [
     base,
-  ]) catch {
-    _ => return ()
-  }
+  ])
   let ids : Map[String, Bool] = Map([])
+  let mut shared_blob_count = 0
+  let mut nested_shared_blob_count = 0
+  let mut new_blob_count = 0
   for obj in objects {
     ids[obj.id.to_hex()] = true
+    if obj.obj_type == @bit.ObjectType::Blob {
+      let content = @utf8.decode_lossy(obj.data[:])
+      if content == "shared" {
+        shared_blob_count += 1
+      }
+      if content == "nested shared" {
+        nested_shared_blob_count += 1
+      }
+      if content == "new" {
+        new_blob_count += 1
+      }
+    }
   }
   assert_true(ids.contains(tip.to_hex()))
   assert_true(!ids.contains(base.to_hex()))
+  // Objects reachable from a remote "have" must not be sent again, even
+  // when the wanted commit's tree still references them.
+  assert_eq(shared_blob_count, 0)
+  assert_eq(nested_shared_blob_count, 0)
+  assert_eq(new_blob_count, 1)
 }

--- a/modules/bitx_hub/src/native/sync_native.mbt
+++ b/modules/bitx_hub/src/native/sync_native.mbt
@@ -1221,12 +1221,33 @@ async fn hub_push_git_http(
       None,
     )
   }
-  let db = @lib.ObjectDb::load(rfs, git_dir)
-  let objects = @lib.collect_reachable_objects(db, rfs, local_id)
-  let pack = @pack.create_packfile(objects)
   let remote = @protocol.Remote::new(remote_url)
   let refs = @bitnative.discover_receive_refs_http(remote)
   let (old_id, push_ref) = @hub.find_remote_notes_ref(refs)
+  if old_id == local_id {
+    return @hub.PrSyncResult::new(
+      true,
+      "Already up to date",
+      Some(local_id),
+      Some(local_id),
+    )
+  }
+  let haves : Array[@bit.ObjectId] = []
+  let zero = @bit.ObjectId::zero()
+  for item in refs {
+    let (id, _) = item
+    if id != zero {
+      haves.push(id)
+    }
+  }
+  let db = @lib.ObjectDb::load(rfs, git_dir)
+  let objects = @lib.collect_reachable_objects_excluding_commits(
+    db,
+    rfs,
+    [local_id],
+    haves,
+  )
+  let pack = @pack.create_packfile(objects)
   let req = @protocol.PushRequest::new(old_id, local_id, push_ref, pack)
   let result = @bitnative.push(remote, req)
   if result.has_prefix("unpack ok") ||

--- a/t/t9020-http-push-negotiation.sh
+++ b/t/t9020-http-push-negotiation.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# Ensure smart HTTP push negotiates remote objects before building a pack.
+#
+
+test_description='bit HTTP push sends only objects missing from advertised refs'
+
+TEST_DIRECTORY=$(cd "$(dirname "$0")" && pwd)
+. "$TEST_DIRECTORY/test-lib.sh"
+
+if ! test_have_prereq GIT; then
+	test_skip "HTTP push negotiation" "git not found"
+	test_done
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+	test_skip "HTTP push negotiation" "node not found"
+	test_done
+fi
+
+cleanup_http() {
+	if test -n "${SERVER_PID:-}"; then
+		kill "$SERVER_PID" 2>/dev/null || true
+		wait "$SERVER_PID" 2>/dev/null || true
+		SERVER_PID=""
+	fi
+}
+trap 'cleanup_http; cleanup' EXIT
+
+PORT=$((10000 + $$ % 50000))
+SERVER_LOG="$TRASH_DIRECTORY/server.log"
+
+test_expect_success 'setup repository with an incompressible base blob' '
+	mkdir upstream &&
+	(cd upstream &&
+	 git init -q &&
+	 git config user.email "test@test.com" &&
+	 git config user.name "Test" &&
+	 node -e '\''let x=1,b=Buffer.alloc(4*1024*1024);for(let i=0;i<b.length;i++){x=(Math.imul(x,1664525)+1013904223)>>>0;b[i]=x>>>24}require("fs").writeFileSync("base.bin",b)'\'' &&
+	 git add base.bin &&
+	 git commit -q -m base) &&
+	git clone -q upstream client &&
+	(cd client &&
+	 git config user.email "test@test.com" &&
+	 git config user.name "Test" &&
+	 echo new > new.txt &&
+	 git add new.txt &&
+	 git commit -q -m new)
+'
+
+test_expect_success 'start smart HTTP server' '
+	USE_REAL_GIT=1 node "$BIT_BUILD_DIR/tools/http-test-server.js" \
+	  "$TRASH_DIRECTORY/upstream" $PORT >"$SERVER_LOG" 2>&1 &
+	SERVER_PID=$! &&
+	sleep 1 &&
+	kill -0 $SERVER_PID
+'
+
+test_expect_success 'push a new branch' '
+	(cd client && $BIT push "http://localhost:$PORT" HEAD:refs/heads/topic) &&
+	test "$(git -C upstream rev-parse refs/heads/topic)" = \
+	     "$(git -C client rev-parse HEAD)"
+'
+
+test_expect_success 'request excludes the base blob advertised by another ref' '
+	request_bytes=$(awk '\''/receive-pack request:/ { print $(NF - 1) }'\'' "$SERVER_LOG" | tail -1) &&
+	test -n "$request_bytes" &&
+	test "$request_bytes" -lt 262144
+'
+
+test_expect_success 'up-to-date push avoids another pack request' '
+	request_count_before=$(grep -c "receive-pack request:" "$SERVER_LOG") &&
+	(cd client && $BIT push "http://localhost:$PORT" HEAD:refs/heads/topic) &&
+	request_count_after=$(grep -c "receive-pack request:" "$SERVER_LOG") &&
+	test "$request_count_after" = "$request_count_before"
+'
+
+test_done

--- a/tools/http-test-server.js
+++ b/tools/http-test-server.js
@@ -2,9 +2,12 @@
 // Simple Git Smart HTTP server for testing git-shim
 // Usage: node http-test-server.js <repo-path> [port]
 
-const http = require('http');
-const { spawn } = require('child_process');
-const path = require('path');
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const repoPath = process.argv[2] || '.';
 const port = parseInt(process.argv[3] || '8080', 10);


### PR DESCRIPTION
## Summary

- discover remote receive refs before building HTTP push packs
- exclude objects reachable from advertised remote refs, including nested trees and shared blobs
- skip object loading and pack upload entirely when the destination ref is already up to date
- apply the same negotiation behavior to hub notes pushes used by agent communication
- add a smart HTTP regression test for request size and no-op pushes

## Root cause

HTTP push collected and delta-compressed every object reachable from local HEAD before discovering what the receiver already owned. On the reported repository that meant processing roughly 13 GB of reachable blob data even though only about 1.55 MB was missing. The existing exclusion walker also marked nested tree IDs before recursing, so shared objects under those trees were not excluded correctly.

## Impact

A controlled 16 MiB fixture reduced peak RSS from 246.4 MB to 13.0 MB and the receive-pack request from 16.78 MB to 416 bytes. An up-to-date push in the original large repository now completes in 0.50 s with 39.7 MB maximum RSS.

## Validation

- `pkf run check`
- native bit_lib and bit_lib/native tests: 315 passed
- native hub and hub/native tests
- `t/t0020-push-fetch-pull.sh`: 21 passed
- `t/t9003-fetch-up-to-date.sh`: 8 passed
- `t/t0012-hub-sync.sh`: passed
- `t/t9020-http-push-negotiation.sh`: 5 passed
- native release build
- real no-op push against the original GitHub branch
